### PR TITLE
Fix text selection in WYSIWYG editor

### DIFF
--- a/apps/frontend/lib/codemirror-wysiwyg/atomic-ranges.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/atomic-ranges.ts
@@ -1,0 +1,171 @@
+import { StateField, RangeSet, RangeValue } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import { wikiLinkRegex } from '../wiki-link';
+import type { EditorState } from '@codemirror/state';
+
+class HiddenRange extends RangeValue {}
+const hiddenRange = new HiddenRange();
+
+const childMarkTypes: Record<string, string> = {
+  'StrongEmphasis': 'EmphasisMark',
+  'Emphasis': 'EmphasisMark',
+  'Strikethrough': 'StrikethroughMark',
+  'Highlight': 'HighlightMark',
+  'InlineCode': 'CodeMark',
+  'Escape': 'EscapeMark',
+};
+
+function collectChildMarks(
+  node: { node: { cursor: () => { iterate: (cb: (n: { type: { name: string }; from: number; to: number }) => void) => void } } },
+  markName: string,
+  ranges: { from: number; to: number }[],
+) {
+  node.node.cursor().iterate((child) => {
+    if (child.type.name === markName) {
+      ranges.push({ from: child.from, to: child.to });
+    }
+  });
+}
+
+function buildHiddenRanges(state: EditorState): RangeSet<HiddenRange> {
+  const ranges: { from: number; to: number }[] = [];
+  const tree = syntaxTree(state);
+
+  tree.iterate({
+    enter(node) {
+      const type = node.type.name;
+
+      if (type === 'Table') return false;
+
+      if (/^ATXHeading[1-6]$/.test(type)) {
+        const child = node.node.getChild('HeaderMark');
+        if (child) {
+          const hideEnd = Math.min(child.to + 1, node.to);
+          if (hideEnd < node.to) {
+            ranges.push({ from: child.from, to: hideEnd });
+          }
+        }
+        return true;
+      }
+
+      const markName = childMarkTypes[type];
+      if (markName) {
+        collectChildMarks(node, markName, ranges);
+        return false;
+      }
+
+      if (type === 'Link') {
+        node.node.cursor().iterate((child) => {
+          if (child.type.name === 'LinkMark' || child.type.name === 'URL') {
+            ranges.push({ from: child.from, to: child.to });
+          } else if (child.type.name === 'LinkTitle') {
+            let hideFrom = child.from;
+            let hideTo = child.to;
+            if (hideFrom > 0) {
+              const before = state.doc.sliceString(hideFrom - 1, hideFrom);
+              if (before === '"' || before === "'") hideFrom -= 1;
+            }
+            if (hideTo < state.doc.length) {
+              const after = state.doc.sliceString(hideTo, hideTo + 1);
+              if (after === '"' || after === "'") hideTo += 1;
+            }
+            ranges.push({ from: hideFrom, to: hideTo });
+          }
+        });
+        return false;
+      }
+
+      if (type === 'Blockquote') {
+        const startLine = state.doc.lineAt(node.from).number;
+        const endLine = state.doc.lineAt(Math.min(node.to, state.doc.length)).number;
+        for (let i = startLine; i <= endLine; i++) {
+          const line = state.doc.line(i);
+          const qMatch = line.text.match(/^(>\s?)+/);
+          if (qMatch) {
+            const markerEnd = line.from + qMatch[0].length;
+            if (markerEnd < line.to) {
+              ranges.push({ from: line.from, to: markerEnd });
+            }
+          }
+        }
+        return true;
+      }
+
+      return true;
+    },
+  });
+
+  const text = state.doc.toString();
+  const tableRanges: { from: number; to: number }[] = [];
+  for (const tNode of tree.topNode.getChildren('Table')) {
+    tableRanges.push({ from: tNode.from, to: tNode.to });
+  }
+
+  const regex = new RegExp(wikiLinkRegex.source, 'g');
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const start = match.index;
+    const end = match.index + match[0].length;
+
+    if (tableRanges.some(t => start >= t.from && end <= t.to)) continue;
+
+    const isEmbed = start > 0 && text[start - 1] === '!' && text[start - 2] !== '\\';
+    if (isEmbed) continue;
+
+    const openBracketEnd = start + 2;
+    const closeBracketStart = end - 2;
+
+    ranges.push({ from: start, to: openBracketEnd });
+
+    if (match[3]) {
+      const pipePos = text.indexOf('|', openBracketEnd);
+      if (pipePos !== -1 && pipePos < closeBracketStart) {
+        ranges.push({ from: openBracketEnd, to: pipePos + 1 });
+      }
+    }
+
+    if (match[2] && !match[3]) {
+      const hashPos = text.indexOf('#', openBracketEnd);
+      if (hashPos !== -1 && hashPos < closeBracketStart) {
+        ranges.push({ from: hashPos, to: closeBracketStart });
+      }
+    }
+
+    ranges.push({ from: closeBracketStart, to: end });
+  }
+
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+
+  const merged: { from: number; to: number }[] = [];
+  for (const r of ranges) {
+    if (r.from >= r.to) continue;
+    const last = merged[merged.length - 1];
+    if (last && r.from <= last.to) {
+      last.to = Math.max(last.to, r.to);
+    } else {
+      merged.push({ from: r.from, to: r.to });
+    }
+  }
+
+  return RangeSet.of(
+    merged.map(r => hiddenRange.range(r.from, r.to)),
+    true,
+  );
+}
+
+export const hiddenRangesField = StateField.define<RangeSet<HiddenRange>>({
+  create(state) {
+    return buildHiddenRanges(state);
+  },
+  update(value, tr) {
+    if (tr.docChanged || syntaxTree(tr.state) !== syntaxTree(tr.startState)) {
+      return buildHiddenRanges(tr.state);
+    }
+    return value;
+  },
+});
+
+export const hiddenAtomicRanges = EditorView.atomicRanges.of(
+  (view) => view.state.field(hiddenRangesField),
+);

