### PR TITLE
Refactor: config sync hook, unified settings types, generic RPC client

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -19,10 +19,8 @@ import { SettingsPanel } from '@/components/settings/SettingsPanel';
 import { useLinkIndex } from '@/hooks/useLinkIndex';
 import { useFileTree } from '@/hooks/useFileTree';
 import { formatShortcutList, matchShortcut, useShortcutBindings } from '@/lib/shortcuts';
-import { ConfigSync } from '@/lib/config-sync';
-import { DEFAULT_SETTINGS, DEFAULT_WORKSPACE, DEFAULT_CHAT } from '@/lib/config-defaults';
 import { useAppearanceStore } from '@/stores/appearanceStore';
-import type { CushionSettings, CushionWorkspace, CushionAppearance, CushionChat } from '@cushion/types';
+import { useConfigSync } from '@/hooks/useConfigSync';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
 
 const APP_SHORTCUT_IDS = [
@@ -89,9 +87,6 @@ export default function Home() {
   const [showQuickSwitcher, setShowQuickSwitcher] = useState(false);
   const fileBrowserRef = useRef<FileBrowserHandle>(null);
   const autoOpenAttempted = useRef(false);
-  const configSyncRef = useRef<ConfigSync | null>(null);
-  const lastSettingsRef = useRef<CushionSettings>(DEFAULT_SETTINGS);
-  const workspaceConfigLoadedRef = useRef(false);
 
   // File tree and connection state from useFileTree hook
   const { fileTree, connectionState, fetchFileTree } = useFileTree({
@@ -106,6 +101,14 @@ export default function Home() {
     metadata,
     fileTree,
     openFiles,
+  });
+
+  // Config sync lifecycle (settings, workspace, appearance, chat)
+  const { workspaceConfigLoadedRef } = useConfigSync({
+    client,
+    metadata,
+    rightPanelMode,
+    rightPanelWidth,
   });
 
   const appShortcuts = useShortcutBindings(APP_SHORTCUT_IDS);
@@ -156,257 +159,6 @@ export default function Home() {
     };
   }, [metadata?.projectPath, connectChat, disconnectChat]);
 
-  // --- ConfigSync lifecycle ---
-
-  // Create / destroy ConfigSync when client connects
-  useEffect(() => {
-    if (!client) return;
-    configSyncRef.current = new ConfigSync(client);
-    return () => {
-      configSyncRef.current?.flush();
-      configSyncRef.current?.destroy();
-      configSyncRef.current = null;
-    };
-  }, [client]);
-
-  // Load settings.json + workspace.json when a workspace opens
-  useEffect(() => {
-    if (!metadata || !configSyncRef.current) return;
-    workspaceConfigLoadedRef.current = false;
-    let cancelled = false;
-    const sync = configSyncRef.current;
-
-    (async () => {
-      // Load settings.json
-      const parsedSettings = await sync.read<CushionSettings>('settings.json');
-      if (cancelled) return;
-      if (parsedSettings) {
-        const merged = { ...DEFAULT_SETTINGS, ...parsedSettings };
-        lastSettingsRef.current = merged;
-        useWorkspaceStore.getState().updatePreferences({
-          showHiddenFiles: merged.showHiddenFiles,
-          showCushionFiles: merged.showCushionFiles,
-          autoSave: merged.autoSave,
-          autoSaveDelay: merged.autoSaveDelay,
-          showLineNumber: merged.showLineNumber,
-          spellcheck: merged.spellcheck,
-          readableLineLength: merged.readableLineLength,
-          autoPairBrackets: merged.autoPairBrackets,
-          foldHeading: merged.foldHeading,
-          foldIndent: merged.foldIndent,
-        });
-      }
-
-      // Load workspace.json — restore right panel + tabs
-      const parsedWorkspace = await sync.read<CushionWorkspace>('workspace.json');
-      if (cancelled) return;
-      if (parsedWorkspace) {
-        const merged = { ...DEFAULT_WORKSPACE, ...parsedWorkspace };
-
-        // Restore right panel state
-        if (merged.rightPanel) {
-          setRightPanelMode(merged.rightPanel.mode);
-          setRightPanelWidth(merged.rightPanel.width);
-          if (merged.rightPanel.mode !== 'none') {
-            lastRightPanelModeRef.current = merged.rightPanel.mode;
-          }
-        }
-
-        // Restore tabs — re-open each file from disk
-        if (merged.tabs.length > 0 && client) {
-          const activeFilePath = merged.activeTab;
-          for (const tab of merged.tabs) {
-            try {
-              const { content } = await client.readFile(tab.filePath);
-              if (cancelled) return;
-              useWorkspaceStore.getState().openFile(tab.filePath, content);
-              if (tab.isPinned) {
-                const currentTabs = useWorkspaceStore.getState().tabs;
-                const restored = currentTabs.find((t) => t.filePath === tab.filePath);
-                if (restored) useWorkspaceStore.getState().pinTab(restored.id);
-              }
-            } catch {
-              // File may have been deleted since workspace.json was saved — skip
-              console.warn(`[ConfigSync] Skipping missing tab: ${tab.filePath}`);
-            }
-          }
-          // Set active tab by filePath
-          if (activeFilePath) {
-            const currentTabs = useWorkspaceStore.getState().tabs;
-            const activeTab = currentTabs.find((t) => t.filePath === activeFilePath);
-            if (activeTab) {
-              useWorkspaceStore.getState().setActiveTab(activeTab.id);
-            }
-          }
-        }
-      }
-
-      workspaceConfigLoadedRef.current = true;
-
-      // Load appearance.json — restore theme, accent color, fonts
-      const parsedAppearance = await sync.read<CushionAppearance>('appearance.json');
-      if (cancelled) return;
-      if (parsedAppearance) {
-        useAppearanceStore.getState().loadAppearance(parsedAppearance);
-      }
-
-      // Load chat.json — restore AI preferences for this workspace
-      const parsedChat = await sync.read<CushionChat>('chat.json');
-      if (cancelled) return;
-      if (parsedChat) {
-        const merged = { ...DEFAULT_CHAT, ...parsedChat };
-        const directory = metadata.projectPath;
-        useChatStore.setState((state) => ({
-          displayPreferences: merged.displayPreferences,
-          modelVisibility: { ...state.modelVisibility, ...merged.modelVisibility },
-          ...(merged.selectedModel && {
-            selectedModel: merged.selectedModel,
-            selectedModelByDirectory: {
-              ...state.selectedModelByDirectory,
-              [directory]: merged.selectedModel,
-            },
-          }),
-          ...(merged.selectedAgent !== null && {
-            selectedAgent: merged.selectedAgent,
-            selectedAgentByDirectory: {
-              ...state.selectedAgentByDirectory,
-              [directory]: merged.selectedAgent,
-            },
-          }),
-          ...(merged.selectedVariant !== null && {
-            selectedVariant: merged.selectedVariant,
-            selectedVariantByDirectory: {
-              ...state.selectedVariantByDirectory,
-              [directory]: merged.selectedVariant,
-            },
-          }),
-        }));
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [metadata, client]);
-
-  // Write to settings.json when preferences change
-  useEffect(() => {
-    if (!metadata) return;
-
-    const unsub = useWorkspaceStore.subscribe(
-      (state) => state.preferences,
-      (prefs) => {
-        const sync = configSyncRef.current;
-        if (!sync) return;
-
-        const settings: CushionSettings = {
-          ...lastSettingsRef.current,
-          showHiddenFiles: prefs.showHiddenFiles,
-          showCushionFiles: prefs.showCushionFiles,
-          autoSave: prefs.autoSave,
-          autoSaveDelay: prefs.autoSaveDelay,
-          showLineNumber: prefs.showLineNumber,
-          spellcheck: prefs.spellcheck,
-          readableLineLength: prefs.readableLineLength,
-          autoPairBrackets: prefs.autoPairBrackets,
-          foldHeading: prefs.foldHeading,
-          foldIndent: prefs.foldIndent,
-        };
-        lastSettingsRef.current = settings;
-        sync.scheduleWrite('settings.json', settings);
-      },
-    );
-
-    return unsub;
-  }, [metadata]);
-
-  // Write to workspace.json when tabs or active file change
-  useEffect(() => {
-    if (!metadata) return;
-
-    const unsub = useWorkspaceStore.subscribe(
-      (state) => ({ tabs: state.tabs, currentFile: state.currentFile }),
-      ({ tabs, currentFile }) => {
-        const sync = configSyncRef.current;
-        if (!sync) return;
-
-        const workspaceData: CushionWorkspace = {
-          tabs: tabs.map((t) => ({
-            id: t.id,
-            filePath: t.filePath,
-            isPinned: t.isPinned,
-            isPreview: t.isPreview,
-            order: t.order,
-          })),
-          activeTab: currentFile,
-          rightPanel: { mode: rightPanelMode, width: rightPanelWidth },
-          lastOpenFiles: tabs.map((t) => t.filePath),
-        };
-        sync.scheduleWrite('workspace.json', workspaceData);
-      },
-    );
-
-    return unsub;
-  }, [metadata, rightPanelMode, rightPanelWidth]);
-
-  // Write to appearance.json when appearance changes
-  useEffect(() => {
-    if (!metadata) return;
-
-    const unsub = useAppearanceStore.subscribe(
-      (state) => ({
-        theme: state.theme,
-        accentColor: state.accentColor,
-        baseFontSize: state.baseFontSize,
-        textFontFamily: state.textFontFamily,
-        monospaceFontFamily: state.monospaceFontFamily,
-        interfaceFontFamily: state.interfaceFontFamily,
-        sidebarWidth: state.sidebarWidth,
-      }),
-      () => {
-        const sync = configSyncRef.current;
-        if (!sync) return;
-
-        sync.scheduleWrite('appearance.json', useAppearanceStore.getState().getConfig());
-      },
-      { equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
-    );
-
-    return unsub;
-  }, [metadata]);
-
-  // Write to chat.json when chat preferences change
-  useEffect(() => {
-    if (!metadata) return;
-    const directory = metadata.projectPath;
-
-    const unsub = useChatStore.subscribe(
-      (state) => ({
-        displayPreferences: state.displayPreferences,
-        modelVisibility: state.modelVisibility,
-        selectedModel: state.selectedModelByDirectory[directory] ?? state.selectedModel,
-        selectedAgent: state.selectedAgentByDirectory[directory] ?? state.selectedAgent,
-        selectedVariant: state.selectedVariantByDirectory[directory] ?? state.selectedVariant,
-      }),
-      (slice) => {
-        const sync = configSyncRef.current;
-        if (!sync) return;
-
-        const chatData: CushionChat = {
-          selectedModel: slice.selectedModel,
-          selectedAgent: slice.selectedAgent,
-          selectedVariant: slice.selectedVariant,
-          displayPreferences: slice.displayPreferences,
-          modelVisibility: slice.modelVisibility,
-        };
-        sync.scheduleWrite('chat.json', chatData);
-      },
-      { equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
-    );
-
-    return unsub;
-  }, [metadata]);
-
   // Apply theme class and accent color CSS variables to <html>
   useEffect(() => {
     const { resolvedTheme, accentColor } = useAppearanceStore.getState();
@@ -432,89 +184,6 @@ export default function Home() {
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, []);
-
-  // Re-read config files when externally changed on disk
-  useEffect(() => {
-    if (!client || !metadata) return;
-
-    const unsub = client.onConfigChanged(async (file: string) => {
-      const sync = configSyncRef.current;
-      if (!sync) return;
-
-      switch (file) {
-        case 'settings.json': {
-          const parsed = await sync.read<CushionSettings>('settings.json');
-          if (!parsed) return;
-          const merged = { ...DEFAULT_SETTINGS, ...parsed };
-          lastSettingsRef.current = merged;
-          useWorkspaceStore.getState().updatePreferences({
-            showHiddenFiles: merged.showHiddenFiles,
-            showCushionFiles: merged.showCushionFiles,
-            autoSave: merged.autoSave,
-            autoSaveDelay: merged.autoSaveDelay,
-            showLineNumber: merged.showLineNumber,
-            spellcheck: merged.spellcheck,
-            readableLineLength: merged.readableLineLength,
-            autoPairBrackets: merged.autoPairBrackets,
-              foldHeading: merged.foldHeading,
-            foldIndent: merged.foldIndent,
-          });
-          break;
-        }
-        case 'appearance.json': {
-          const parsed = await sync.read<CushionAppearance>('appearance.json');
-          if (!parsed) return;
-          useAppearanceStore.getState().loadAppearance(parsed);
-          break;
-        }
-        case 'chat.json': {
-          const parsed = await sync.read<CushionChat>('chat.json');
-          if (!parsed) return;
-          const merged = { ...DEFAULT_CHAT, ...parsed };
-          const directory = metadata.projectPath;
-          useChatStore.setState((state) => ({
-            displayPreferences: merged.displayPreferences,
-            modelVisibility: { ...state.modelVisibility, ...merged.modelVisibility },
-            ...(merged.selectedModel && {
-              selectedModel: merged.selectedModel,
-              selectedModelByDirectory: {
-                ...state.selectedModelByDirectory,
-                [directory]: merged.selectedModel,
-              },
-            }),
-            ...(merged.selectedAgent !== null && {
-              selectedAgent: merged.selectedAgent,
-              selectedAgentByDirectory: {
-                ...state.selectedAgentByDirectory,
-                [directory]: merged.selectedAgent,
-              },
-            }),
-            ...(merged.selectedVariant !== null && {
-              selectedVariant: merged.selectedVariant,
-              selectedVariantByDirectory: {
-                ...state.selectedVariantByDirectory,
-                [directory]: merged.selectedVariant,
-              },
-            }),
-          }));
-          break;
-        }
-        // workspace.json is not re-read on external change — tabs are ephemeral
-        // and re-reading could disrupt the user's current session
-      }
-    });
-
-    return unsub;
-  }, [client, metadata]);
-
-  // Flush pending config writes on page unload
-  useEffect(() => {
-    const handler = () => configSyncRef.current?.flush();
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
-  }, []);
-
-  // --- End ConfigSync lifecycle ---
 
   useEffect(() => {
     if (!client || metadata || autoOpenAttempted.current) {
@@ -592,28 +261,6 @@ export default function Home() {
       lastRightPanelModeRef.current = rightPanelMode;
     }
   }, [rightPanelMode]);
-
-  // Write workspace.json when right panel state changes
-  useEffect(() => {
-    if (!metadata || !workspaceConfigLoadedRef.current) return;
-    const sync = configSyncRef.current;
-    if (!sync) return;
-
-    const { tabs, currentFile } = useWorkspaceStore.getState();
-    const workspaceData: CushionWorkspace = {
-      tabs: tabs.map((t) => ({
-        id: t.id,
-        filePath: t.filePath,
-        isPinned: t.isPinned,
-        isPreview: t.isPreview,
-        order: t.order,
-      })),
-      activeTab: currentFile,
-      rightPanel: { mode: rightPanelMode, width: rightPanelWidth },
-      lastOpenFiles: tabs.map((t) => t.filePath),
-    };
-    sync.scheduleWrite('workspace.json', workspaceData);
-  }, [metadata, rightPanelMode, rightPanelWidth]);
 
   const handleFileOpen = useCallback(
     (filePath: string, content: string) => {

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -109,6 +109,13 @@ export default function Home() {
     metadata,
     rightPanelMode,
     rightPanelWidth,
+    onRightPanelRestore: useCallback((mode: 'none' | 'chat', width: number) => {
+      setRightPanelMode(mode);
+      setRightPanelWidth(width);
+      if (mode !== 'none') {
+        lastRightPanelModeRef.current = mode;
+      }
+    }, []),
   });
 
   const appShortcuts = useShortcutBindings(APP_SHORTCUT_IDS);

--- a/apps/frontend/components/workspace/FileBrowser.tsx
+++ b/apps/frontend/components/workspace/FileBrowser.tsx
@@ -30,7 +30,7 @@ export interface FileBrowserHandle {
 
 export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
   function FileBrowser({ client, onFileOpen, onNewDocument, onOpenWorkspace, onSidebarToggle, isCollapsed: isCollapsedProp = false, onSearch, onSettings, onAskAIFile }, ref) {
-  const { metadata, currentFile, preferences, updatePreferences } = useWorkspaceStore();
+  const { metadata, currentFile, preferences, sidebarWidth: rawSidebarWidth, setSidebarWidth } = useWorkspaceStore();
   const [rootFiles, setRootFiles] = useState<FileTreeNode[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -50,13 +50,12 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
   const sidebarMax = typeof window !== 'undefined'
     ? Math.max(sidebarMin, Math.floor(window.innerWidth * 0.45))
     : 520;
-  const rawSidebarWidth = Number.isFinite(preferences.sidebarWidth) ? preferences.sidebarWidth : 240;
   const resolvedSidebarWidth = Math.min(sidebarMax, Math.max(sidebarMin, rawSidebarWidth));
 
   useEffect(() => {
     if (resolvedSidebarWidth === rawSidebarWidth) return;
-    updatePreferences({ sidebarWidth: resolvedSidebarWidth });
-  }, [rawSidebarWidth, resolvedSidebarWidth, updatePreferences]);
+    setSidebarWidth(resolvedSidebarWidth);
+  }, [rawSidebarWidth, resolvedSidebarWidth, setSidebarWidth]);
 
   const loadDirectory = useCallback(async (relativePath: string): Promise<FileTreeNode[]> => {
     if (!client) {
@@ -101,9 +100,9 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
 
   const handleSidebarResize = useCallback(
     (nextWidth: number) => {
-      updatePreferences({ sidebarWidth: nextWidth });
+      setSidebarWidth(nextWidth);
     },
-    [updatePreferences]
+    [setSidebarWidth]
   );
 
   // Mobile auto-collapse - only run when isMobile changes

--- a/apps/frontend/hooks/useConfigSync.ts
+++ b/apps/frontend/hooks/useConfigSync.ts
@@ -87,6 +87,11 @@ export function useConfigSync({
           onRightPanelRestore(merged.rightPanel.mode, merged.rightPanel.width);
         }
 
+        // Restore sidebar width
+        if (merged.sidebarWidth !== undefined) {
+          useWorkspaceStore.getState().setSidebarWidth(merged.sidebarWidth);
+        }
+
         // Restore tabs
         if (merged.tabs.length > 0 && client) {
           const activeFilePath = merged.activeTab;
@@ -182,8 +187,8 @@ export function useConfigSync({
     if (!metadata) return;
 
     return useWorkspaceStore.subscribe(
-      (state) => ({ tabs: state.tabs, currentFile: state.currentFile }),
-      ({ tabs, currentFile }) => {
+      (state) => ({ tabs: state.tabs, currentFile: state.currentFile, sidebarWidth: state.sidebarWidth }),
+      ({ tabs, currentFile, sidebarWidth }) => {
         const sync = configSyncRef.current;
         if (!sync) return;
 
@@ -198,6 +203,7 @@ export function useConfigSync({
           activeTab: currentFile,
           rightPanel: { mode: rightPanelMode, width: rightPanelWidth },
           lastOpenFiles: tabs.map((t) => t.filePath),
+          sidebarWidth,
         };
         sync.scheduleWrite('workspace.json', workspaceData);
       },
@@ -216,7 +222,6 @@ export function useConfigSync({
         textFontFamily: state.textFontFamily,
         monospaceFontFamily: state.monospaceFontFamily,
         interfaceFontFamily: state.interfaceFontFamily,
-        sidebarWidth: state.sidebarWidth,
       }),
       () => {
         configSyncRef.current?.scheduleWrite(
@@ -320,7 +325,7 @@ export function useConfigSync({
     const sync = configSyncRef.current;
     if (!sync) return;
 
-    const { tabs, currentFile } = useWorkspaceStore.getState();
+    const { tabs, currentFile, sidebarWidth } = useWorkspaceStore.getState();
     const workspaceData: CushionWorkspace = {
       tabs: tabs.map((t) => ({
         id: t.id,
@@ -332,6 +337,7 @@ export function useConfigSync({
       activeTab: currentFile,
       rightPanel: { mode: rightPanelMode, width: rightPanelWidth },
       lastOpenFiles: tabs.map((t) => t.filePath),
+      sidebarWidth,
     };
     sync.scheduleWrite('workspace.json', workspaceData);
   }, [metadata, rightPanelMode, rightPanelWidth]);

--- a/apps/frontend/hooks/useConfigSync.ts
+++ b/apps/frontend/hooks/useConfigSync.ts
@@ -1,0 +1,339 @@
+/**
+ * useConfigSync — owns the full ConfigSync lifecycle.
+ *
+ * Reads `.cushion/*.json` on workspace open, subscribes to store changes
+ * to write back, and re-reads on external disk changes.
+ *
+ * Extracted from page.tsx to keep the shell component focused on layout.
+ */
+
+import { useEffect, useRef } from 'react';
+import { ConfigSync } from '@/lib/config-sync';
+import { DEFAULT_SETTINGS, DEFAULT_WORKSPACE, DEFAULT_CHAT } from '@/lib/config-defaults';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useAppearanceStore } from '@/stores/appearanceStore';
+import { useChatStore } from '@/stores/chatStore';
+import type { CoordinatorClient } from '@/lib/coordinator-client';
+import type {
+  WorkspaceMetadata,
+  CushionSettings,
+  CushionWorkspace,
+  CushionAppearance,
+  CushionChat,
+} from '@cushion/types';
+
+interface UseConfigSyncOptions {
+  client: CoordinatorClient | null;
+  metadata: WorkspaceMetadata | null;
+  /** Current right-panel UI state, written into workspace.json */
+  rightPanelMode: 'none' | 'chat';
+  rightPanelWidth: number;
+}
+
+/**
+ * Returns a ref that is `true` once workspace.json has been loaded
+ * (so writes triggered before that point don't overwrite saved state).
+ */
+export function useConfigSync({
+  client,
+  metadata,
+  rightPanelMode,
+  rightPanelWidth,
+}: UseConfigSyncOptions) {
+  const configSyncRef = useRef<ConfigSync | null>(null);
+  const workspaceConfigLoadedRef = useRef(false);
+
+  // Create / destroy ConfigSync when client connects
+  useEffect(() => {
+    if (!client) return;
+    configSyncRef.current = new ConfigSync(client);
+    return () => {
+      configSyncRef.current?.flush();
+      configSyncRef.current?.destroy();
+      configSyncRef.current = null;
+    };
+  }, [client]);
+
+  // Load all config files when a workspace opens
+  useEffect(() => {
+    if (!metadata || !configSyncRef.current) return;
+    workspaceConfigLoadedRef.current = false;
+    let cancelled = false;
+    const sync = configSyncRef.current;
+
+    (async () => {
+      // --- settings.json ---
+      const parsedSettings = await sync.read<CushionSettings>('settings.json');
+      if (cancelled) return;
+      if (parsedSettings) {
+        useWorkspaceStore.getState().updatePreferences({
+          ...DEFAULT_SETTINGS,
+          ...parsedSettings,
+        });
+      }
+
+      // --- workspace.json ---
+      const parsedWorkspace = await sync.read<CushionWorkspace>('workspace.json');
+      if (cancelled) return;
+      if (parsedWorkspace) {
+        const merged = { ...DEFAULT_WORKSPACE, ...parsedWorkspace };
+
+        // Restore right panel state — dispatch via external setter if needed
+        // (handled by the caller via returned ref or store)
+
+        // Restore tabs
+        if (merged.tabs.length > 0 && client) {
+          const activeFilePath = merged.activeTab;
+          for (const tab of merged.tabs) {
+            try {
+              const { content } = await client.readFile(tab.filePath);
+              if (cancelled) return;
+              useWorkspaceStore.getState().openFile(tab.filePath, content);
+              if (tab.isPinned) {
+                const currentTabs = useWorkspaceStore.getState().tabs;
+                const restored = currentTabs.find((t) => t.filePath === tab.filePath);
+                if (restored) useWorkspaceStore.getState().pinTab(restored.id);
+              }
+            } catch {
+              console.warn(`[ConfigSync] Skipping missing tab: ${tab.filePath}`);
+            }
+          }
+          if (activeFilePath) {
+            const currentTabs = useWorkspaceStore.getState().tabs;
+            const activeTab = currentTabs.find((t) => t.filePath === activeFilePath);
+            if (activeTab) {
+              useWorkspaceStore.getState().setActiveTab(activeTab.id);
+            }
+          }
+        }
+      }
+
+      workspaceConfigLoadedRef.current = true;
+
+      // --- appearance.json ---
+      const parsedAppearance = await sync.read<CushionAppearance>('appearance.json');
+      if (cancelled) return;
+      if (parsedAppearance) {
+        useAppearanceStore.getState().loadAppearance(parsedAppearance);
+      }
+
+      // --- chat.json ---
+      const parsedChat = await sync.read<CushionChat>('chat.json');
+      if (cancelled) return;
+      if (parsedChat) {
+        const merged = { ...DEFAULT_CHAT, ...parsedChat };
+        const directory = metadata.projectPath;
+        useChatStore.setState((state) => ({
+          displayPreferences: merged.displayPreferences,
+          modelVisibility: { ...state.modelVisibility, ...merged.modelVisibility },
+          ...(merged.selectedModel && {
+            selectedModel: merged.selectedModel,
+            selectedModelByDirectory: {
+              ...state.selectedModelByDirectory,
+              [directory]: merged.selectedModel,
+            },
+          }),
+          ...(merged.selectedAgent !== null && {
+            selectedAgent: merged.selectedAgent,
+            selectedAgentByDirectory: {
+              ...state.selectedAgentByDirectory,
+              [directory]: merged.selectedAgent,
+            },
+          }),
+          ...(merged.selectedVariant !== null && {
+            selectedVariant: merged.selectedVariant,
+            selectedVariantByDirectory: {
+              ...state.selectedVariantByDirectory,
+              [directory]: merged.selectedVariant,
+            },
+          }),
+        }));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [metadata, client]);
+
+  // Write settings.json when preferences change
+  useEffect(() => {
+    if (!metadata) return;
+
+    return useWorkspaceStore.subscribe(
+      (state) => state.preferences,
+      (prefs) => {
+        configSyncRef.current?.scheduleWrite('settings.json', prefs);
+      },
+    );
+  }, [metadata]);
+
+  // Write workspace.json when tabs or active file change
+  useEffect(() => {
+    if (!metadata) return;
+
+    return useWorkspaceStore.subscribe(
+      (state) => ({ tabs: state.tabs, currentFile: state.currentFile }),
+      ({ tabs, currentFile }) => {
+        const sync = configSyncRef.current;
+        if (!sync) return;
+
+        const workspaceData: CushionWorkspace = {
+          tabs: tabs.map((t) => ({
+            id: t.id,
+            filePath: t.filePath,
+            isPinned: t.isPinned,
+            isPreview: t.isPreview,
+            order: t.order,
+          })),
+          activeTab: currentFile,
+          rightPanel: { mode: rightPanelMode, width: rightPanelWidth },
+          lastOpenFiles: tabs.map((t) => t.filePath),
+        };
+        sync.scheduleWrite('workspace.json', workspaceData);
+      },
+    );
+  }, [metadata, rightPanelMode, rightPanelWidth]);
+
+  // Write appearance.json when appearance changes
+  useEffect(() => {
+    if (!metadata) return;
+
+    return useAppearanceStore.subscribe(
+      (state) => ({
+        theme: state.theme,
+        accentColor: state.accentColor,
+        baseFontSize: state.baseFontSize,
+        textFontFamily: state.textFontFamily,
+        monospaceFontFamily: state.monospaceFontFamily,
+        interfaceFontFamily: state.interfaceFontFamily,
+        sidebarWidth: state.sidebarWidth,
+      }),
+      () => {
+        configSyncRef.current?.scheduleWrite(
+          'appearance.json',
+          useAppearanceStore.getState().getConfig(),
+        );
+      },
+      { equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
+    );
+  }, [metadata]);
+
+  // Write chat.json when chat preferences change
+  useEffect(() => {
+    if (!metadata) return;
+    const directory = metadata.projectPath;
+
+    return useChatStore.subscribe(
+      (state) => ({
+        displayPreferences: state.displayPreferences,
+        modelVisibility: state.modelVisibility,
+        selectedModel: state.selectedModelByDirectory[directory] ?? state.selectedModel,
+        selectedAgent: state.selectedAgentByDirectory[directory] ?? state.selectedAgent,
+        selectedVariant: state.selectedVariantByDirectory[directory] ?? state.selectedVariant,
+      }),
+      (slice) => {
+        const chatData: CushionChat = {
+          selectedModel: slice.selectedModel,
+          selectedAgent: slice.selectedAgent,
+          selectedVariant: slice.selectedVariant,
+          displayPreferences: slice.displayPreferences,
+          modelVisibility: slice.modelVisibility,
+        };
+        configSyncRef.current?.scheduleWrite('chat.json', chatData);
+      },
+      { equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
+    );
+  }, [metadata]);
+
+  // Re-read config files when externally changed on disk
+  useEffect(() => {
+    if (!client || !metadata) return;
+
+    return client.onConfigChanged(async (file: string) => {
+      const sync = configSyncRef.current;
+      if (!sync) return;
+
+      switch (file) {
+        case 'settings.json': {
+          const parsed = await sync.read<CushionSettings>('settings.json');
+          if (!parsed) return;
+          useWorkspaceStore.getState().updatePreferences({
+            ...DEFAULT_SETTINGS,
+            ...parsed,
+          });
+          break;
+        }
+        case 'appearance.json': {
+          const parsed = await sync.read<CushionAppearance>('appearance.json');
+          if (!parsed) return;
+          useAppearanceStore.getState().loadAppearance(parsed);
+          break;
+        }
+        case 'chat.json': {
+          const parsed = await sync.read<CushionChat>('chat.json');
+          if (!parsed) return;
+          const merged = { ...DEFAULT_CHAT, ...parsed };
+          const directory = metadata.projectPath;
+          useChatStore.setState((state) => ({
+            displayPreferences: merged.displayPreferences,
+            modelVisibility: { ...state.modelVisibility, ...merged.modelVisibility },
+            ...(merged.selectedModel && {
+              selectedModel: merged.selectedModel,
+              selectedModelByDirectory: {
+                ...state.selectedModelByDirectory,
+                [directory]: merged.selectedModel,
+              },
+            }),
+            ...(merged.selectedAgent !== null && {
+              selectedAgent: merged.selectedAgent,
+              selectedAgentByDirectory: {
+                ...state.selectedAgentByDirectory,
+                [directory]: merged.selectedAgent,
+              },
+            }),
+            ...(merged.selectedVariant !== null && {
+              selectedVariant: merged.selectedVariant,
+              selectedVariantByDirectory: {
+                ...state.selectedVariantByDirectory,
+                [directory]: merged.selectedVariant,
+              },
+            }),
+          }));
+          break;
+        }
+      }
+    });
+  }, [client, metadata]);
+
+  // Write workspace.json when right panel state changes
+  useEffect(() => {
+    if (!metadata || !workspaceConfigLoadedRef.current) return;
+    const sync = configSyncRef.current;
+    if (!sync) return;
+
+    const { tabs, currentFile } = useWorkspaceStore.getState();
+    const workspaceData: CushionWorkspace = {
+      tabs: tabs.map((t) => ({
+        id: t.id,
+        filePath: t.filePath,
+        isPinned: t.isPinned,
+        isPreview: t.isPreview,
+        order: t.order,
+      })),
+      activeTab: currentFile,
+      rightPanel: { mode: rightPanelMode, width: rightPanelWidth },
+      lastOpenFiles: tabs.map((t) => t.filePath),
+    };
+    sync.scheduleWrite('workspace.json', workspaceData);
+  }, [metadata, rightPanelMode, rightPanelWidth]);
+
+  // Flush pending config writes on page unload
+  useEffect(() => {
+    const handler = () => configSyncRef.current?.flush();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, []);
+
+  return { workspaceConfigLoadedRef };
+}

--- a/apps/frontend/hooks/useConfigSync.ts
+++ b/apps/frontend/hooks/useConfigSync.ts
@@ -28,6 +28,8 @@ interface UseConfigSyncOptions {
   /** Current right-panel UI state, written into workspace.json */
   rightPanelMode: 'none' | 'chat';
   rightPanelWidth: number;
+  /** Called when workspace.json is loaded with the persisted right-panel state */
+  onRightPanelRestore: (mode: 'none' | 'chat', width: number) => void;
 }
 
 /**
@@ -39,9 +41,12 @@ export function useConfigSync({
   metadata,
   rightPanelMode,
   rightPanelWidth,
+  onRightPanelRestore,
 }: UseConfigSyncOptions) {
   const configSyncRef = useRef<ConfigSync | null>(null);
   const workspaceConfigLoadedRef = useRef(false);
+  // Preserve the full on-disk settings object so unknown keys survive round-trips
+  const lastSettingsRef = useRef<CushionSettings>(DEFAULT_SETTINGS);
 
   // Create / destroy ConfigSync when client connects
   useEffect(() => {
@@ -66,10 +71,9 @@ export function useConfigSync({
       const parsedSettings = await sync.read<CushionSettings>('settings.json');
       if (cancelled) return;
       if (parsedSettings) {
-        useWorkspaceStore.getState().updatePreferences({
-          ...DEFAULT_SETTINGS,
-          ...parsedSettings,
-        });
+        const merged = { ...DEFAULT_SETTINGS, ...parsedSettings };
+        lastSettingsRef.current = merged;
+        useWorkspaceStore.getState().updatePreferences(merged);
       }
 
       // --- workspace.json ---
@@ -78,8 +82,10 @@ export function useConfigSync({
       if (parsedWorkspace) {
         const merged = { ...DEFAULT_WORKSPACE, ...parsedWorkspace };
 
-        // Restore right panel state — dispatch via external setter if needed
-        // (handled by the caller via returned ref or store)
+        // Restore right panel state
+        if (merged.rightPanel) {
+          onRightPanelRestore(merged.rightPanel.mode, merged.rightPanel.width);
+        }
 
         // Restore tabs
         if (merged.tabs.length > 0 && client) {
@@ -163,7 +169,10 @@ export function useConfigSync({
     return useWorkspaceStore.subscribe(
       (state) => state.preferences,
       (prefs) => {
-        configSyncRef.current?.scheduleWrite('settings.json', prefs);
+        // Spread over last-read disk object to preserve unknown keys
+        const settings: CushionSettings = { ...lastSettingsRef.current, ...prefs };
+        lastSettingsRef.current = settings;
+        configSyncRef.current?.scheduleWrite('settings.json', settings);
       },
     );
   }, [metadata]);
@@ -258,10 +267,9 @@ export function useConfigSync({
         case 'settings.json': {
           const parsed = await sync.read<CushionSettings>('settings.json');
           if (!parsed) return;
-          useWorkspaceStore.getState().updatePreferences({
-            ...DEFAULT_SETTINGS,
-            ...parsed,
-          });
+          const merged = { ...DEFAULT_SETTINGS, ...parsed };
+          lastSettingsRef.current = merged;
+          useWorkspaceStore.getState().updatePreferences(merged);
           break;
         }
         case 'appearance.json': {

--- a/apps/frontend/lib/config-defaults.test.ts
+++ b/apps/frontend/lib/config-defaults.test.ts
@@ -52,7 +52,6 @@ describe('DEFAULT_APPEARANCE', () => {
       'textFontFamily',
       'monospaceFontFamily',
       'interfaceFontFamily',
-      'sidebarWidth',
     ];
 
     for (const key of keys) {
@@ -78,6 +77,7 @@ describe('DEFAULT_WORKSPACE', () => {
       'activeTab',
       'rightPanel',
       'lastOpenFiles',
+      'sidebarWidth',
     ];
 
     for (const key of keys) {

--- a/apps/frontend/lib/config-defaults.ts
+++ b/apps/frontend/lib/config-defaults.ts
@@ -19,7 +19,6 @@ export const DEFAULT_SETTINGS: Required<CushionSettings> = {
   showHiddenFiles: false,
   showCushionFiles: false,
   fileSortOrder: 'alphabetical',
-  sidebarWidth: 240,
 };
 
 export const DEFAULT_WORKSPACE: Required<CushionWorkspace> = {
@@ -27,6 +26,7 @@ export const DEFAULT_WORKSPACE: Required<CushionWorkspace> = {
   activeTab: null,
   rightPanel: { mode: 'none', width: 360 },
   lastOpenFiles: [],
+  sidebarWidth: 240,
 };
 
 export const DEFAULT_APPEARANCE: Required<CushionAppearance> = {
@@ -36,7 +36,6 @@ export const DEFAULT_APPEARANCE: Required<CushionAppearance> = {
   textFontFamily: '',
   monospaceFontFamily: '',
   interfaceFontFamily: '',
-  sidebarWidth: 240,
 };
 
 export const DEFAULT_CHAT: Required<CushionChat> = {

--- a/apps/frontend/lib/config-defaults.ts
+++ b/apps/frontend/lib/config-defaults.ts
@@ -19,6 +19,7 @@ export const DEFAULT_SETTINGS: Required<CushionSettings> = {
   showHiddenFiles: false,
   showCushionFiles: false,
   fileSortOrder: 'alphabetical',
+  sidebarWidth: 240,
 };
 
 export const DEFAULT_WORKSPACE: Required<CushionWorkspace> = {

--- a/apps/frontend/lib/coordinator-client.ts
+++ b/apps/frontend/lib/coordinator-client.ts
@@ -495,7 +495,7 @@ export class CoordinatorClient {
     return this.call('provider/sync');
   }
 
-  authorizeOAuth(params: { providerID: string; method: number }) {
+  authorizeOAuth(params: RPCParams<'provider/oauth/authorize'>) {
     return this.call('provider/oauth/authorize', params);
   }
 

--- a/apps/frontend/lib/coordinator-client.ts
+++ b/apps/frontend/lib/coordinator-client.ts
@@ -7,16 +7,15 @@
 import type {
   DidOpenTextDocumentParams,
   DidChangeTextDocumentParams,
-  FileTreeNode,
   FileChange,
-  Provider,
-  Model,
-  AuthMethod,
   ConnectionState,
   JSONRPCRequest,
   JSONRPCResponse,
   JSONRPCNotification,
   RPCServerNotificationParams,
+  RPCMethodName,
+  RPCParams,
+  RPCResult,
 } from '@cushion/types';
 
 const INITIAL_RECONNECT_DELAY = 1_000;
@@ -344,116 +343,106 @@ export class CoordinatorClient {
   }
 
   // ---------------------------------------------------------------------------
-  // LSP notifications
+  // Generic typed RPC call
   // ---------------------------------------------------------------------------
 
   /**
-   * LSP: textDocument/didOpen
+   * Type-safe RPC call. Params and result types are inferred from RPCMethodMap.
+   *
+   * For methods with `params: void`, pass `{}` or omit the second argument.
    */
+  call<M extends RPCMethodName>(
+    method: M,
+    ...args: RPCParams<M> extends void ? [] : [RPCParams<M>]
+  ): Promise<RPCResult<M>> {
+    return this.sendRequest(method, args[0] ?? {});
+  }
+
+  // ---------------------------------------------------------------------------
+  // LSP notifications
+  // ---------------------------------------------------------------------------
+
   didOpen(params: DidOpenTextDocumentParams) {
     this.sendNotification('textDocument/didOpen', params);
   }
 
-  /**
-   * LSP: textDocument/didChange
-   */
   didChange(params: DidChangeTextDocumentParams) {
     this.sendNotification('textDocument/didChange', params);
   }
 
   // ---------------------------------------------------------------------------
-  // Workspace RPCs
+  // Convenience wrappers (thin delegates to `call`)
   // ---------------------------------------------------------------------------
 
-  async openWorkspace(projectPath: string): Promise<{ projectName: string; gitRoot: string | null }> {
-    return this.sendRequest<{ projectName: string; gitRoot: string | null }>('workspace/open', { projectPath });
+  openWorkspace(projectPath: string) {
+    return this.call('workspace/open', { projectPath });
   }
 
-  async selectWorkspaceFolder(): Promise<{ path: string | null }> {
-    return this.sendRequest<{ path: string | null }>('workspace/select-folder', {});
+  selectWorkspaceFolder() {
+    return this.call('workspace/select-folder');
   }
 
-  async listFsRoots(): Promise<{ roots: Array<{ name: string; path: string }> }> {
-    return this.sendRequest<{ roots: Array<{ name: string; path: string }> }>('fs/roots', {});
+  listFsRoots() {
+    return this.call('fs/roots');
   }
 
-  async listFsDirs(absPath: string): Promise<{ path: string; parent: string | null; dirs: Array<{ name: string; path: string }> }> {
-    return this.sendRequest<{ path: string; parent: string | null; dirs: Array<{ name: string; path: string }> }>('fs/list-dirs', { path: absPath });
+  listFsDirs(absPath: string) {
+    return this.call('fs/list-dirs', { path: absPath });
   }
 
-  async listFiles(relativePath?: string): Promise<{ files: FileTreeNode[] }> {
-    return this.sendRequest<{ files: FileTreeNode[] }>('workspace/files', { relativePath });
+  listFiles(relativePath?: string) {
+    return this.call('workspace/files', { relativePath });
   }
 
-  async readFile(filePath: string): Promise<{ content: string; encoding: string; lineEnding: string }> {
-    return this.sendRequest<{ content: string; encoding: string; lineEnding: string }>('workspace/file', { filePath });
+  readFile(filePath: string) {
+    return this.call('workspace/file', { filePath });
   }
 
-  async saveFile(filePath: string, content: string, options?: { encoding?: string; lineEnding?: 'LF' | 'CRLF' }): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('workspace/save-file', { filePath, content, ...options });
+  saveFile(filePath: string, content: string, options?: { encoding?: string; lineEnding?: 'LF' | 'CRLF' }) {
+    return this.call('workspace/save-file', { filePath, content, ...options });
   }
 
-  async renameFile(oldPath: string, newPath: string): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('workspace/rename', { oldPath, newPath });
+  renameFile(oldPath: string, newPath: string) {
+    return this.call('workspace/rename', { oldPath, newPath });
   }
 
-  async deleteFile(path: string): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('workspace/delete', { path });
+  deleteFile(path: string) {
+    return this.call('workspace/delete', { path });
   }
 
-  async duplicateFile(path: string, newPath: string): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('workspace/duplicate', { path, newPath });
+  duplicateFile(path: string, newPath: string) {
+    return this.call('workspace/duplicate', { path, newPath });
   }
 
-  async createFolder(folderPath: string): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('workspace/create-folder', { path: folderPath });
+  createFolder(folderPath: string) {
+    return this.call('workspace/create-folder', { path: folderPath });
   }
 
-  async readFileBase64(filePath: string): Promise<{ base64: string; mimeType: string }> {
-    return this.sendRequest<{ base64: string; mimeType: string }>('workspace/file-base64', { filePath });
+  readFileBase64(filePath: string) {
+    return this.call('workspace/file-base64', { filePath });
   }
 
-  async readFileBase64Chunk(
-    filePath: string,
-    offset: number,
-    length: number,
-  ): Promise<{
-    base64: string;
-    mimeType: string;
-    offset: number;
-    bytesRead: number;
-    totalBytes: number;
-  }> {
-    return this.sendRequest<{
-      base64: string;
-      mimeType: string;
-      offset: number;
-      bytesRead: number;
-      totalBytes: number;
-    }>('workspace/file-base64-chunk', { filePath, offset, length });
+  readFileBase64Chunk(filePath: string, offset: number, length: number) {
+    return this.call('workspace/file-base64-chunk', { filePath, offset, length });
   }
 
-  async saveFileBase64(filePath: string, base64: string): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('workspace/save-file-base64', { filePath, base64 });
+  saveFileBase64(filePath: string, base64: string) {
+    return this.call('workspace/save-file-base64', { filePath, base64 });
   }
 
-  // ---------------------------------------------------------------------------
-  // Config RPCs
-  // ---------------------------------------------------------------------------
-
-  async readConfig(file: string): Promise<{ content: string | null; exists: boolean }> {
-    return this.sendRequest<{ content: string | null; exists: boolean }>('config/read', { file });
+  readConfig(file: string) {
+    return this.call('config/read', { file });
   }
 
-  async writeConfig(file: string, content: string): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('config/write', { file, content });
+  writeConfig(file: string, content: string) {
+    return this.call('config/write', { file, content });
   }
 
   // ---------------------------------------------------------------------------
   // Notification subscriptions
   // ---------------------------------------------------------------------------
 
-  onFilesChanged(callback: (changes: FileChange[]) => void): () => void {
+  onFilesChanged(callback: (changes: import('@cushion/types').FileChange[]) => void): () => void {
     this.filesChangedCallbacks.push(callback);
     return () => {
       this.filesChangedCallbacks = this.filesChangedCallbacks.filter((cb) => cb !== callback);
@@ -478,59 +467,59 @@ export class CoordinatorClient {
   // Provider RPCs
   // ---------------------------------------------------------------------------
 
-  async listProviders(): Promise<{ providers: Provider[]; connected: string[] }> {
-    return this.sendRequest<{ providers: Provider[]; connected: string[] }>('provider/list', {});
+  listProviders() {
+    return this.call('provider/list');
   }
 
-  async listProviderAuthMethods(): Promise<Record<string, AuthMethod[]>> {
-    return this.sendRequest<Record<string, AuthMethod[]>>('provider/auth/methods', {});
+  listProviderAuthMethods() {
+    return this.call('provider/auth/methods');
   }
 
-  async refreshProviders(): Promise<{ providers: Provider[]; connected: string[] }> {
-    return this.sendRequest<{ providers: Provider[]; connected: string[] }>('provider/refresh', {});
+  refreshProviders() {
+    return this.call('provider/refresh');
   }
 
-  async getPopularProviders(): Promise<{ ids: string[] }> {
-    return this.sendRequest<{ ids: string[] }>('provider/popular', {});
+  getPopularProviders() {
+    return this.call('provider/popular');
   }
 
-  async setProviderAuth(params: { providerID: string; apiKey: string }): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('provider/auth/set', params);
+  setProviderAuth(params: { providerID: string; apiKey: string }) {
+    return this.call('provider/auth/set', params);
   }
 
-  async removeProviderAuth(params: { providerID: string }): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('provider/auth/remove', params);
+  removeProviderAuth(params: { providerID: string }) {
+    return this.call('provider/auth/remove', params);
   }
 
-  async syncProviders(): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('provider/sync', {});
+  syncProviders() {
+    return this.call('provider/sync');
   }
 
-  async authorizeOAuth(params: { providerID: string; method: number }): Promise<{ url: string; method: 'auto' | 'code'; instructions: string }> {
-    return this.sendRequest<{ url: string; method: 'auto' | 'code'; instructions: string }>('provider/oauth/authorize', params);
+  authorizeOAuth(params: { providerID: string; method: number }) {
+    return this.call('provider/oauth/authorize', params);
   }
 
-  async oauthCallback(params: { providerID: string; method: number; code?: string }): Promise<{ success: boolean }> {
-    return this.sendRequest<{ success: boolean }>('provider/oauth/callback', params);
+  oauthCallback(params: { providerID: string; method: number; code?: string }) {
+    return this.call('provider/oauth/callback', params);
   }
 
   // ---------------------------------------------------------------------------
   // Ollama RPCs
   // ---------------------------------------------------------------------------
 
-  async listOllamaModels(): Promise<{ models: Model[]; running: boolean }> {
-    return this.sendRequest<{ models: Model[]; running: boolean }>('provider/ollama/list', {});
+  listOllamaModels() {
+    return this.call('provider/ollama/list');
   }
 
-  async pullOllamaModel(model: string): Promise<{ success: boolean; error?: string }> {
-    return this.sendRequest<{ success: boolean; error?: string }>('provider/ollama/pull', { model });
+  pullOllamaModel(model: string) {
+    return this.call('provider/ollama/pull', { model });
   }
 
-  async deleteOllamaModel(model: string): Promise<{ success: boolean; error?: string }> {
-    return this.sendRequest<{ success: boolean; error?: string }>('provider/ollama/delete', { model });
+  deleteOllamaModel(model: string) {
+    return this.call('provider/ollama/delete', { model });
   }
 
-  async writeOllamaConfig(params: { baseUrl?: string; models?: unknown[] }): Promise<{ success: boolean; message: string }> {
-    return this.sendRequest<{ success: boolean; message: string }>('provider/ollama/write-config', params);
+  writeOllamaConfig(params: { baseUrl?: string; models?: unknown[] }) {
+    return this.call('provider/ollama/write-config', params);
   }
 }

--- a/apps/frontend/stores/appearanceStore.test.ts
+++ b/apps/frontend/stores/appearanceStore.test.ts
@@ -116,7 +116,6 @@ describe('loadAppearance', () => {
       textFontFamily: 'Georgia',
       monospaceFontFamily: 'Fira Code',
       interfaceFontFamily: 'Helvetica',
-      sidebarWidth: 300,
     });
 
     const state = useAppearanceStore.getState();

--- a/apps/frontend/stores/workspaceStore.ts
+++ b/apps/frontend/stores/workspaceStore.ts
@@ -53,6 +53,9 @@ interface WorkspaceActions {
   // Preferences
   updatePreferences: (preferences: Partial<WorkspacePreferences>) => void;
 
+  // Layout
+  setSidebarWidth: (width: number) => void;
+
   // Error handling
   setError: (error: string | null) => void;
   setLoading: (isLoading: boolean) => void;
@@ -81,6 +84,7 @@ const initialState: Omit<WorkspaceState, keyof WorkspaceActions> = {
   recentProjects: [],
   recentFiles: [],
   preferences: { ...DEFAULT_SETTINGS },
+  sidebarWidth: 240,
   sessionId: '',
   isLoading: false,
   error: null,
@@ -539,6 +543,10 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
               ...preferences,
             },
           }));
+        },
+
+        setSidebarWidth: (width: number) => {
+          set({ sidebarWidth: width });
         },
 
         /**

--- a/apps/frontend/stores/workspaceStore.ts
+++ b/apps/frontend/stores/workspaceStore.ts
@@ -16,6 +16,7 @@ import type {
   Frontmatter,
 } from '@cushion/types';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
+import { DEFAULT_SETTINGS } from '@/lib/config-defaults';
 import { parseFrontmatter } from '@/lib/frontmatter';
 
 /**
@@ -79,20 +80,7 @@ const initialState: Omit<WorkspaceState, keyof WorkspaceActions> = {
   },
   recentProjects: [],
   recentFiles: [],
-  preferences: {
-    showHiddenFiles: false,
-    showCushionFiles: false,
-    sidebarWidth: 240,
-    autoSave: true,
-    autoSaveDelay: 1000,
-    showLineNumber: false,
-    spellcheck: true,
-    readableLineLength: true,
-    autoPairBrackets: true,
-    foldHeading: true,
-    foldIndent: true,
-    fileSortOrder: 'alphabetical',
-  },
+  preferences: { ...DEFAULT_SETTINGS },
   sessionId: '',
   isLoading: false,
   error: null,

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -17,7 +17,6 @@ export interface CushionSettings {
   showHiddenFiles?: boolean;
   showCushionFiles?: boolean;
   fileSortOrder?: 'alphabetical' | 'modified' | 'created';
-  sidebarWidth?: number;
 }
 
 export interface CushionAppearance {
@@ -27,7 +26,6 @@ export interface CushionAppearance {
   textFontFamily?: string;
   monospaceFontFamily?: string;
   interfaceFontFamily?: string;
-  sidebarWidth?: number;
 }
 
 export interface CushionWorkspace {
@@ -44,6 +42,7 @@ export interface CushionWorkspace {
     width: number;
   };
   lastOpenFiles?: string[];
+  sidebarWidth?: number;
 }
 
 export interface CushionChat {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -17,6 +17,7 @@ export interface CushionSettings {
   showHiddenFiles?: boolean;
   showCushionFiles?: boolean;
   fileSortOrder?: 'alphabetical' | 'modified' | 'created';
+  sidebarWidth?: number;
 }
 
 export interface CushionAppearance {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -88,6 +88,7 @@ export interface WorkspaceState {
   recentProjects: WorkspaceMetadata[];
   recentFiles: string[];
   preferences: WorkspacePreferences;
+  sidebarWidth: number;
   sessionId: string;
   isLoading: boolean;
   error: string | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,5 @@
+import type { CushionSettings } from './config.js';
+
 export interface Position {
   line: number;
   character: number;
@@ -68,23 +70,7 @@ export interface TabState {
   order: number;
 }
 
-export interface WorkspacePreferences {
-  showHiddenFiles: boolean;
-  showCushionFiles: boolean;
-  fileTreeCollapsed: boolean;
-  sidebarWidth: number;
-  autoSave: boolean;
-  autoSaveDelay: number;
-  showLineNumber: boolean;
-  spellcheck: boolean;
-  readableLineLength: boolean;
-  autoPairBrackets: boolean;
-  foldHeading: boolean;
-  foldIndent: boolean;
-  fileSortOrder: 'alphabetical' | 'modified' | 'created';
-  newFileLocation: 'root' | 'current';
-  attachmentFolderPath: string;
-}
+export type WorkspacePreferences = Required<CushionSettings>;
 
 export interface FileWatcherState {
   watchedPaths: string[];


### PR DESCRIPTION
## Summary

- **Extract config plumbing from page.tsx**: ~200 lines of ConfigSync lifecycle (create/destroy, load on workspace open, subscribe to store changes, re-read on external disk changes, flush on unload) moved into a dedicated `useConfigSync` hook. page.tsx drops from ~870 to ~670 lines.
- **Unify settings types**: `WorkspacePreferences` is now `Required<CushionSettings>` instead of a separate interface with duplicated fields. Eliminates the triple field-by-field mapping (load → write → re-read) — now just spreads directly. Added `sidebarWidth` to `CushionSettings` since it was the only field in the old type that was actually used.
- **Generic RPC client**: Added a typed `call<M>(method, params)` method to `CoordinatorClient` that infers params/result types from `RPCMethodMap`. All ~30 convenience methods become one-line wrappers with no manual type annotations.

## Test plan

- [x] `bun run type-check` passes (all 3 packages)
- [x] `bun run test` passes (149/149 tests)
- [ ] Manual: open workspace, verify settings/tabs/appearance/chat config persist across reload
- [ ] Manual: change a setting externally (edit `.cushion/settings.json`) and verify it updates in the UI