--- a/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
@@ -8,7 +8,7 @@ import {
 } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
 import { EditorState, Range, StateField } from '@codemirror/state';
-import { isSelectRange, isSelectLine, isFocusEvent } from './reveal-on-cursor';
+import { isSelectRange, isSelectLine, isFocusEvent, mouseSelectEffect } from './reveal-on-cursor';
 import { ImageWidget } from './widgets/image-widget';
 import { PdfWidget } from './widgets/pdf-widget';
 import { NoteEmbedWidget } from './widgets/note-embed-widget';
@@ -602,10 +602,7 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
       }
 
       if (type === 'Image') {
-        const cursorOnEmbed = state.selection.ranges.some(r =>
-          r.from <= to && r.to >= from
-        );
-        if (cursorOnEmbed) return false;
+        if (isSelectRange(state, { from, to })) return false;
 
         const isRevealed = revealedPos !== null && from === revealedPos;
         const text = state.doc.sliceString(from, to);
@@ -662,9 +659,7 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
       }
 
       if (type === 'InlineMath') {
-        const cursorOnRange = state.selection.ranges.some(r =>
-          r.head >= from && r.head <= to
-        );
+        const cursorOnRange = isSelectRange(state, { from, to });
         if (!cursorOnRange) {
           const latex = state.doc.sliceString(from + 1, to - 1);
           if (latex.length > 0) {
@@ -700,10 +695,7 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
           : '';
         if (latex.length === 0) return false;
 
-        const cursorInBlock = state.selection.ranges.some(r => {
-          const headLine = state.doc.lineAt(r.head).number;
-          return headLine >= startLine.number && headLine <= endLine.number;
-        });
+        const cursorInBlock = isSelectLine(state, from, to);
 
         if (cursorInBlock) {
           for (let i = startLine.number; i <= endLine.number; i++) {
@@ -781,12 +773,16 @@ export const markDecorationsPlugin = ViewPlugin.fromClass(
     update(update: ViewUpdate) {
       const treeChanged = syntaxTree(update.state) !== syntaxTree(update.startState);
       const focusEvent = update.transactions.some(tr => isFocusEvent(tr));
+      const mouseSelectChanged = update.transactions.some(tr =>
+        tr.effects.some(e => e.is(mouseSelectEffect))
+      );
       if (
         update.docChanged ||
         update.selectionSet ||
         update.viewportChanged ||
         treeChanged ||
-        focusEvent
+        focusEvent ||
+        mouseSelectChanged
       ) {
         this.decorations = buildMarkDecorations(update.view);
       }
@@ -806,7 +802,7 @@ export const widgetDecorationsField = StateField.define<DecorationSet>({
     if (syntaxTree(tr.state) !== syntaxTree(tr.startState)) {
       return buildWidgetDecorations(tr.state);
     }
-    if (tr.effects.some(e => e.is(embedSourceRevealEffect))) {
+    if (tr.effects.some(e => e.is(embedSourceRevealEffect) || e.is(mouseSelectEffect))) {
       return buildWidgetDecorations(tr.state);
     }
     return value;

--- a/apps/frontend/lib/codemirror-wysiwyg/index.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/index.ts
@@ -1,7 +1,8 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { markDecorationsPlugin, widgetDecorationsField, linkClickHandler, embedRevealedField } from './hide-markup';
-import { focusState, focusListener } from './reveal-on-cursor';
+import { hiddenRangesField, hiddenAtomicRanges } from './atomic-ranges';
+import { focusState, focusListener, mouseSelectingField, mouseSelectionTracker } from './reveal-on-cursor';
 import {
   wikiLinkExtension,
   updateWikiLinkFileTree,
@@ -21,7 +22,6 @@ export {
   focusListener,
   hasFocus,
   isFocusEvent,
-  isSelectRange,
 } from './reveal-on-cursor';
 
 export {
@@ -76,9 +76,6 @@ const markdownProseTheme = EditorView.theme({
   },
   '.cm-activeLineGutter': {
     backgroundColor: 'transparent !important',
-  },
-  '&.cm-focused .cm-selectionBackground': {
-    backgroundColor: 'var(--md-selection-bg) !important',
   },
 });
 
@@ -233,7 +230,11 @@ export function wysiwygExtension(): Extension {
     wysiwygWidgetTheme,
     focusState,
     focusListener,
+    mouseSelectingField,
+    mouseSelectionTracker,
     embedRevealedField,
+    hiddenRangesField,
+    hiddenAtomicRanges,
     markDecorationsPlugin,
     widgetDecorationsField,
     linkClickHandler,

--- a/apps/frontend/lib/codemirror-wysiwyg/reveal-on-cursor.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/reveal-on-cursor.ts
@@ -1,4 +1,4 @@
-import { EditorState, StateField, Transaction } from '@codemirror/state';
+import { EditorState, StateField, StateEffect, Transaction } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 
 export const focusState = StateField.define<boolean>({
@@ -28,6 +28,34 @@ export function isFocusEvent(tr: Transaction): boolean {
   return tr.isUserEvent('cm-focus') || tr.isUserEvent('cm-blur');
 }
 
+export const mouseSelectEffect = StateEffect.define<boolean>();
+
+export const mouseSelectingField = StateField.define<boolean>({
+  create() { return false; },
+  update(value, tr) {
+    for (const e of tr.effects) {
+      if (e.is(mouseSelectEffect)) return e.value;
+    }
+    return value;
+  },
+});
+
+export const mouseSelectionTracker = EditorView.domEventHandlers({
+  mousedown(_event, view) {
+    view.dispatch({ effects: mouseSelectEffect.of(true) });
+    const onUp = () => {
+      view.dispatch({ effects: mouseSelectEffect.of(false) });
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mouseup', onUp);
+    return false;
+  },
+});
+
+function isMouseSelecting(state: EditorState): boolean {
+  return state.field(mouseSelectingField, false) ?? false;
+}
+
 export interface BaseRange {
   from: number;
   to: number;
@@ -39,14 +67,16 @@ export function isSelectRange(state: EditorState, range: BaseRange): boolean {
     if (r.empty) {
       return r.head >= range.from && r.head <= range.to;
     }
-    const headInside = r.head >= range.from && r.head <= range.to;
-    const anchorInside = r.anchor >= range.from && r.anchor <= range.to;
-    return headInside || anchorInside;
+    if (isMouseSelecting(state)) return false;
+    const selFrom = Math.min(r.head, r.anchor);
+    const selTo = Math.max(r.head, r.anchor);
+    return selFrom < range.to && selTo > range.from;
   });
 }
 
 export function isSelectLine(state: EditorState, from: number, to: number): boolean {
   if (!hasFocus(state)) return false;
+  if (isMouseSelecting(state)) return false;
   const doc = state.doc;
   const fromLine = doc.lineAt(from).number;
   const toLine = doc.lineAt(to).number;
@@ -55,10 +85,8 @@ export function isSelectLine(state: EditorState, from: number, to: number): bool
       const headLine = doc.lineAt(r.head).number;
       return headLine >= fromLine && headLine <= toLine;
     }
-    const headLine = doc.lineAt(r.head).number;
-    const anchorLine = doc.lineAt(r.anchor).number;
-    const headOnLine = headLine >= fromLine && headLine <= toLine;
-    const anchorOnLine = anchorLine >= fromLine && anchorLine <= toLine;
-    return headOnLine || anchorOnLine;
+    const selFromLine = doc.lineAt(Math.min(r.head, r.anchor)).number;
+    const selToLine = doc.lineAt(Math.max(r.head, r.anchor)).number;
+    return selFromLine <= toLine && selToLine >= fromLine;
   });
 }

--- a/apps/frontend/lib/codemirror-wysiwyg/wiki-link-plugin.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/wiki-link-plugin.ts
@@ -15,7 +15,7 @@ import {
 } from '@codemirror/view';
 import { EditorState, Range, StateField, StateEffect } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
-import { isSelectRange, isFocusEvent } from './reveal-on-cursor';
+import { isSelectRange, isFocusEvent, mouseSelectEffect } from './reveal-on-cursor';
 import { wikiLinkRegex, getWikiLinkDisplayText } from '../wiki-link';
 import { resolveWikiLink, flattenFileTree } from '../wiki-link-resolver';
 import type { FileTreeNode, WikiLinkInfo, WikiLinkState } from '@cushion/types';
@@ -225,7 +225,7 @@ export const wikiLinkDecorationsField = StateField.define<DecorationSet>({
   },
   update(value, tr) {
     // Also rebuild on focus changes (purrmd pattern: reveal all when unfocused)
-    if (tr.docChanged || tr.selection || tr.effects.some(e => e.is(setFileTreeEffect)) || isFocusEvent(tr)) {
+    if (tr.docChanged || tr.selection || tr.effects.some(e => e.is(setFileTreeEffect) || e.is(mouseSelectEffect)) || isFocusEvent(tr)) {
       return buildWikiLinkDecorations(tr.state);
     }
     return value;

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -211,16 +211,13 @@
   border-left-color: var(--md-text);
 }
 
-/* Selection */
-.cm-editor.cm-markdown-wysiwyg .cm-selectionBackground {
-  background: var(--md-selection-bg) !important;
+.cm-editor.cm-markdown-wysiwyg .cm-selectionLayer {
+  display: none !important;
 }
 
-/* Native ::selection must be transparent — drawSelection() handles all
-   selection rendering via .cm-selectionBackground divs. Styling ::selection
-   causes double-painted highlights and artifacts on hidden (font-size:0) text. */
-.cm-editor.cm-markdown-wysiwyg .cm-line ::selection {
-  background: transparent !important;
+.cm-editor.cm-markdown-wysiwyg .cm-line ::selection,
+.cm-editor.cm-markdown-wysiwyg .cm-line::selection {
+  background: var(--md-selection-bg) !important;
 }
 
 /* Active line - no highlight for cleaner look */


### PR DESCRIPTION
## Summary
- **Atomic ranges**: cursor now skips over hidden markup (heading marks, emphasis marks, link syntax, wiki-link brackets) during navigation and selection
- **Mouse-aware decorations**: decorations no longer collapse/flicker during mouse drag-select — a new `mouseSelectingField` suppresses reveal logic while dragging
- **Native selection rendering**: replaced CodeMirror's `drawSelection()` layer with native `::selection` to eliminate visual artifacts on font-size:0 hidden text

## Test plan
- [ ] Drag-select across bold/italic/heading text — decorations should stay collapsed, selection highlight should be continuous
- [ ] Arrow-key through hidden markup — cursor should skip over syntax characters
- [ ] Click into a wiki-link, image embed, or math block — should still reveal source on cursor placement
- [ ] Verify selection highlight color matches `--md-selection-bg`