### PR TITLE
Redesign chat sidebar with OpenCode-inspired UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Reference implementations (cloned for research)
 inspo/
 docs/
+notes/
 
 # AI tools
 .claude/

--- a/apps/coordinator/src/providers/credential-sync.ts
+++ b/apps/coordinator/src/providers/credential-sync.ts
@@ -99,6 +99,9 @@ export async function syncCredentialsToOpenCode(
   const mergedConfig = {
     ...config,
     provider: providerSection,
+    // Ensure OpenCode asks for permissions so Cushion's auto-accept toggle works.
+    // Only set the default if the user hasn't configured permissions themselves.
+    ...(!config.permission ? { permission: { '*': 'ask' } } : {}),
   };
 
   const fs = await import('fs/promises');

--- a/apps/coordinator/src/providers/credential-sync.ts
+++ b/apps/coordinator/src/providers/credential-sync.ts
@@ -99,9 +99,27 @@ export async function syncCredentialsToOpenCode(
   const mergedConfig = {
     ...config,
     provider: providerSection,
-    // Ensure OpenCode asks for permissions so Cushion's auto-accept toggle works.
+    // Set sensible permission defaults so read-only tools run without prompts
+    // while destructive actions still go through Cushion's auto-accept toggle.
     // Only set the default if the user hasn't configured permissions themselves.
-    ...(!config.permission ? { permission: { '*': 'ask' } } : {}),
+    ...(!config.permission
+      ? {
+          permission: {
+            read: 'allow',
+            glob: 'allow',
+            grep: 'allow',
+            list: 'allow',
+            todoread: 'allow',
+            lsp: 'allow',
+            edit: 'ask',
+            bash: 'ask',
+            task: 'ask',
+            webfetch: 'ask',
+            websearch: 'ask',
+            codesearch: 'ask',
+          },
+        }
+      : {}),
   };
 
   const fs = await import('fs/promises');

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -1,5 +1,6 @@
 /* Markdown Editor Styles - imported first as @import must precede other rules */
 @import '../styles/markdown-editor.css';
+@import '../styles/opencode-chat.css';
 @import '../components/chat/provider-icon.css';
 
 @tailwind base;
@@ -12,7 +13,7 @@
   --color-base-00: #ffffff;
   --color-base-05: #fcfcfc;
   --color-base-10: #fafafa;
-  --color-base-20: #f6f6f6;
+  --color-base-20: #f9f9f9;
   --color-base-25: #e3e3e3;
   --color-base-30: #e0e0e0;
   --color-base-35: #d4d4d4;
@@ -517,6 +518,28 @@ html, body {
   }
 }
 
+/* Content visibility optimization for assistant messages */
+[data-component="text-part"],
+[data-component="reasoning-part"] {
+  content-visibility: auto;
+}
+
+/* Clickable URLs in inline code */
+[data-component="markdown"] a.external-link {
+  color: var(--accent-primary);
+  text-decoration: none;
+}
+
+[data-component="markdown"] a.external-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+[data-component="markdown"] a.external-link > code {
+  color: var(--accent-primary);
+  cursor: pointer;
+}
+
 /* Markdown code block wrapper for copy button */
 [data-component="markdown-code"] {
   position: relative;
@@ -665,10 +688,10 @@ html, body {
   position: relative;
   white-space: pre-wrap;
   word-break: break-word;
-  background: var(--surface);
+  background: var(--surface-elevated);
   border: 1px solid var(--border);
   padding: 8px 12px;
-  border-radius: 4px;
+  border-radius: 6px;
 }
 
 [data-slot="user-message-copy-wrapper"] {
@@ -757,7 +780,6 @@ html, body {
    ======================================== */
 
 [data-component="session-turn"] {
-  --session-title-height: 0px;
   --session-turn-sticky-height: 0px;
   --sticky-header-height: calc(var(--session-title-height, 0px) + var(--session-turn-sticky-height, 0px) + 24px);
   --session-turn-side-padding: 16px;
@@ -807,7 +829,7 @@ html, body {
   position: sticky;
   top: var(--session-title-height, 0px);
   z-index: 20;
-  background-color: var(--surface);
+  background-color: var(--sidebar-bg);
   margin-left: -9px;
   padding-left: 9px;
   display: flex;
@@ -867,7 +889,7 @@ html, body {
   content: "";
   position: absolute;
   inset: 0;
-  background-color: var(--surface);
+  background-color: var(--sidebar-bg);
   z-index: -1;
 }
 
@@ -878,7 +900,7 @@ html, body {
   left: 0;
   right: 0;
   height: 32px;
-  background: linear-gradient(to bottom, var(--surface), transparent);
+  background: linear-gradient(to bottom, var(--sidebar-bg), transparent);
   pointer-events: none;
 }
 
@@ -1048,6 +1070,9 @@ html, body {
   border: none;
   cursor: pointer;
   text-align: left;
+  position: sticky;
+  top: 0;
+  z-index: 5;
 }
 
 [data-slot="tool-file-trigger-content"] {
@@ -1334,6 +1359,124 @@ html, body {
   color: var(--accent-red);
   margin-top: 3px;
   flex-shrink: 0;
+}
+
+/* ── Tool Error Card (collapsible error with copy) ── */
+
+[data-component="tool-error-card"] {
+  width: 100%;
+  background-color: var(--accent-red-12);
+  border: 1px solid color-mix(in srgb, var(--accent-red) 35%, transparent);
+  border-radius: var(--radius-md, 6px);
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 20px;
+  color: color-mix(in srgb, var(--accent-red) 80%, var(--foreground));
+
+  [data-slot="tool-error-card-icon"] [data-component="icon"],
+  [data-slot="tool-error-card-icon"] svg {
+    color: var(--accent-red);
+    flex-shrink: 0;
+  }
+
+  [data-component="collapsible"] {
+    gap: 0px;
+  }
+
+  &[data-open="true"] [data-component="collapsible"] {
+    gap: 4px;
+  }
+
+  [data-slot="tool-error-card-content"] {
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 8px;
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  &[data-open="true"] [data-slot="tool-error-card-content"] {
+    padding-right: 40px;
+  }
+
+  [data-slot="tool-error-card-copy"] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+  }
+
+  &:hover [data-slot="tool-error-card-copy"],
+  &:focus-within [data-slot="tool-error-card-copy"] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  [data-slot="tool-error-card-body"] {
+    max-height: 240px;
+    overflow-y: auto;
+    word-break: break-word;
+    margin: 0;
+  }
+}
+
+/* ── Shell Submessage (animated width + blur) ── */
+
+[data-component="shell-submessage"] {
+  min-width: 0;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: baseline;
+  vertical-align: baseline;
+
+  [data-slot="shell-submessage-width"] {
+    min-width: 0;
+    max-width: 100%;
+    display: inline-flex;
+    align-items: baseline;
+    overflow: hidden;
+  }
+
+  [data-slot="shell-submessage-value"] {
+    display: inline-block;
+    vertical-align: baseline;
+    min-width: 0;
+    line-height: inherit;
+    white-space: nowrap;
+  }
+}
+
+/* ── Compaction / Message Divider ── */
+
+[data-component="compaction-part"] {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+
+  [data-slot="compaction-part-divider"] {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 0;
+    width: 100%;
+  }
+
+  [data-slot="compaction-part-line"] {
+    flex: 1 1 auto;
+    height: 1px;
+    background: var(--border);
+  }
+
+  [data-slot="compaction-part-label"] {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    text-align: center;
+    font-size: 12px;
+    color: var(--muted-foreground);
+  }
 }
 
 [data-slot="session-turn-diff-section"] {
@@ -1878,7 +2021,7 @@ html, body {
 
 /* TodoWrite checklist */
 [data-component="todos"] {
-  padding: 10px 0 24px 8px;
+  padding: 10px 0 24px 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1904,12 +2047,28 @@ html, body {
   flex-shrink: 0;
   border-radius: var(--radius-sm, 4px);
   border: 1px solid var(--border);
+  transition:
+    border-color 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-slot="todo-checkbox-control"] svg {
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    opacity 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 [data-component="todo-checkbox"][data-checked] [data-slot="todo-checkbox-control"] {
   border-color: var(--border);
   background-color: var(--muted);
   color: var(--foreground);
+}
+
+[data-component="todo-checkbox"][data-checked] [data-slot="todo-checkbox-control"] svg {
+  opacity: 1;
+  transform: scale(1);
 }
 
 [data-slot="todo-content"] {
@@ -1919,6 +2078,174 @@ html, body {
 }
 
 [data-slot="todo-content"][data-completed] {
+  text-decoration: line-through;
+  color: var(--foreground-muted);
+}
+
+/* TodoDock — collapsible dock above prompt input */
+[data-component="todo-dock"] {
+  background-color: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: clip;
+  position: relative;
+  z-index: 0;
+}
+
+[data-slot="todo-dock-header"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 8px 10px 12px;
+  cursor: pointer;
+  user-select: none;
+  overflow: visible;
+}
+
+[data-slot="todo-dock-progress"] {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--foreground);
+  white-space: pre;
+  flex-shrink: 0;
+}
+
+[data-slot="todo-dock-preview"] {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  margin-left: 4px;
+}
+
+[data-slot="todo-dock-preview-text"] {
+  font-size: 14px;
+  color: var(--foreground-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+[data-slot="todo-dock-toggle"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm, 4px);
+  border: none;
+  background: transparent;
+  color: var(--foreground-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: auto;
+  transition: background-color 0.15s ease;
+}
+
+[data-slot="todo-dock-toggle"]:hover {
+  background-color: var(--overlay-10, rgba(255, 255, 255, 0.06));
+}
+
+[data-slot="todo-dock-list"] {
+  padding: 0 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 168px;
+  overflow-y: auto;
+}
+
+[data-slot="todo-dock-list"]::-webkit-scrollbar {
+  display: none;
+}
+
+[data-slot="todo-dock-fade-top"] {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 16px;
+  background: linear-gradient(to bottom, var(--background), transparent);
+  transition: opacity 0.15s ease;
+}
+
+/* TodoDock checkbox items */
+[data-component="todo-dock-checkbox"] {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  cursor: default;
+  pointer-events: none;
+  transition: opacity 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-slot="todo-dock-checkbox-control"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 2px;
+  margin-top: 1px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border);
+  transition:
+    border-color 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-slot="todo-dock-checkbox-control"] svg {
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    opacity 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-component="todo-dock-checkbox"][data-checked] [data-slot="todo-dock-checkbox-control"] {
+  border-color: var(--border);
+  background-color: var(--muted);
+  color: var(--foreground);
+}
+
+[data-component="todo-dock-checkbox"][data-checked] [data-slot="todo-dock-checkbox-control"] svg {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Pulsing dot for in-progress */
+[data-component="todo-dock-checkbox"][data-in-progress] [data-slot="todo-dock-checkbox-control"] {
+  border-color: var(--foreground-muted);
+  color: var(--foreground);
+}
+
+[data-slot="todo-dot"] {
+  animation: todo-pulse-scale 1.5s ease-in-out infinite;
+  transform-origin: center;
+}
+
+@keyframes todo-pulse-scale {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(0.7); opacity: 0.5; }
+}
+
+[data-slot="todo-dock-content"] {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--foreground);
+  min-width: 0;
+  word-break: break-word;
+  transition:
+    color 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-slot="todo-dock-content"][data-completed] {
   text-decoration: line-through;
   color: var(--foreground-muted);
 }
@@ -2013,44 +2340,132 @@ html, body {
   content-visibility: auto;
 }
 
-/* Tool shimmer animation for pending/running states */
-@keyframes text-shimmer {
-  0% { opacity: 1; }
-  50% { opacity: 0.4; }
-  100% { opacity: 1; }
+[data-slot="collapsible-content"][data-animated] {
+  overflow: hidden;
 }
 
-.text-shimmer {
-  color: var(--foreground-muted);
-  animation: text-shimmer 1.5s ease-in-out infinite;
+/* TextShimmer — dual-layer gradient sweep */
+[data-component="text-shimmer"] {
+  --text-shimmer-step: 45ms;
+  --text-shimmer-duration: 1200ms;
+  --text-shimmer-swap: 220ms;
+  --text-shimmer-index: 0;
+  --text-shimmer-angle: 90deg;
+  --text-shimmer-spread: 5.2ch;
+  --text-shimmer-size: 360%;
+  --text-shimmer-base-color: var(--muted-foreground);
+  --text-shimmer-peak-color: var(--foreground);
+  --text-shimmer-sweep: linear-gradient(
+    var(--text-shimmer-angle),
+    transparent calc(50% - var(--text-shimmer-spread)),
+    var(--text-shimmer-peak-color) 50%,
+    transparent calc(50% + var(--text-shimmer-spread))
+  );
+  --text-shimmer-base: linear-gradient(var(--text-shimmer-base-color), var(--text-shimmer-base-color));
+
+  display: inline-flex;
+  align-items: baseline;
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
 }
 
-/* Per-character text shimmer (OpenCode-style thinking indicator) */
 [data-component="text-shimmer"] [data-slot="text-shimmer-char"] {
+  display: inline-grid;
   white-space: pre;
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}
+
+[data-component="text-shimmer"] [data-slot="text-shimmer-char-base"],
+[data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
+  grid-area: 1 / 1;
+  white-space: pre;
+  transition: opacity var(--text-shimmer-swap) ease-out;
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}
+
+[data-component="text-shimmer"] [data-slot="text-shimmer-char-base"] {
   color: inherit;
+  opacity: 1;
 }
 
-[data-component="text-shimmer"][data-active="true"] [data-slot="text-shimmer-char"] {
-  animation-name: text-shimmer-char;
-  animation-duration: var(--text-shimmer-duration, 1200ms);
+[data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
+  color: var(--muted-foreground);
+  opacity: 0;
+}
+
+[data-component="text-shimmer"][data-active="true"] [data-slot="text-shimmer-char-shimmer"] {
+  opacity: 1;
+}
+
+[data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"][data-run="true"] {
+  animation-name: text-shimmer-sweep;
+  animation-duration: var(--text-shimmer-duration);
   animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-delay: calc(var(--text-shimmer-step, 45ms) * var(--text-shimmer-index));
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+  animation-delay: calc(var(--text-shimmer-step) * var(--text-shimmer-index) * -1);
+  will-change: background-position;
 }
 
-@keyframes text-shimmer-char {
-  0%, 100% { color: var(--foreground-muted); }
-  30% { color: var(--muted-foreground); }
-  55% { color: var(--foreground); }
-  75% { color: var(--foreground); }
+@keyframes text-shimmer-sweep {
+  0% {
+    background-position: 100% 0, 0 0;
+  }
+  100% {
+    background-position: 0% 0, 0 0;
+  }
+}
+
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    background-image: var(--text-shimmer-sweep), var(--text-shimmer-base);
+    background-size: var(--text-shimmer-size) 100%, 100% 100%;
+    background-position: 100% 0, 0 0;
+    background-repeat: no-repeat;
+    -webkit-background-clip: text;
+    background-clip: text;
+  }
+
+  [data-component="text-shimmer"][data-active="true"] [data-slot="text-shimmer-char-base"] {
+    opacity: 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-component="text-shimmer"] [data-slot="text-shimmer-char"] {
+  [data-component="text-shimmer"] [data-slot="text-shimmer-char-base"],
+  [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
+    transition-duration: 0ms;
+  }
+
+  [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
     animation: none !important;
     color: inherit;
+    -webkit-text-fill-color: currentColor;
+    background-image: none;
   }
+
+  [data-component="text-shimmer"] [data-slot="text-shimmer-char-base"] {
+    opacity: 1 !important;
+  }
+}
+
+/* Legacy shimmer class (used by edit triggers) */
+.text-shimmer {
+  color: var(--foreground-muted);
+  animation: text-shimmer-legacy 1.5s ease-in-out infinite;
+}
+
+@keyframes text-shimmer-legacy {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
 }
 
 /* Thinking indicator */
@@ -2083,6 +2498,81 @@ html, body {
   color: var(--muted-foreground);
   font-size: 12px;
   font-weight: 400;
+}
+
+/* BasicTool trigger layout */
+[data-component="tool-trigger"] {
+  content-visibility: auto;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  gap: 0px;
+  justify-content: space-between;
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-trigger-content"] {
+  width: auto;
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  gap: 8px;
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-info"] {
+  flex: 0 1 auto;
+  min-width: 0;
+  font-size: 14px;
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-info-structured"] {
+  width: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-start;
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-info-main"] {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-title"] {
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--foreground);
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-subtitle"] {
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--foreground-muted);
+}
+
+[data-component="tool-trigger"] [data-slot="basic-tool-tool-arg"] {
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--foreground-muted);
 }
 
 /* Context tool group trigger */
@@ -2174,5 +2664,306 @@ html, body {
     font-weight: 400;
     line-height: 1.5;
     color: var(--muted-foreground);
+  }
+}
+
+/* ── Animated Number (odometer digits) ── */
+
+[data-component="animated-number"] {
+  display: inline-flex;
+  align-items: baseline;
+  vertical-align: baseline;
+  line-height: inherit;
+  font-variant-numeric: tabular-nums;
+
+  [data-slot="animated-number-value"] {
+    display: inline-flex;
+    flex-direction: row-reverse;
+    align-items: baseline;
+    justify-content: flex-end;
+    line-height: inherit;
+    width: var(--animated-number-width, 1ch);
+    overflow: hidden;
+    transition: width 560ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot="animated-number-digit"] {
+    display: inline-block;
+    width: 1ch;
+    height: 1em;
+    line-height: 1em;
+    overflow: hidden;
+    vertical-align: baseline;
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      transparent 0%,
+      #000 18%,
+      #000 82%,
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0%,
+      #000 18%,
+      #000 82%,
+      transparent 100%
+    );
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+  }
+
+  [data-slot="animated-number-strip"] {
+    display: inline-flex;
+    flex-direction: column;
+    transform: translateY(calc(var(--animated-number-offset, 10) * -1em));
+    transition-property: transform;
+    transition-duration: var(--animated-number-duration, 560ms);
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot="animated-number-strip"][data-animating="false"] {
+    transition-duration: 0ms;
+  }
+
+  [data-slot="animated-number-cell"] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1ch;
+    height: 1em;
+    line-height: 1em;
+  }
+}
+
+/* ── Tool Count Label (number + word) ── */
+
+[data-component="tool-count-label"] {
+  display: inline-flex;
+  align-items: baseline;
+  white-space: nowrap;
+  gap: 0;
+
+  [data-slot="tool-count-label-before"] {
+    display: inline-block;
+    white-space: pre;
+    line-height: inherit;
+  }
+
+  [data-slot="tool-count-label-word"] {
+    display: inline-flex;
+    align-items: baseline;
+    white-space: pre;
+    line-height: inherit;
+  }
+
+  [data-slot="tool-count-label-stem"] {
+    display: inline-block;
+    white-space: pre;
+  }
+
+  [data-slot="tool-count-label-suffix"] {
+    display: inline-grid;
+    grid-template-columns: 0fr;
+    opacity: 0;
+    filter: blur(0.84px);
+    overflow: hidden;
+    transform: translateX(-0.04em);
+    transition-property: grid-template-columns, opacity, filter, transform;
+    transition-duration: 250ms;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1), ease-out, ease-out, cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot="tool-count-label-suffix"][data-active="true"] {
+    grid-template-columns: 1fr;
+    opacity: 1;
+    filter: blur(0);
+    transform: translateX(0);
+  }
+
+  [data-slot="tool-count-label-suffix-inner"] {
+    min-width: 0;
+    overflow: hidden;
+    white-space: pre;
+  }
+}
+
+/* ── Tool Count Summary (animated comma list) ── */
+
+[data-component="tool-count-summary"] {
+  display: inline-flex;
+  align-items: baseline;
+  white-space: nowrap;
+
+  [data-slot="tool-count-summary-empty"] {
+    display: inline-grid;
+    grid-template-columns: 1fr;
+    align-items: baseline;
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+    overflow: hidden;
+    transform-origin: left center;
+    transition-property: grid-template-columns, opacity, filter, transform;
+    transition-duration: 480ms, 240ms, 280ms, 480ms;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1), ease-out, ease-out, cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot="tool-count-summary-empty"][data-active="false"] {
+    grid-template-columns: 0fr;
+    opacity: 0;
+    filter: blur(1.44px);
+    transform: translateY(0.05em) scale(0.985);
+  }
+
+  [data-slot="tool-count-summary-item"] {
+    display: inline-grid;
+    grid-template-columns: 0fr;
+    align-items: baseline;
+    opacity: 0;
+    filter: blur(2px);
+    transform: translateY(0.06em) scale(0.985);
+    overflow: hidden;
+    transform-origin: left center;
+    transition-property: grid-template-columns, opacity, filter, transform;
+    transition-duration: 480ms, 280ms, 320ms, 480ms;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1), ease-out, ease-out, cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot="tool-count-summary-item"][data-active="true"] {
+    grid-template-columns: 1fr;
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+  }
+
+  [data-slot="tool-count-summary-empty-inner"] {
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  [data-slot="tool-count-summary-item-inner"] {
+    display: inline-flex;
+    align-items: baseline;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  [data-slot="tool-count-summary-prefix"] {
+    display: inline-flex;
+    align-items: baseline;
+    justify-content: flex-start;
+    max-width: 0;
+    margin-right: 0;
+    opacity: 0;
+    filter: blur(1.1px);
+    overflow: hidden;
+    transform: translateX(-0.08em);
+    transition-property: opacity, filter, transform;
+    transition-duration: 150ms, 165ms, 132ms;
+    transition-timing-function: ease-out;
+  }
+
+  [data-slot="tool-count-summary-prefix"][data-active="true"] {
+    max-width: 1ch;
+    margin-right: 0.45ch;
+    opacity: 1;
+    filter: blur(0);
+    transform: translateX(0);
+  }
+}
+
+/* ── Tool Status Title (active/done crossfade) ── */
+
+[data-component="tool-status-title"] {
+  display: inline-flex;
+  align-items: baseline;
+  white-space: nowrap;
+  text-align: start;
+
+  [data-slot="tool-status-suffix"] {
+    display: inline-flex;
+    align-items: baseline;
+    white-space: nowrap;
+  }
+
+  [data-slot="tool-status-prefix"] {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  [data-slot="tool-status-swap"],
+  [data-slot="tool-status-tail"] {
+    display: inline-grid;
+    overflow: hidden;
+    justify-items: start;
+    transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot="tool-status-active"],
+  [data-slot="tool-status-done"] {
+    grid-area: 1 / 1;
+    white-space: nowrap;
+    justify-self: start;
+    text-align: start;
+    transition-property: opacity, filter, transform;
+    transition-duration: 240ms, 192ms, 192ms;
+    transition-timing-function: ease-out;
+  }
+
+  &[data-ready="false"] {
+    [data-slot="tool-status-swap"],
+    [data-slot="tool-status-tail"] {
+      transition-duration: 0ms;
+    }
+
+    [data-slot="tool-status-active"],
+    [data-slot="tool-status-done"] {
+      transition-duration: 0ms;
+    }
+  }
+
+  [data-slot="tool-status-active"] {
+    opacity: 0;
+    filter: blur(0.9px);
+    transform: translateY(0.03em);
+  }
+
+  [data-slot="tool-status-done"] {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+
+  &[data-active="true"] {
+    [data-slot="tool-status-active"] {
+      opacity: 1;
+      filter: blur(0);
+      transform: translateY(0);
+    }
+
+    [data-slot="tool-status-done"] {
+      opacity: 0;
+      filter: blur(0.9px);
+      transform: translateY(0.03em);
+    }
+  }
+}
+
+/* ── Reduced motion ── */
+
+@media (prefers-reduced-motion: reduce) {
+  [data-component="animated-number"] [data-slot="animated-number-value"],
+  [data-component="animated-number"] [data-slot="animated-number-strip"],
+  [data-component="tool-count-label"] [data-slot="tool-count-label-suffix"],
+  [data-component="tool-count-summary"] [data-slot="tool-count-summary-empty"],
+  [data-component="tool-count-summary"] [data-slot="tool-count-summary-item"],
+  [data-component="tool-count-summary"] [data-slot="tool-count-summary-prefix"],
+  [data-component="tool-status-title"] [data-slot="tool-status-swap"],
+  [data-component="tool-status-title"] [data-slot="tool-status-tail"],
+  [data-component="tool-status-title"] [data-slot="tool-status-active"],
+  [data-component="tool-status-title"] [data-slot="tool-status-done"] {
+    transition-duration: 0ms;
   }
 }

--- a/apps/frontend/components/chat/AnimatedCountLabel.tsx
+++ b/apps/frontend/components/chat/AnimatedCountLabel.tsx
@@ -1,0 +1,65 @@
+
+import { memo, useMemo } from 'react';
+import { AnimatedNumber } from './AnimatedNumber';
+
+function split(text: string) {
+  const match = /{{\s*count\s*}}/.exec(text);
+  if (!match || match.index === undefined) return { before: '', after: text };
+  return {
+    before: text.slice(0, match.index),
+    after: text.slice(match.index + match[0].length),
+  };
+}
+
+function common(one: string, other: string) {
+  const a = Array.from(one);
+  const b = Array.from(other);
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return {
+    stem: a.slice(0, i).join(''),
+    one: a.slice(i).join(''),
+    other: b.slice(i).join(''),
+  };
+}
+
+export const AnimatedCountLabel = memo(function AnimatedCountLabel({
+  count,
+  one: oneTemplate,
+  other: otherTemplate,
+  className,
+}: {
+  count: number;
+  one: string;
+  other: string;
+  className?: string;
+}) {
+  const one = useMemo(() => split(oneTemplate), [oneTemplate]);
+  const other = useMemo(() => split(otherTemplate), [otherTemplate]);
+  const singular = Math.round(count) === 1;
+  const active = singular ? one : other;
+  const suffix = useMemo(() => common(one.after, other.after), [one.after, other.after]);
+  const splitSuffix = useMemo(
+    () =>
+      one.before === other.before &&
+      (one.after.startsWith(other.after) || other.after.startsWith(one.after)),
+    [one, other],
+  );
+  const before = splitSuffix ? one.before : active.before;
+  const stem = splitSuffix ? suffix.stem : active.after;
+  const tail = splitSuffix ? (singular ? suffix.one : suffix.other) : '';
+  const showTail = splitSuffix && tail.length > 0;
+
+  return (
+    <span data-component="tool-count-label" className={className}>
+      <span data-slot="tool-count-label-before">{before}</span>
+      <AnimatedNumber value={count} />
+      <span data-slot="tool-count-label-word">
+        <span data-slot="tool-count-label-stem">{stem}</span>
+        <span data-slot="tool-count-label-suffix" data-active={showTail ? 'true' : 'false'}>
+          <span data-slot="tool-count-label-suffix-inner">{tail}</span>
+        </span>
+      </span>
+    </span>
+  );
+});

--- a/apps/frontend/components/chat/AnimatedCountList.tsx
+++ b/apps/frontend/components/chat/AnimatedCountList.tsx
@@ -1,0 +1,55 @@
+
+import { memo } from 'react';
+import { AnimatedCountLabel } from './AnimatedCountLabel';
+
+export type CountItem = {
+  key: string;
+  count: number;
+  one: string;
+  other: string;
+};
+
+export const AnimatedCountList = memo(function AnimatedCountList({
+  items,
+  fallback = '',
+  className,
+}: {
+  items: CountItem[];
+  fallback?: string;
+  className?: string;
+}) {
+  const showEmpty = items.every((item) => item.count <= 0) && fallback.length > 0;
+
+  return (
+    <span data-component="tool-count-summary" className={className}>
+      <span data-slot="tool-count-summary-empty" data-active={showEmpty ? 'true' : 'false'}>
+        <span data-slot="tool-count-summary-empty-inner">{fallback}</span>
+      </span>
+
+      {items.map((item, index) => {
+        const active = item.count > 0;
+        let hasPrev = false;
+        for (let i = index - 1; i >= 0; i--) {
+          if (items[i].count > 0) { hasPrev = true; break; }
+        }
+
+        return (
+          <span key={item.key}>
+            <span data-slot="tool-count-summary-prefix" data-active={active && hasPrev ? 'true' : 'false'}>
+              ,
+            </span>
+            <span data-slot="tool-count-summary-item" data-active={active ? 'true' : 'false'}>
+              <span data-slot="tool-count-summary-item-inner">
+                <AnimatedCountLabel
+                  one={item.one}
+                  other={item.other}
+                  count={Math.max(0, Math.round(item.count))}
+                />
+              </span>
+            </span>
+          </span>
+        );
+      })}
+    </span>
+  );
+});

--- a/apps/frontend/components/chat/AnimatedNumber.tsx
+++ b/apps/frontend/components/chat/AnimatedNumber.tsx
@@ -1,0 +1,95 @@
+
+import { memo, useEffect, useRef, useState } from 'react';
+
+const TRACK = Array.from({ length: 30 }, (_, i) => i % 10);
+const DURATION = 600;
+
+function normalize(value: number) {
+  return ((value % 10) + 10) % 10;
+}
+
+function spin(from: number, to: number, direction: 1 | -1) {
+  if (from === to) return 0;
+  if (direction > 0) return (to - from + 10) % 10;
+  return -((from - to + 10) % 10);
+}
+
+function Digit({ value, direction }: { value: number; direction: 1 | -1 }) {
+  const [step, setStep] = useState(value + 10);
+  const [animating, setAnimating] = useState(false);
+  const lastRef = useRef(value);
+
+  useEffect(() => {
+    const delta = spin(lastRef.current, value, direction);
+    lastRef.current = value;
+    if (!delta) {
+      setAnimating(false);
+      setStep(value + 10);
+      return;
+    }
+    setAnimating(true);
+    setStep((prev) => prev + delta);
+  }, [value, direction]);
+
+  return (
+    <span data-slot="animated-number-digit">
+      <span
+        data-slot="animated-number-strip"
+        data-animating={animating ? 'true' : 'false'}
+        onTransitionEnd={() => {
+          setAnimating(false);
+          setStep(normalize(step) + 10);
+        }}
+        style={
+          {
+            '--animated-number-offset': `${step}`,
+            '--animated-number-duration': `var(--tool-motion-odometer-ms, ${DURATION}ms)`,
+          } as React.CSSProperties
+        }
+      >
+        {TRACK.map((v, i) => (
+          <span key={i} data-slot="animated-number-cell">
+            {v}
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}
+
+export const AnimatedNumber = memo(function AnimatedNumber({
+  value,
+  className,
+}: {
+  value: number;
+  className?: string;
+}) {
+  const target = Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
+
+  const [current, setCurrent] = useState(target);
+  const [direction, setDirection] = useState<1 | -1>(1);
+
+  useEffect(() => {
+    if (target === current) return;
+    setDirection(target > current ? 1 : -1);
+    setCurrent(target);
+  }, [target]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const label = current.toString();
+  const digits = Array.from(label, (char) => {
+    const code = char.charCodeAt(0) - 48;
+    return code >= 0 && code <= 9 ? code : 0;
+  }).reverse();
+
+  const width = `${digits.length}ch`;
+
+  return (
+    <span data-component="animated-number" className={className} aria-label={label}>
+      <span data-slot="animated-number-value" style={{ '--animated-number-width': width } as React.CSSProperties}>
+        {digits.map((digit, i) => (
+          <Digit key={i} value={digit} direction={direction} />
+        ))}
+      </span>
+    </span>
+  );
+});

--- a/apps/frontend/components/chat/BasicTool.tsx
+++ b/apps/frontend/components/chat/BasicTool.tsx
@@ -1,0 +1,182 @@
+
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
+import { animate, type AnimationPlaybackControls } from 'motion';
+import { Collapsible } from './Collapsible';
+import { Icon, type IconName } from './Icon';
+import { TextShimmer } from './TextShimmer';
+import { prefersReducedMotion } from './message-helpers';
+
+export type TriggerTitle = {
+  title: string;
+  subtitle?: string;
+  args?: string[];
+  action?: ReactNode;
+};
+
+export function isTriggerTitle(val: unknown): val is TriggerTitle {
+  return (
+    typeof val === 'object' &&
+    val !== null &&
+    'title' in val &&
+    typeof (val as TriggerTitle).title === 'string'
+  );
+}
+
+export interface BasicToolProps {
+  icon: IconName;
+  trigger: TriggerTitle | ReactNode;
+  children?: ReactNode;
+  status?: string;
+  hideDetails?: boolean;
+  defaultOpen?: boolean;
+  forceOpen?: boolean;
+  defer?: boolean;
+  locked?: boolean;
+  animated?: boolean;
+  className?: string;
+}
+
+const SPRING = { type: 'spring' as const, visualDuration: 0.35, bounce: 0 };
+
+export const BasicTool = memo(function BasicTool({
+  icon,
+  trigger,
+  children,
+  status,
+  hideDetails,
+  defaultOpen = false,
+  forceOpen,
+  defer,
+  locked,
+  animated = true,
+  className,
+}: BasicToolProps) {
+  const pending = status === 'pending' || status === 'running';
+  const [open, setOpen] = useState(defaultOpen);
+  const [ready, setReady] = useState(!defer || defaultOpen);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const heightAnim = useRef<AnimationPlaybackControls | null>(null);
+  const initialOpen = useRef(defaultOpen);
+  const isFirstRender = useRef(true);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (forceOpen) setOpen(true);
+  }, [forceOpen]);
+
+  useEffect(() => {
+    setOpen(defaultOpen);
+  }, [defaultOpen]);
+
+  useEffect(() => {
+    if (!defer) return;
+    if (open) {
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        setReady(true);
+      });
+    } else {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+      setReady(false);
+    }
+    return () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    };
+  }, [open, defer]);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (!animated) return;
+    const el = contentRef.current;
+    if (!el) return;
+
+    if (prefersReducedMotion()) {
+      el.style.height = open ? 'auto' : '0px';
+      el.style.overflow = open ? 'visible' : 'hidden';
+      return;
+    }
+
+    heightAnim.current?.stop();
+    if (open) {
+      el.style.overflow = 'hidden';
+      heightAnim.current = animate(el, { height: 'auto' }, SPRING);
+      heightAnim.current.finished.then(() => {
+        if (!contentRef.current) return;
+        contentRef.current.style.overflow = 'visible';
+        contentRef.current.style.height = 'auto';
+      });
+    } else {
+      el.style.overflow = 'hidden';
+      heightAnim.current = animate(el, { height: '0px' }, SPRING);
+    }
+    return () => { heightAnim.current?.stop(); };
+  }, [open, animated]);
+
+  const handleOpenChange = (value: boolean) => {
+    if (pending) return;
+    if (locked && !value) return;
+    setOpen(value);
+  };
+
+  const hasDetails = !!children && !hideDetails;
+  const showArrow = hasDetails && !locked && !pending;
+
+  return (
+    <Collapsible open={open} onOpenChange={handleOpenChange}>
+      <Collapsible.Trigger>
+        <div data-component="tool-trigger" className={className}>
+          <div data-slot="basic-tool-tool-trigger-content">
+            {isTriggerTitle(trigger) ? (
+              <>
+                <Icon name={icon} size="small" />
+                <div data-slot="basic-tool-tool-info">
+                  <div data-slot="basic-tool-tool-info-structured">
+                    <div data-slot="basic-tool-tool-info-main">
+                      <span data-slot="basic-tool-tool-title">
+                        <TextShimmer text={trigger.title} active={pending} />
+                      </span>
+                      {!pending && trigger.subtitle && (
+                        <span data-slot="basic-tool-tool-subtitle">{trigger.subtitle}</span>
+                      )}
+                      {!pending && trigger.args?.map((arg, i) => (
+                        <span key={i} data-slot="basic-tool-tool-arg">{arg}</span>
+                      ))}
+                    </div>
+                    {!pending && trigger.action}
+                  </div>
+                </div>
+              </>
+            ) : (
+              trigger
+            )}
+          </div>
+          {showArrow && <Collapsible.Arrow />}
+        </div>
+      </Collapsible.Trigger>
+
+      {animated && hasDetails && (
+        <div
+          ref={contentRef}
+          data-slot="collapsible-content"
+          data-animated
+          style={{
+            height: initialOpen.current ? 'auto' : '0px',
+            overflow: initialOpen.current ? 'visible' : 'hidden',
+          }}
+        >
+          {(!defer || ready) && children}
+        </div>
+      )}
+      {!animated && hasDetails && (
+        <Collapsible.Content>
+          {(!defer || ready) && children}
+        </Collapsible.Content>
+      )}
+    </Collapsible>
+  );
+});

--- a/apps/frontend/components/chat/BasicTool.tsx
+++ b/apps/frontend/components/chat/BasicTool.tsx
@@ -13,7 +13,7 @@ export type TriggerTitle = {
   action?: ReactNode;
 };
 
-export function isTriggerTitle(val: unknown): val is TriggerTitle {
+function isTriggerTitle(val: unknown): val is TriggerTitle {
   return (
     typeof val === 'object' &&
     val !== null &&

--- a/apps/frontend/components/chat/ChatSidebar.tsx
+++ b/apps/frontend/components/chat/ChatSidebar.tsx
@@ -1,11 +1,12 @@
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useChatStore, type PromptInputPayload } from '@/stores/chatStore';
 import { MessageList } from './MessageList';
 import { PromptInput } from './PromptInput';
+import { TodoDock } from './TodoDock';
+import { QuestionDock } from './QuestionDock';
 import { useToast } from './Toast';
-import type { PermissionRequest, QuestionRequest } from '@opencode-ai/sdk/v2/client';
-import { cn } from '@/lib/utils';
+import type { PermissionRequest } from '@opencode-ai/sdk/v2/client';
 
 export function ChatSidebar() {
   const connection = useChatStore((state) => state.connection);
@@ -18,15 +19,52 @@ export function ChatSidebar() {
   const respondToPermission = useChatStore((state) => state.respondToPermission);
   const replyToQuestion = useChatStore((state) => state.replyToQuestion);
   const rejectQuestion = useChatStore((state) => state.rejectQuestion);
+  const autoAccept = useChatStore((state) => state.autoAccept);
+  const todos = useChatStore((state) => state.todos);
+  const sessionStatus = useChatStore((state) => state.sessionStatus);
   const isConnected = connection.status === 'connected' || connection.status === 'reconnecting';
   const pendingPermissions = activeSessionId ? permissions[activeSessionId] ?? [] : [];
   const pendingQuestions = activeSessionId ? questions[activeSessionId] ?? [] : [];
   const promptDockRef = useRef<HTMLDivElement | null>(null);
   const [promptDockHeight, setPromptDockHeight] = useState(0);
+  const [showDock, setShowDock] = useState(false);
+  const closeTimer = useRef<number | undefined>(undefined);
   const { showToast } = useToast();
 
   const sessionError = activeSessionId ? sessionErrors[activeSessionId] : undefined;
   const hasProviderAuthError = Object.keys(providerAuthErrors).length > 0;
+
+  const sessionTodos = activeSessionId ? todos[activeSessionId] ?? [] : [];
+  const status = activeSessionId ? sessionStatus[activeSessionId] : undefined;
+  const isBusy = status?.type === 'busy' || status?.type === 'retry';
+  const allDone = sessionTodos.length > 0 && sessionTodos.every((t) => t.status === 'completed' || t.status === 'cancelled');
+
+  useEffect(() => {
+    if (closeTimer.current) window.clearTimeout(closeTimer.current);
+    closeTimer.current = undefined;
+
+    if (sessionTodos.length === 0) {
+      setShowDock(false);
+      return;
+    }
+    if (!isBusy && !allDone) {
+      // Session ended but todos not complete — clear after brief delay
+      setShowDock(false);
+      return;
+    }
+    if (allDone) {
+      // All done — close after 400ms
+      closeTimer.current = window.setTimeout(() => setShowDock(false), 400);
+      return;
+    }
+    setShowDock(true);
+  }, [sessionTodos, isBusy, allDone]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current) window.clearTimeout(closeTimer.current);
+    };
+  }, []);
 
   const handleSubmit = useCallback((value: PromptInputPayload) => {
     sendPrompt(value).catch((error) => {
@@ -50,35 +88,38 @@ export function ChatSidebar() {
   return (
     <div
       className="h-full flex flex-col relative"
+      data-chat-theme="opencode"
       style={{ '--prompt-dock-height': `${promptDockHeight}px` } as React.CSSProperties}
     >
       <MessageList className="flex-1 min-h-0" />
 
       <div className="absolute inset-x-0 bottom-0 pt-10 pb-4 flex flex-col items-center z-30 px-4 bg-gradient-to-t from-sidebar-bg via-sidebar-bg to-transparent pointer-events-none chat-dock">
         <div ref={promptDockRef} className="w-full flex flex-col gap-3 pointer-events-auto">
+          {showDock && sessionTodos.length > 0 && (
+            <TodoDock todos={sessionTodos} />
+          )}
           {sessionError && (
             <SessionErrorBanner
               message={sessionError}
               isAuthError={hasProviderAuthError}
             />
           )}
-          {(pendingPermissions.length > 0 || pendingQuestions.length > 0) && (
+          {!autoAccept && pendingPermissions.length > 0 && (
             <div className="chat-dock-panel rounded-md border border-border bg-background/90 px-3 py-3 space-y-3">
-              {pendingPermissions.length > 0 && (
-                <PermissionPanel
-                  requests={pendingPermissions}
-                  onRespond={(input) => respondToPermission(input).catch(() => undefined)}
-                />
-              )}
-              {pendingQuestions.length > 0 && (
-                <QuestionPanel
-                  requests={pendingQuestions}
-                  onReply={(input) => replyToQuestion(input).catch(() => undefined)}
-                  onReject={(input) => rejectQuestion(input).catch(() => undefined)}
-                />
-              )}
+              <PermissionPanel
+                requests={pendingPermissions}
+                onRespond={(input) => respondToPermission(input).catch(() => undefined)}
+              />
             </div>
           )}
+          {pendingQuestions.map((request) => (
+            <QuestionDock
+              key={request.id}
+              request={request}
+              onReply={(input) => replyToQuestion(input).catch(() => undefined)}
+              onReject={(input) => rejectQuestion(input).catch(() => undefined)}
+            />
+          ))}
 
           <PromptInput
             className="flex flex-col"
@@ -132,148 +173,6 @@ function PermissionPanel({ requests, onRespond }: PermissionPanelProps) {
           </div>
         </div>
       ))}
-    </div>
-  );
-}
-
-type QuestionPanelProps = {
-  requests: QuestionRequest[];
-  onReply: (input: { requestID: string; answers: string[][] }) => void;
-  onReject: (input: { requestID: string }) => void;
-};
-
-function QuestionPanel({ requests, onReply, onReject }: QuestionPanelProps) {
-  return (
-    <div className="space-y-3">
-      {requests.map((request) => (
-        <QuestionCard key={request.id} request={request} onReply={onReply} onReject={onReject} />
-      ))}
-    </div>
-  );
-}
-
-type QuestionCardProps = {
-  request: QuestionRequest;
-  onReply: (input: { requestID: string; answers: string[][] }) => void;
-  onReject: (input: { requestID: string }) => void;
-};
-
-function QuestionCard({ request, onReply, onReject }: QuestionCardProps) {
-  const [answers, setAnswers] = useState<string[][]>(() => request.questions.map(() => []));
-  const [customInputs, setCustomInputs] = useState<string[]>(() => request.questions.map(() => ''));
-  const canSubmit = useMemo(
-    () => request.questions.every((_, index) => (answers[index]?.length ?? 0) > 0),
-    [answers, request.questions]
-  );
-
-  const updateAnswer = (index: number, label: string, multiple: boolean) => {
-    setAnswers((prev) => {
-      const next = prev.map((entry) => entry.slice());
-      const current = next[index] ?? [];
-      if (multiple) {
-        const exists = current.includes(label);
-        next[index] = exists ? current.filter((item) => item !== label) : [...current, label];
-        return next;
-      }
-      next[index] = [label];
-      return next;
-    });
-  };
-
-  const addCustom = (index: number, multiple: boolean) => {
-    const value = customInputs[index]?.trim();
-    if (!value) return;
-    setAnswers((prev) => {
-      const next = prev.map((entry) => entry.slice());
-      const current = next[index] ?? [];
-      if (multiple) {
-        if (!current.includes(value)) next[index] = [...current, value];
-      } else {
-        next[index] = [value];
-      }
-      return next;
-    });
-    setCustomInputs((prev) => {
-      const next = prev.slice();
-      next[index] = '';
-      return next;
-    });
-  };
-
-  return (
-    <div className="rounded-md border border-border bg-muted/10 p-2 text-xs">
-      {request.questions.map((question, index) => {
-        const selected = answers[index] ?? [];
-        const multiple = question.multiple === true;
-        const allowCustom = question.custom !== false;
-        return (
-          <div key={`${request.id}-${question.header}`} className="space-y-2">
-            <div className="text-[11px] uppercase text-muted-foreground">{question.header}</div>
-            <div className="text-foreground">{question.question}</div>
-            {multiple && (
-              <div className="text-[11px] text-muted-foreground">Select all that apply</div>
-            )}
-            <div className="flex flex-wrap gap-2">
-              {question.options.map((opt) => {
-                const active = selected.includes(opt.label);
-                return (
-                  <button
-                    key={opt.label}
-                    type="button"
-                    onClick={() => updateAnswer(index, opt.label, multiple)}
-                    className={cn(
-                      "rounded-md border px-2 py-1 text-xs",
-                      active
-                        ? "border-[var(--md-accent)] text-foreground"
-                        : "border-border text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-10)]"
-                    )}
-                  >
-                    {opt.label}
-                  </button>
-                );
-              })}
-            </div>
-            {allowCustom && (
-              <div className="flex items-center gap-2">
-                <input
-                  value={customInputs[index] ?? ''}
-                  onChange={(event) => {
-                    const next = customInputs.slice();
-                    next[index] = event.target.value;
-                    setCustomInputs(next);
-                  }}
-                  placeholder="Type your own answer"
-                  className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-xs"
-                />
-                <button
-                  type="button"
-                  onClick={() => addCustom(index, multiple)}
-                  className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-10)] transition-colors"
-                >
-                  {multiple ? 'Add' : 'Set'}
-                </button>
-              </div>
-            )}
-          </div>
-        );
-      })}
-      <div className="mt-3 flex items-center gap-2">
-        <button
-          type="button"
-          onClick={() => onReject({ requestID: request.id })}
-          className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-10)] transition-colors"
-        >
-          Dismiss
-        </button>
-        <button
-          type="button"
-          onClick={() => onReply({ requestID: request.id, answers })}
-          disabled={!canSubmit}
-          className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-10)] disabled:opacity-50 transition-colors"
-        >
-          Submit
-        </button>
-      </div>
     </div>
   );
 }

--- a/apps/frontend/components/chat/Collapsible.tsx
+++ b/apps/frontend/components/chat/Collapsible.tsx
@@ -1,7 +1,5 @@
 
-import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
-import { animate, type AnimationPlaybackControls } from 'motion';
-import { prefersReducedMotion } from './message-helpers';
+import { createContext, useContext, useState, type ReactNode } from 'react';
 
 interface CollapsibleContextValue {
   open: boolean;
@@ -97,101 +95,6 @@ function CollapsibleContent({ children, className }: CollapsibleContentProps) {
   );
 }
 
-const SPRING = { type: 'spring' as const, visualDuration: 0.35, bounce: 0 };
-
-interface AnimatedCollapsibleContentProps {
-  children: ReactNode;
-  className?: string;
-  defer?: boolean;
-}
-
-function AnimatedCollapsibleContent({
-  children,
-  className,
-  defer,
-}: AnimatedCollapsibleContentProps) {
-  const { open } = useCollapsible();
-  const contentRef = useRef<HTMLDivElement>(null);
-  const heightAnim = useRef<AnimationPlaybackControls | null>(null);
-  const initialOpen = useRef(open);
-  const isFirstRender = useRef(true);
-  const [ready, setReady] = useState(!defer || open);
-  const frameRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!defer) return;
-
-    if (open) {
-      frameRef.current = requestAnimationFrame(() => {
-        frameRef.current = null;
-        setReady(true);
-      });
-    } else {
-      if (frameRef.current !== null) {
-        cancelAnimationFrame(frameRef.current);
-        frameRef.current = null;
-      }
-      setReady(false);
-    }
-
-    return () => {
-      if (frameRef.current !== null) {
-        cancelAnimationFrame(frameRef.current);
-      }
-    };
-  }, [open, defer]);
-
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-
-    const el = contentRef.current;
-    if (!el) return;
-
-    if (prefersReducedMotion()) {
-      el.style.height = open ? 'auto' : '0px';
-      el.style.overflow = open ? 'visible' : 'hidden';
-      return;
-    }
-
-    heightAnim.current?.stop();
-
-    if (open) {
-      el.style.overflow = 'hidden';
-      heightAnim.current = animate(el, { height: 'auto' }, SPRING);
-      heightAnim.current.finished.then(() => {
-        if (!contentRef.current) return;
-        contentRef.current.style.overflow = 'visible';
-        contentRef.current.style.height = 'auto';
-      });
-    } else {
-      el.style.overflow = 'hidden';
-      heightAnim.current = animate(el, { height: '0px' }, SPRING);
-    }
-
-    return () => {
-      heightAnim.current?.stop();
-    };
-  }, [open]);
-
-  return (
-    <div
-      ref={contentRef}
-      data-slot="collapsible-content"
-      data-animated
-      className={className}
-      style={{
-        height: initialOpen.current ? 'auto' : '0px',
-        overflow: initialOpen.current ? 'visible' : 'hidden',
-      }}
-    >
-      {(!defer || ready) && children}
-    </div>
-  );
-}
-
 interface CollapsibleArrowProps {
   className?: string;
 }
@@ -222,6 +125,5 @@ function CollapsibleArrow({ className }: CollapsibleArrowProps) {
 export const Collapsible = Object.assign(CollapsibleRoot, {
   Trigger: CollapsibleTrigger,
   Content: CollapsibleContent,
-  AnimatedContent: AnimatedCollapsibleContent,
   Arrow: CollapsibleArrow,
 });

--- a/apps/frontend/components/chat/Collapsible.tsx
+++ b/apps/frontend/components/chat/Collapsible.tsx
@@ -1,6 +1,7 @@
 
-import { createContext, useContext, useState, type ReactNode } from 'react';
-import { cn } from '@/lib/utils';
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { animate, type AnimationPlaybackControls } from 'motion';
+import { prefersReducedMotion } from './message-helpers';
 
 interface CollapsibleContextValue {
   open: boolean;
@@ -96,35 +97,124 @@ function CollapsibleContent({ children, className }: CollapsibleContentProps) {
   );
 }
 
+const SPRING = { type: 'spring' as const, visualDuration: 0.35, bounce: 0 };
+
+interface AnimatedCollapsibleContentProps {
+  children: ReactNode;
+  className?: string;
+  defer?: boolean;
+}
+
+function AnimatedCollapsibleContent({
+  children,
+  className,
+  defer,
+}: AnimatedCollapsibleContentProps) {
+  const { open } = useCollapsible();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const heightAnim = useRef<AnimationPlaybackControls | null>(null);
+  const initialOpen = useRef(open);
+  const isFirstRender = useRef(true);
+  const [ready, setReady] = useState(!defer || open);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!defer) return;
+
+    if (open) {
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        setReady(true);
+      });
+    } else {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      setReady(false);
+    }
+
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+      }
+    };
+  }, [open, defer]);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    const el = contentRef.current;
+    if (!el) return;
+
+    if (prefersReducedMotion()) {
+      el.style.height = open ? 'auto' : '0px';
+      el.style.overflow = open ? 'visible' : 'hidden';
+      return;
+    }
+
+    heightAnim.current?.stop();
+
+    if (open) {
+      el.style.overflow = 'hidden';
+      heightAnim.current = animate(el, { height: 'auto' }, SPRING);
+      heightAnim.current.finished.then(() => {
+        if (!contentRef.current) return;
+        contentRef.current.style.overflow = 'visible';
+        contentRef.current.style.height = 'auto';
+      });
+    } else {
+      el.style.overflow = 'hidden';
+      heightAnim.current = animate(el, { height: '0px' }, SPRING);
+    }
+
+    return () => {
+      heightAnim.current?.stop();
+    };
+  }, [open]);
+
+  return (
+    <div
+      ref={contentRef}
+      data-slot="collapsible-content"
+      data-animated
+      className={className}
+      style={{
+        height: initialOpen.current ? 'auto' : '0px',
+        overflow: initialOpen.current ? 'visible' : 'hidden',
+      }}
+    >
+      {(!defer || ready) && children}
+    </div>
+  );
+}
+
 interface CollapsibleArrowProps {
   className?: string;
 }
 
 function CollapsibleArrow({ className }: CollapsibleArrowProps) {
-  const { open } = useCollapsible();
-
   return (
     <div data-slot="collapsible-arrow" className={className}>
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 10 10"
-        fill="none"
-        className={cn("transition-transform", open && "rotate-180")}
-      >
-        <path
-          d="M6.66675 7.49984L10.0001 4.1665L13.3334 7.49984M6.66675 12.4998L10.0001 15.8332L13.3334 12.4998"
-          transform={open ? 'translate(0, -5)' : 'translate(0, -5)'}
-          stroke="currentColor"
-          strokeLinecap="square"
-        />
-        <path
-          d="M6.66675 2.49984L10.0001 5.83317L13.3334 2.49984M6.66675 7.49984L10.0001 10.8332L13.3334 7.49984"
-          transform="translate(0, -2)"
-          stroke="currentColor"
-          strokeLinecap="square"
-        />
-      </svg>
+      <div data-slot="collapsible-arrow-icon">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+        >
+          <path
+            d="M2.5 3.5L5 6.5L7.5 3.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
     </div>
   );
 }
@@ -132,5 +222,6 @@ function CollapsibleArrow({ className }: CollapsibleArrowProps) {
 export const Collapsible = Object.assign(CollapsibleRoot, {
   Trigger: CollapsibleTrigger,
   Content: CollapsibleContent,
+  AnimatedContent: AnimatedCollapsibleContent,
   Arrow: CollapsibleArrow,
 });

--- a/apps/frontend/components/chat/DiffView.tsx
+++ b/apps/frontend/components/chat/DiffView.tsx
@@ -414,7 +414,6 @@ export function DiffSummary({ diffs }: DiffSummaryProps) {
     setLimit(diffInit);
   }, [diffs]);
 
-  // Reset expanded files when collapsible closes
   const handleSectionToggle = () => {
     setSectionOpen((prev) => {
       if (prev) {
@@ -435,7 +434,6 @@ export function DiffSummary({ diffs }: DiffSummaryProps) {
       } else {
         next.add(file);
         setFirstOpen((p) => new Set(p).add(file));
-        // Lazy render via rAF
         requestAnimationFrame(() => {
           setVisibleFiles((v) => new Set(v).add(file));
         });
@@ -500,7 +498,7 @@ export function DiffSummary({ diffs }: DiffSummaryProps) {
                           <FileIcon className="size-4 text-muted-foreground" />
                           <div data-slot="session-turn-file-path">
                             {directory && (
-                              <span data-slot="session-turn-directory">{directory}/</span>
+                              <span data-slot="session-turn-directory">{'\u202A' + directory + '/' + '\u202C'}</span>
                             )}
                             <span data-slot="session-turn-filename">{filename}</span>
                           </div>

--- a/apps/frontend/components/chat/DisplayOptionsPopover.tsx
+++ b/apps/frontend/components/chat/DisplayOptionsPopover.tsx
@@ -28,14 +28,14 @@ function ToggleRow({
       </div>
       <div
         className={cn(
-          'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors',
-          checked ? 'bg-accent-blue' : 'bg-[var(--overlay-20)]'
+          'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors',
+          checked ? 'bg-[var(--accent-primary)]' : 'bg-[var(--border-subtle)]'
         )}
       >
         <span
           className={cn(
-            'inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform',
-            checked ? 'translate-x-[18px]' : 'translate-x-[3px]'
+            'inline-block size-4 rounded-full bg-background shadow transition-transform',
+            checked ? 'translate-x-4' : 'translate-x-0.5'
           )}
         />
       </div>

--- a/apps/frontend/components/chat/ManageModelsDialog.tsx
+++ b/apps/frontend/components/chat/ManageModelsDialog.tsx
@@ -1,7 +1,7 @@
 
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { RefreshCw, X } from 'lucide-react';
+import { RefreshCw, Search, X } from 'lucide-react';
 import { useChatStore, type SelectedModel } from '@/stores/chatStore';
 import { createModelSorter } from '@/lib/model-constants';
 import { usePopularProviders } from '@/hooks/usePopularProviders';
@@ -164,7 +164,7 @@ export function ManageModelsDialog({ onClose, onConnectProvider }: ManageModelsD
         </div>
         <div className="px-4 pb-3">
           <div className="flex h-8 items-center gap-2 rounded-md bg-surface px-2">
-            <Icon name="magnifying-glass-menu" size="small" className="shrink-0 text-muted-foreground" />
+            <Search size={16} className="shrink-0 text-muted-foreground" />
             <input
               type="text"
               placeholder="Search models"

--- a/apps/frontend/components/chat/ManageModelsDialog.tsx
+++ b/apps/frontend/components/chat/ManageModelsDialog.tsx
@@ -6,7 +6,7 @@ import { useChatStore, type SelectedModel } from '@/stores/chatStore';
 import { createModelSorter } from '@/lib/model-constants';
 import { usePopularProviders } from '@/hooks/usePopularProviders';
 import { ProviderIcon } from './ProviderIcon';
-import { iconNames, type IconName } from './provider-icons/types';
+import { resolveProviderIcon } from './provider-icons/types';
 import { Icon } from './Icon';
 import { cn } from '@/lib/utils';
 
@@ -27,8 +27,6 @@ type ProviderGroup = {
   providerName: string;
   models: ModelEntry[];
 };
-
-const resolveProviderIcon = (id: string): IconName => (iconNames.includes(id as IconName) ? (id as IconName) : 'synthetic');
 
 export function ManageModelsDialog({ onClose, onConnectProvider }: ManageModelsDialogProps) {
   const popularProviderIDs = usePopularProviders();
@@ -107,12 +105,7 @@ export function ManageModelsDialog({ onClose, onConnectProvider }: ManageModelsD
     }
   };
 
-  const isModelVisible = (model: SelectedModel) => {
-    const state = modelVisibility[`${model.providerID}:${model.modelID}`];
-    if (state === 'hide') return false;
-    if (state === 'show') return true;
-    return true;
-  };
+  const isModelVisible = useChatStore((s) => s.isModelVisible);
 
   const handleRefresh = async () => {
     if (refreshing) return;

--- a/apps/frontend/components/chat/Markdown.tsx
+++ b/apps/frontend/components/chat/Markdown.tsx
@@ -43,7 +43,7 @@ function checksum(str: string): string {
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
     hash = ((hash << 5) - hash) + char;
-    hash = hash & hash;
+    hash |= 0;
   }
   return hash.toString(36);
 }

--- a/apps/frontend/components/chat/Markdown.tsx
+++ b/apps/frontend/components/chat/Markdown.tsx
@@ -1,8 +1,9 @@
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
-// Configure DOMPurify for security
+import morphdom from 'morphdom';
+
 const SANITIZE_CONFIG = {
   USE_PROFILES: { html: true, mathMl: true },
   SANITIZE_NAMED_PROPS: true,
@@ -10,7 +11,6 @@ const SANITIZE_CONFIG = {
   FORBID_CONTENTS: ['style', 'script'],
 };
 
-// Add security hook for anchor tags (noopener, noreferrer)
 if (typeof window !== 'undefined' && DOMPurify.isSupported) {
   DOMPurify.addHook('afterSanitizeAttributes', (node: Element) => {
     if (!(node instanceof HTMLAnchorElement)) return;
@@ -24,7 +24,6 @@ if (typeof window !== 'undefined' && DOMPurify.isSupported) {
   });
 }
 
-// Cache for rendered markdown to avoid re-parsing
 const MAX_CACHE_SIZE = 200;
 const markdownCache = new Map<string, { hash: string; html: string }>();
 
@@ -39,13 +38,12 @@ function cacheTouch(key: string, value: { hash: string; html: string }) {
   markdownCache.delete(first);
 }
 
-// Simple checksum function for cache keys
 function checksum(str: string): string {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
     hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32bit integer
+    hash = hash & hash;
   }
   return hash.toString(36);
 }
@@ -55,6 +53,141 @@ function sanitize(html: string): string {
   return DOMPurify.sanitize(html, SANITIZE_CONFIG);
 }
 
+// Code block copy button
+
+const COPY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="copy-icon"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+const CHECK_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="check-icon" style="display:none;"><path d="M20 6 9 17l-5-5"/></svg>`;
+
+function createCopyButton(): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'markdown-copy-button';
+  button.setAttribute('aria-label', 'Copy code');
+  button.setAttribute('data-slot', 'markdown-copy-button');
+  button.innerHTML = COPY_ICON + CHECK_ICON;
+  return button;
+}
+
+function setCopyState(button: HTMLButtonElement, copied: boolean) {
+  const copyIcon = button.querySelector<SVGElement>('.copy-icon');
+  const checkIcon = button.querySelector<SVGElement>('.check-icon');
+  if (copied) {
+    button.setAttribute('data-copied', 'true');
+    button.setAttribute('aria-label', 'Copied!');
+    if (copyIcon) copyIcon.style.display = 'none';
+    if (checkIcon) checkIcon.style.display = 'inline-block';
+  } else {
+    button.removeAttribute('data-copied');
+    button.setAttribute('aria-label', 'Copy code');
+    if (copyIcon) copyIcon.style.display = '';
+    if (checkIcon) checkIcon.style.display = 'none';
+  }
+}
+
+function ensureCodeWrappers(root: HTMLDivElement) {
+  const blocks = root.querySelectorAll('pre');
+  for (const pre of blocks) {
+    const parent = pre.parentElement;
+    if (!parent) continue;
+    if (parent.getAttribute('data-component') === 'markdown-code') {
+      // Already wrapped
+      if (!parent.querySelector('[data-slot="markdown-copy-button"]')) {
+        parent.appendChild(createCopyButton());
+      }
+      continue;
+    }
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-component', 'markdown-code');
+    parent.replaceChild(wrapper, pre);
+    pre.setAttribute('data-scrollable', '');
+    wrapper.appendChild(pre);
+    wrapper.appendChild(createCopyButton());
+  }
+}
+
+// Clickable URLs in inline code
+
+const URL_PATTERN = /^https?:\/\/[^\s<>()`"']+$/;
+
+function codeUrl(text: string): string | undefined {
+  const href = text.trim().replace(/[),.;!?]+$/, '');
+  if (!URL_PATTERN.test(href)) return undefined;
+  try {
+    return new URL(href).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function markCodeLinks(root: HTMLDivElement) {
+  const codeNodes = root.querySelectorAll(':not(pre) > code');
+  for (const code of codeNodes) {
+    const href = codeUrl(code.textContent ?? '');
+    const parentLink =
+      code.parentElement instanceof HTMLAnchorElement && code.parentElement.classList.contains('external-link')
+        ? code.parentElement
+        : null;
+
+    if (!href) {
+      if (parentLink) parentLink.replaceWith(code);
+      continue;
+    }
+
+    if (parentLink) {
+      parentLink.href = href;
+      continue;
+    }
+
+    const link = document.createElement('a');
+    link.href = href;
+    link.className = 'external-link';
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    code.parentNode?.replaceChild(link, code);
+    link.appendChild(code);
+  }
+}
+
+function decorate(root: HTMLDivElement) {
+  ensureCodeWrappers(root);
+  markCodeLinks(root);
+}
+
+function setupCodeCopy(root: HTMLDivElement): () => void {
+  const timeouts = new Map<HTMLButtonElement, ReturnType<typeof setTimeout>>();
+
+  const handleClick = async (event: MouseEvent) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const button = target.closest('[data-slot="markdown-copy-button"]');
+    if (!(button instanceof HTMLButtonElement)) return;
+
+    const code = button.closest('[data-component="markdown-code"]')?.querySelector('code');
+    const content = code?.textContent ?? '';
+    if (!content) return;
+
+    const clipboard = navigator?.clipboard;
+    if (!clipboard) return;
+
+    await clipboard.writeText(content);
+    setCopyState(button, true);
+
+    const existing = timeouts.get(button);
+    if (existing) clearTimeout(existing);
+    timeouts.set(button, setTimeout(() => setCopyState(button, false), 2000));
+  };
+
+  root.addEventListener('click', handleClick);
+
+  return () => {
+    root.removeEventListener('click', handleClick);
+    for (const timeout of timeouts.values()) clearTimeout(timeout);
+  };
+}
+
+// Component
+
 type MarkdownProps = {
   text: string;
   cacheKey?: string;
@@ -63,129 +196,67 @@ type MarkdownProps = {
 
 export function Markdown({ text, cacheKey, className }: MarkdownProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [html, setHtml] = useState('');
-  const [copiedCodeId, setCopiedCodeId] = useState<string | null>(null);
+  const copyCleanupRef = useRef<(() => void) | null>(null);
 
-  // Parse and render markdown
   useEffect(() => {
-    const parseMarkdown = async () => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const run = async () => {
       const hash = checksum(text);
       const key = cacheKey ?? hash;
 
-      // Check cache
+      let safe: string;
+
       if (key && hash) {
         const cached = markdownCache.get(key);
         if (cached && cached.hash === hash) {
           cacheTouch(key, cached);
-          setHtml(cached.html);
-          return;
+          safe = cached.html;
+        } else {
+          const parsed = await marked.parse(text);
+          safe = sanitize(parsed);
+          cacheTouch(key, { hash, html: safe });
         }
+      } else {
+        const parsed = await marked.parse(text);
+        safe = sanitize(parsed);
       }
 
-      // Parse markdown
-      const parsed = await marked.parse(text);
-      const safe = sanitize(parsed);
+      const temp = document.createElement('div');
+      temp.innerHTML = safe;
+      decorate(temp);
 
-      if (key && hash) {
-        cacheTouch(key, { hash, html: safe });
-      }
-
-      setHtml(safe);
-    };
-
-    parseMarkdown();
-  }, [text, cacheKey]);
-
-  // Setup code copy buttons after HTML is rendered
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || !html) return;
-
-    // Setup copy buttons for code blocks
-    const preElements = container.querySelectorAll('pre');
-    preElements.forEach((pre) => {
-      const parent = pre.parentElement;
-      if (!parent) return;
-
-      // Skip if already wrapped
-      if (parent.getAttribute('data-component') === 'markdown-code') return;
-
-      // Create wrapper
-      const wrapper = document.createElement('div');
-      wrapper.setAttribute('data-component', 'markdown-code');
-      wrapper.style.position = 'relative';
-
-      // Create unique ID for this code block
-      const codeId = Math.random().toString(36).substring(7);
-      const code = pre.querySelector('code');
-      const codeContent = code?.textContent ?? '';
-
-      // Create copy button
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'markdown-copy-button';
-      button.setAttribute('aria-label', 'Copy code');
-      button.setAttribute('title', 'Copy code');
-      button.innerHTML = `
-        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="copy-icon">
-          <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
-          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
-        </svg>
-        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="check-icon" style="display: none;">
-          <path d="M20 6 9 17l-5-5"/>
-        </svg>
-      `;
-
-      button.addEventListener('click', async () => {
-        const clipboard = navigator?.clipboard;
-        if (!clipboard) return;
-
-        await clipboard.writeText(codeContent);
-        setCopiedCodeId(codeId);
-
-        // Reset after 2 seconds
-        setTimeout(() => {
-          setCopiedCodeId((prev) => (prev === codeId ? null : prev));
-        }, 2000);
+      morphdom(container, temp, {
+        childrenOnly: true,
+        onBeforeElUpdated(fromEl, toEl) {
+          if (fromEl.isEqualNode(toEl)) return false;
+          return true;
+        },
       });
 
-      // Update button state when copiedCodeId changes
-      const updateButtonState = () => {
-        if (copiedCodeId === codeId) {
-          button.setAttribute('data-copied', 'true');
-          button.setAttribute('aria-label', 'Copied!');
-          button.setAttribute('title', 'Copied!');
-          button.querySelector('.copy-icon')?.setAttribute('style', 'display: none');
-          button.querySelector('.check-icon')?.setAttribute('style', 'display: inline-block');
-        } else {
-          button.removeAttribute('data-copied');
-          button.setAttribute('aria-label', 'Copy code');
-          button.setAttribute('title', 'Copy code');
-          button.querySelector('.copy-icon')?.setAttribute('style', 'display: inline-block');
-          button.querySelector('.check-icon')?.setAttribute('style', 'display: none');
-        }
-      };
+      decorate(container);
 
-      button.addEventListener('copied-state-changed', updateButtonState);
-
-      parent.replaceChild(wrapper, pre);
-      // Add data-scrollable to pre for proper scroll handling
-      pre.setAttribute('data-scrollable', '');
-      wrapper.appendChild(pre);
-      wrapper.appendChild(button);
-    });
-
-    return () => {
-      // Cleanup happens automatically when component unmounts
+      if (!copyCleanupRef.current) {
+        copyCleanupRef.current = setupCodeCopy(container);
+      }
     };
-  }, [html, copiedCodeId]);
+
+    run();
+  }, [text, cacheKey]);
+
+  useEffect(() => {
+    return () => {
+      copyCleanupRef.current?.();
+      copyCleanupRef.current = null;
+    };
+  }, []);
 
   return (
     <div
       ref={containerRef}
       className={className}
       data-component="markdown"
-      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 }

--- a/apps/frontend/components/chat/MessageDivider.tsx
+++ b/apps/frontend/components/chat/MessageDivider.tsx
@@ -1,0 +1,18 @@
+
+import { memo } from 'react';
+
+interface MessageDividerProps {
+  label: string;
+}
+
+export const MessageDivider = memo(function MessageDivider({ label }: MessageDividerProps) {
+  return (
+    <div data-component="compaction-part">
+      <div data-slot="compaction-part-divider">
+        <span data-slot="compaction-part-line" />
+        <span data-slot="compaction-part-label">{label}</span>
+        <span data-slot="compaction-part-line" />
+      </div>
+    </div>
+  );
+});

--- a/apps/frontend/components/chat/MessageList.tsx
+++ b/apps/frontend/components/chat/MessageList.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useChatStore } from '@/stores/chatStore';
@@ -34,7 +34,6 @@ export function MessageList({ className }: MessageListProps) {
     return sessions.find((session) => session.id === resolvedSessionId);
   }, [resolvedSessionId, sessions]);
   const sessionTitle = activeSession?.title ?? '';
-  const showTitle = true;
   const titleLabel = sessionTitle.trim().length > 0 ? sessionTitle : 'New session';
   const filteredSessions = useMemo(() => {
     const query = sessionQuery.trim().toLowerCase();
@@ -70,7 +69,7 @@ export function MessageList({ className }: MessageListProps) {
     overflowAnchor: 'auto',
   });
 
-  const prevTurnCount = React.useRef(turns.length);
+  const prevTurnCount = useRef(turns.length);
   useEffect(() => {
     const grew = turns.length > prevTurnCount.current;
     prevTurnCount.current = turns.length;
@@ -104,10 +103,9 @@ export function MessageList({ className }: MessageListProps) {
         ref={autoScroll.scrollRef}
         onScroll={autoScroll.handleScroll}
         data-slot="session-turn-content"
-        style={{ '--session-title-height': showTitle ? '40px' : '0px' } as React.CSSProperties}
+        style={{ '--session-title-height': '40px' } as React.CSSProperties}
       >
-        {showTitle && (
-          <div className="sticky top-0 z-30 bg-sidebar-bg px-4">
+        <div className="sticky top-0 z-30 bg-sidebar-bg px-4">
             <div className="h-10 flex items-center justify-between gap-2">
               <Popover open={sessionMenuOpen} onOpenChange={setSessionMenuOpen}>
                 <PopoverTrigger asChild>
@@ -209,7 +207,6 @@ export function MessageList({ className }: MessageListProps) {
               </div>
             </div>
           </div>
-        )}
         {meta?.hasMore && (
           <div className="flex justify-center bg-sidebar-bg py-2">
             <button

--- a/apps/frontend/components/chat/MessageList.tsx
+++ b/apps/frontend/components/chat/MessageList.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useChatStore } from '@/stores/chatStore';
 import { useAutoScroll } from './useAutoScroll';
@@ -7,6 +8,7 @@ import { Icon } from './Icon';
 import { Popover, PopoverContent, PopoverTrigger } from './Popover';
 import { Turn } from './Turn';
 import { DisplayOptionsPopover } from './DisplayOptionsPopover';
+import { MessageDivider } from './MessageDivider';
 import { groupMessagesIntoTurns, EMPTY_MESSAGES } from './message-helpers';
 
 type MessageListProps = {
@@ -22,6 +24,7 @@ export function MessageList({ className }: MessageListProps) {
   const loadMoreMessages = useChatStore((state) => state.loadMoreMessages);
   const setActiveSession = useChatStore((state) => state.setActiveSession);
   const showThinking = useChatStore((s) => s.displayPreferences.showThinking);
+  const compactedSessions = useChatStore((s) => s.compactedSessions);
   const [sessionQuery, setSessionQuery] = useState('');
   const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
 
@@ -67,8 +70,11 @@ export function MessageList({ className }: MessageListProps) {
     overflowAnchor: 'auto',
   });
 
+  const prevTurnCount = React.useRef(turns.length);
   useEffect(() => {
-    if (isWorking) {
+    const grew = turns.length > prevTurnCount.current;
+    prevTurnCount.current = turns.length;
+    if (grew || isWorking) {
       autoScroll.forceScrollToBottom();
     }
   }, [turns.length, isWorking, autoScroll.forceScrollToBottom]);
@@ -120,7 +126,7 @@ export function MessageList({ className }: MessageListProps) {
                 <PopoverContent className="max-h-80 overflow-hidden p-2 flex flex-col !bg-surface-elevated !border-border">
                   <div className="mb-2 flex items-center gap-2">
                     <div className="flex h-8 flex-1 items-center gap-2 rounded-md bg-surface px-2">
-                      <Icon name="magnifying-glass-menu" size="small" className="shrink-0 text-muted-foreground" />
+                      <Search size={16} className="shrink-0 text-muted-foreground" />
                       <input
                         value={sessionQuery}
                         onChange={(event) => setSessionQuery(event.target.value)}
@@ -227,7 +233,11 @@ export function MessageList({ className }: MessageListProps) {
           {emptyState ? (
             <div className="px-4 py-4 text-sm text-muted-foreground">{emptyState}</div>
           ) : (
-            turns.map((turn) => (
+            <>
+            {compactedSessions[sessionId] && (
+              <MessageDivider label="Session compacted" />
+            )}
+            {turns.map((turn) => (
               <Turn
                 key={turn.userMessage.id}
                 turn={turn}
@@ -236,7 +246,8 @@ export function MessageList({ className }: MessageListProps) {
                 onInteract={autoScroll.handleInteraction}
                 showThinking={showThinking}
               />
-            ))
+            ))}
+            </>
           )}
         </div>
       </div>

--- a/apps/frontend/components/chat/ModelSelector.tsx
+++ b/apps/frontend/components/chat/ModelSelector.tsx
@@ -1,6 +1,6 @@
 
 import { useEffect, useMemo, useState } from 'react';
-import { Check, ChevronDown } from 'lucide-react';
+import { Check, ChevronDown, Search } from 'lucide-react';
 import { useChatStore, type SelectedModel } from '@/stores/chatStore';
 import { Popover, PopoverContent, PopoverTrigger } from './Popover';
 import { Icon } from './Icon';
@@ -200,7 +200,7 @@ export function ModelSelector({ disabled = false, compactLevel }: ModelSelectorP
         <PopoverContent className="h-80 overflow-hidden p-2 flex flex-col !bg-surface-elevated !border-border">
           <div className="mb-2 flex items-center gap-2">
             <div className="flex h-8 flex-1 items-center gap-2 rounded-md bg-surface px-2">
-              <Icon name="magnifying-glass-menu" size="small" className="text-muted-foreground shrink-0" />
+              <Search size={16} className="text-muted-foreground shrink-0" />
               <input
                 type="text"
                 placeholder="Search models"

--- a/apps/frontend/components/chat/ModelSelector.tsx
+++ b/apps/frontend/components/chat/ModelSelector.tsx
@@ -6,15 +6,13 @@ import { Popover, PopoverContent, PopoverTrigger } from './Popover';
 import { Icon } from './Icon';
 import { cn } from '@/lib/utils';
 import { ProviderIcon } from './ProviderIcon';
-import { iconNames, type IconName } from './provider-icons/types';
+import { resolveProviderIcon } from './provider-icons/types';
 import { SelectProviderDialog } from './SelectProviderDialog';
 import { ConnectProviderDialog } from './ConnectProviderDialog';
 import { ManageModelsDialog } from './ManageModelsDialog';
 import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
 import { createModelSorter } from '@/lib/model-constants';
 import { usePopularProviders } from '@/hooks/usePopularProviders';
-
-const resolveProviderIcon = (id: string): IconName => (iconNames.includes(id as IconName) ? (id as IconName) : 'synthetic');
 
 type ModelSelectorProps = {
   disabled?: boolean;
@@ -60,12 +58,7 @@ export function ModelSelector({ disabled = false, compactLevel }: ModelSelectorP
     setSearchQuery('');
   }, [isOpen]);
 
-  const isModelVisible = (model: SelectedModel) => {
-    const state = modelVisibility[`${model.providerID}:${model.modelID}`];
-    if (state === 'hide') return false;
-    if (state === 'show') return true;
-    return true;
-  };
+  const isModelVisible = useChatStore((s) => s.isModelVisible);
 
   const selectedProviderId = selectedModel?.providerID ?? '';
   const provider = providers.find((item) => item.id === selectedProviderId);

--- a/apps/frontend/components/chat/PromptInput.tsx
+++ b/apps/frontend/components/chat/PromptInput.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useCallback, useMemo, useRef, useState } from 'react';
-import { ArrowUp, File as FileIcon, Image as ImageIcon, StopCircle, Terminal } from 'lucide-react';
+import { ArrowUp, File as FileIcon, Image as ImageIcon, Shield, StopCircle, Terminal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   useChatStore,
@@ -80,6 +80,8 @@ export function PromptInput({
   const selectedModel = useChatStore((state) => state.selectedModel);
   const selectedVariant = useChatStore((state) => state.selectedVariant);
   const setSelectedVariant = useChatStore((state) => state.setSelectedVariant);
+  const autoAccept = useChatStore((state) => state.autoAccept);
+  const toggleAutoAccept = useChatStore((state) => state.toggleAutoAccept);
   const [composing, setComposing] = useState(false);
   const sessionStatus = useChatStore((state) => state.sessionStatus);
   const status = activeSessionId ? sessionStatus[activeSessionId] : undefined;
@@ -105,6 +107,22 @@ export function PromptInput({
     usePromptEditor({ disabled, trigger, setTriggerState, updateTrigger });
 
   const shellMode = promptText.startsWith('!');
+
+  // Hide context chips for files already referenced inline via @mention
+  const visibleContextItems = useMemo(() => {
+    const mentionedFiles = new Set<string>();
+    const regex = /@([^\s]+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(promptText))) {
+      const token = match[1]?.toLowerCase();
+      if (token) mentionedFiles.add(token);
+    }
+    if (mentionedFiles.size === 0) return contextItems;
+    return contextItems.filter((item) => {
+      const name = (item.path.split(/[/\\]/).pop() || item.path).toLowerCase();
+      return !mentionedFiles.has(name);
+    });
+  }, [contextItems, promptText]);
 
   const { compactLevel, footerRef, leftControlsRef, rightControlsRef } = usePromptCompact({
     shellMode,
@@ -322,9 +340,9 @@ export function PromptInput({
         )}
       >
         <DragOverlay dragging={dragging} />
-        {contextItems.length > 0 && (
+        {visibleContextItems.length > 0 && (
           <div className="flex flex-nowrap items-center gap-1.5 px-3 pt-2.5 pb-0.5 overflow-x-auto thin-scrollbar">
-            {contextItems.map((item) => {
+            {visibleContextItems.map((item) => {
               const selection = item.selection;
               const start = selection ? Math.min(selection.startLine, selection.endLine) : null;
               const end = selection ? Math.max(selection.startLine, selection.endLine) : null;
@@ -456,6 +474,21 @@ export function PromptInput({
               }}
             />
             <SessionContextUsage />
+            <button
+              type="button"
+              onClick={toggleAutoAccept}
+              className={cn(
+                "size-7 flex items-center justify-center rounded-md transition-colors",
+                autoAccept
+                  ? "text-[var(--accent-green)] hover:bg-[color-mix(in_srgb,var(--accent-green)_10%,transparent)]"
+                  : "text-muted-foreground hover:bg-[var(--overlay-10)] hover:text-foreground"
+              )}
+              title={autoAccept ? 'Auto-accept permissions (on)' : 'Auto-accept permissions (off)'}
+              aria-label={autoAccept ? 'Auto-accept permissions (on)' : 'Auto-accept permissions (off)'}
+              aria-pressed={autoAccept}
+            >
+              <Shield className="size-4" />
+            </button>
             <button
               type="button"
               onClick={() => inputRef.current?.click()}

--- a/apps/frontend/components/chat/PromptInputSuggestions.tsx
+++ b/apps/frontend/components/chat/PromptInputSuggestions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import fuzzysort from 'fuzzysort';
 import { useChatStore } from '@/stores/chatStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
@@ -18,23 +18,6 @@ export function usePromptSuggestions() {
 
   const [trigger, setTrigger] = useState<TriggerState | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
-  const [fileSearchResults, setFileSearchResults] = useState<string[]>([]);
-
-  const searchWorkspaceFiles = useCallback((query: string): string[] => {
-    if (!workspaceMetadata || !query || fileTree.length === 0) return [];
-    return searchFiles(query, fileTree, 20).map((p: string) => p.replace(/\\/g, '/'));
-  }, [workspaceMetadata, fileTree]);
-
-  useEffect(() => {
-    if (trigger?.type === 'mention' && trigger.query.length > 0 && workspaceMetadata) {
-      const debouncedSearch = setTimeout(() => {
-        setFileSearchResults(searchWorkspaceFiles(trigger.query));
-      }, 150);
-      return () => clearTimeout(debouncedSearch);
-    } else {
-      setFileSearchResults([]);
-    }
-  }, [trigger?.query, trigger?.type, workspaceMetadata, searchWorkspaceFiles]);
 
   const recentFiles = useMemo(() => {
     return Array.from(openFiles.keys()).map((key) => String(key).replace(/\\/g, '/'));
@@ -53,34 +36,6 @@ export function usePromptSuggestions() {
         group: 'agent' as const,
       }));
   }, [agents]);
-
-  const fileSuggestions = useMemo(() => {
-    const recentSuggestions = recentFiles
-      .filter((path) => !fileSearchResults.includes(path))
-      .map((path) => ({
-        id: path,
-        label: `@${path}`,
-        value: `@${path}`,
-        description: path,
-        type: 'mention' as const,
-        path,
-        group: 'recent' as const,
-      }));
-
-    const searchSuggestions = fileSearchResults
-      .filter((path) => !recentFiles.includes(path))
-      .map((path) => ({
-        id: `search-${path}`,
-        label: `@${path}`,
-        value: `@${path}`,
-        description: path,
-        type: 'mention' as const,
-        path,
-        group: 'search' as const,
-      }));
-
-    return [...recentSuggestions, ...searchSuggestions];
-  }, [recentFiles, fileSearchResults]);
 
   const commandSuggestions = useMemo(() => {
     const builtinIds = new Set(BUILTIN_COMMANDS.map((item) => item.id));
@@ -103,26 +58,53 @@ export function usePromptSuggestions() {
   const suggestions = useMemo(() => {
     if (!trigger) return [];
     const query = trigger.query.toLowerCase();
+
     if (trigger.type === 'command') {
       return commandSuggestions.filter((item) => item.label.toLowerCase().includes(query));
     }
 
-    const needle = query;
-    const allSuggestions = [...agentSuggestions, ...fileSuggestions];
-
-    if (!needle) {
-      return allSuggestions.filter((item) =>
-        !('group' in item && item.group === 'search')
-      );
+    // No query — show agents + recent files
+    if (!query) {
+      const recentSuggestions: SuggestionItem[] = recentFiles.map((path) => ({
+        id: path,
+        label: `@${path}`,
+        value: `@${path}`,
+        description: path,
+        type: 'mention' as const,
+        path,
+        group: 'recent' as const,
+      }));
+      return [...agentSuggestions, ...recentSuggestions];
     }
 
-    const results = fuzzysort.go(needle, allSuggestions, {
+    // With query — fuzzy-match agents, search files synchronously
+    const agentResults = fuzzysort.go(query, agentSuggestions, {
       key: 'label',
       limit: 20,
     });
 
-    return results.map((r) => r.obj);
-  }, [trigger, agentSuggestions, fileSuggestions, commandSuggestions]);
+    const searchResults = workspaceMetadata && fileTree.length > 0
+      ? searchFiles(query, fileTree, 20).map((p) => p.replace(/\\/g, '/'))
+      : [];
+
+    const seen = new Set<string>();
+    const fileSuggestions: SuggestionItem[] = [];
+    for (const path of searchResults) {
+      if (seen.has(path)) continue;
+      seen.add(path);
+      fileSuggestions.push({
+        id: `search-${path}`,
+        label: `@${path}`,
+        value: `@${path}`,
+        description: path,
+        type: 'mention' as const,
+        path,
+        group: 'search' as const,
+      });
+    }
+
+    return [...agentResults.map((r) => r.obj), ...fileSuggestions];
+  }, [trigger, agentSuggestions, recentFiles, commandSuggestions, workspaceMetadata, fileTree]);
 
   const setTriggerState = useCallback((next: TriggerState | null) => {
     setTrigger((prev) => {

--- a/apps/frontend/components/chat/QuestionDock.tsx
+++ b/apps/frontend/components/chat/QuestionDock.tsx
@@ -42,8 +42,7 @@ export const QuestionDock = memo(function QuestionDock({ request, onReply, onRej
     });
     if (isCustom) {
       setCustom((prev) => { const n = prev.slice(); n[tab] = label; return n; });
-    }
-    if (!isCustom) {
+    } else {
       setCustomOn((prev) => { const n = prev.slice(); n[tab] = false; return n; });
     }
     setEditing(false);

--- a/apps/frontend/components/chat/QuestionDock.tsx
+++ b/apps/frontend/components/chat/QuestionDock.tsx
@@ -1,0 +1,421 @@
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { QuestionRequest } from '@opencode-ai/sdk/v2/client';
+
+type QuestionDockProps = {
+  request: QuestionRequest;
+  onReply: (input: { requestID: string; answers: string[][] }) => void;
+  onReject: (input: { requestID: string }) => void;
+};
+
+export const QuestionDock = memo(function QuestionDock({ request, onReply, onReject }: QuestionDockProps) {
+  const questions = request.questions;
+  const total = questions.length;
+
+  const [tab, setTab] = useState(0);
+  const [answers, setAnswers] = useState<string[][]>(() => questions.map(() => []));
+  const [custom, setCustom] = useState<string[]>(() => questions.map(() => ''));
+  const [customOn, setCustomOn] = useState<boolean[]>(() => questions.map(() => false));
+  const [editing, setEditing] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  const question = questions[tab];
+  const options = question?.options ?? [];
+  const multi = question?.multiple === true;
+  const input = custom[tab] ?? '';
+  const on = customOn[tab] === true;
+  const isLast = tab >= total - 1;
+  const selected = answers[tab] ?? [];
+
+  const canSubmit = useMemo(
+    () => questions.every((_, i) => (answers[i]?.length ?? 0) > 0),
+    [answers, questions],
+  );
+
+  // --- Selection logic ---
+
+  const pick = useCallback((label: string, isCustom = false) => {
+    setAnswers((prev) => {
+      const next = prev.map((a) => a.slice());
+      next[tab] = [label];
+      return next;
+    });
+    if (isCustom) {
+      setCustom((prev) => { const n = prev.slice(); n[tab] = label; return n; });
+    }
+    if (!isCustom) {
+      setCustomOn((prev) => { const n = prev.slice(); n[tab] = false; return n; });
+    }
+    setEditing(false);
+  }, [tab]);
+
+  const toggle = useCallback((label: string) => {
+    setAnswers((prev) => {
+      const next = prev.map((a) => a.slice());
+      const current = next[tab] ?? [];
+      next[tab] = current.includes(label)
+        ? current.filter((item) => item !== label)
+        : [...current, label];
+      return next;
+    });
+  }, [tab]);
+
+  const customUpdate = useCallback((value: string, isSelected: boolean = on) => {
+    const prev = input.trim();
+    const next = value.trim();
+    setCustom((p) => { const n = p.slice(); n[tab] = value; return n; });
+
+    if (!isSelected) return;
+
+    if (multi) {
+      setAnswers((p) => {
+        const a = p.map((x) => x.slice());
+        const current = a[tab] ?? [];
+        const removed = prev ? current.filter((item) => item.trim() !== prev) : current;
+        if (!next) { a[tab] = removed; return a; }
+        if (removed.some((item) => item.trim() === next)) { a[tab] = removed; return a; }
+        a[tab] = [...removed, next];
+        return a;
+      });
+      return;
+    }
+    setAnswers((p) => {
+      const a = p.map((x) => x.slice());
+      a[tab] = next ? [next] : [];
+      return a;
+    });
+  }, [tab, multi, on, input]);
+
+  const commitCustom = useCallback(() => {
+    setEditing(false);
+    customUpdate(input);
+  }, [customUpdate, input]);
+
+  const customOpen = useCallback(() => {
+    if (sending) return;
+    if (!on) setCustomOn((p) => { const n = p.slice(); n[tab] = true; return n; });
+    setEditing(true);
+    customUpdate(input, true);
+  }, [sending, on, tab, customUpdate, input]);
+
+  const customToggle = useCallback(() => {
+    if (sending) return;
+    if (!multi) {
+      setCustomOn((p) => { const n = p.slice(); n[tab] = true; return n; });
+      setEditing(true);
+      customUpdate(input, true);
+      return;
+    }
+    const next = !on;
+    setCustomOn((p) => { const n = p.slice(); n[tab] = next; return n; });
+    if (next) {
+      setEditing(true);
+      customUpdate(input, true);
+      return;
+    }
+    const value = input.trim();
+    if (value) {
+      setAnswers((p) => {
+        const a = p.map((x) => x.slice());
+        a[tab] = (a[tab] ?? []).filter((item) => item.trim() !== value);
+        return a;
+      });
+    }
+    setEditing(false);
+  }, [sending, multi, on, tab, customUpdate, input]);
+
+  const selectOption = useCallback((optIndex: number) => {
+    if (sending) return;
+    if (optIndex === options.length) {
+      customOpen();
+      return;
+    }
+    const opt = options[optIndex];
+    if (!opt) return;
+    if (multi) {
+      toggle(opt.label);
+      return;
+    }
+    pick(opt.label);
+  }, [sending, options, multi, toggle, pick, customOpen]);
+
+  // --- Navigation ---
+
+  const submit = useCallback(() => {
+    setSending(true);
+    const finalAnswers = questions.map((_, i) => answers[i] ?? []);
+    onReply({ requestID: request.id, answers: finalAnswers });
+  }, [questions, answers, request.id, onReply]);
+
+  const next = useCallback(() => {
+    if (sending) return;
+    if (editing) commitCustom();
+    if (isLast) { submit(); return; }
+    setTab((t) => t + 1);
+    setEditing(false);
+  }, [sending, editing, commitCustom, isLast, submit]);
+
+  const back = useCallback(() => {
+    if (sending || tab <= 0) return;
+    setTab((t) => t - 1);
+    setEditing(false);
+  }, [sending, tab]);
+
+  const jump = useCallback((t: number) => {
+    if (sending) return;
+    setTab(t);
+    setEditing(false);
+  }, [sending]);
+
+  const dismiss = useCallback(() => {
+    if (sending) return;
+    setSending(true);
+    onReject({ requestID: request.id });
+  }, [sending, request.id, onReject]);
+
+  if (!question) return null;
+
+  return (
+    <div data-component="question-dock">
+      {/* Shell (elevated surface) */}
+      <div data-slot="question-dock-shell">
+        {/* Header */}
+        <div data-slot="question-dock-header">
+          <span data-slot="question-dock-title">
+            {total > 1 ? `Question ${tab + 1} of ${total}` : 'Question'}
+          </span>
+          {total > 1 && (
+            <div data-slot="question-dock-progress">
+              {questions.map((_, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  data-slot="question-dock-segment"
+                  data-active={i === tab || undefined}
+                  data-answered={(answers[i]?.length ?? 0) > 0 || undefined}
+                  disabled={sending}
+                  onClick={() => jump(i)}
+                  aria-label={`Question ${i + 1}`}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Content */}
+        <div data-slot="question-dock-content">
+          <div data-slot="question-dock-text">{question.question}</div>
+          <div data-slot="question-dock-hint">
+            {multi ? 'Select all that apply' : 'Choose one'}
+          </div>
+
+          <div data-slot="question-dock-options">
+            {options.map((opt, i) => {
+              const picked = selected.includes(opt.label);
+              return (
+                <button
+                  key={opt.label}
+                  type="button"
+                  data-slot="question-dock-option"
+                  data-picked={picked || undefined}
+                  role={multi ? 'checkbox' : 'radio'}
+                  aria-checked={picked}
+                  disabled={sending}
+                  onClick={() => selectOption(i)}
+                >
+                  <span data-slot="question-dock-option-check" aria-hidden="true">
+                    <span
+                      data-slot="question-dock-option-box"
+                      data-type={multi ? 'checkbox' : 'radio'}
+                      data-picked={picked || undefined}
+                    >
+                      {multi
+                        ? <CheckIcon />
+                        : <span data-slot="question-dock-option-radio-dot" />
+                      }
+                    </span>
+                  </span>
+                  <span data-slot="question-dock-option-main">
+                    <span data-slot="question-dock-option-label">{opt.label}</span>
+                    {opt.description && (
+                      <span data-slot="question-dock-option-desc">{opt.description}</span>
+                    )}
+                  </span>
+                </button>
+              );
+            })}
+
+            {/* Custom answer option */}
+            {question.custom !== false && (
+              editing ? (
+                <CustomEditOption
+                  multi={multi}
+                  on={on}
+                  input={input}
+                  sending={sending}
+                  onInput={(v) => customUpdate(v)}
+                  onToggle={customToggle}
+                  onCommit={commitCustom}
+                  onCancel={() => setEditing(false)}
+                />
+              ) : (
+                <button
+                  type="button"
+                  data-slot="question-dock-option"
+                  data-custom="true"
+                  data-picked={on || undefined}
+                  role={multi ? 'checkbox' : 'radio'}
+                  aria-checked={on}
+                  disabled={sending}
+                  onClick={customOpen}
+                >
+                  <span
+                    data-slot="question-dock-option-check"
+                    aria-hidden="true"
+                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); customToggle(); }}
+                  >
+                    <span
+                      data-slot="question-dock-option-box"
+                      data-type={multi ? 'checkbox' : 'radio'}
+                      data-picked={on || undefined}
+                    >
+                      {multi ? <CheckIcon /> : <span data-slot="question-dock-option-radio-dot" />}
+                    </span>
+                  </span>
+                  <span data-slot="question-dock-option-main">
+                    <span data-slot="question-dock-option-label">Type your own answer</span>
+                    <span data-slot="question-dock-option-desc">
+                      {input || 'Enter a custom response'}
+                    </span>
+                  </span>
+                </button>
+              )
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Tray (footer) */}
+      <div data-slot="question-dock-tray">
+        <button
+          type="button"
+          data-slot="question-dock-btn"
+          data-variant="ghost"
+          disabled={sending}
+          onClick={dismiss}
+        >
+          Dismiss
+        </button>
+        <div data-slot="question-dock-actions">
+          {tab > 0 && (
+            <button
+              type="button"
+              data-slot="question-dock-btn"
+              data-variant="secondary"
+              disabled={sending}
+              onClick={back}
+            >
+              Back
+            </button>
+          )}
+          <button
+            type="button"
+            data-slot="question-dock-btn"
+            data-variant={isLast ? 'primary' : 'secondary'}
+            disabled={sending || (isLast && !canSubmit)}
+            onClick={next}
+          >
+            {isLast ? 'Submit' : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 12 12" fill="none" width="10" height="10" data-slot="question-dock-check-icon">
+      <path d="M3 7.17905L5.02703 8.85135L9 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}
+
+function CustomEditOption({
+  multi, on, input, sending,
+  onInput, onToggle, onCommit, onCancel,
+}: {
+  multi: boolean;
+  on: boolean;
+  input: string;
+  sending: boolean;
+  onInput: (value: string) => void;
+  onToggle: () => void;
+  onCommit: () => void;
+  onCancel: () => void;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    setTimeout(() => {
+      el.focus();
+      el.style.height = '0px';
+      el.style.height = `${el.scrollHeight}px`;
+    }, 0);
+  }, []);
+
+  return (
+    <form
+      data-slot="question-dock-option"
+      data-custom="true"
+      data-picked={on || undefined}
+      role={multi ? 'checkbox' : 'radio'}
+      aria-checked={on}
+      onMouseDown={(e) => {
+        if (sending) { e.preventDefault(); return; }
+        if (e.target instanceof HTMLTextAreaElement) return;
+        textareaRef.current?.focus();
+      }}
+      onSubmit={(e) => { e.preventDefault(); onCommit(); }}
+    >
+      <span
+        data-slot="question-dock-option-check"
+        aria-hidden="true"
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggle(); }}
+      >
+        <span
+          data-slot="question-dock-option-box"
+          data-type={multi ? 'checkbox' : 'radio'}
+          data-picked={on || undefined}
+        >
+          {multi ? <CheckIcon /> : <span data-slot="question-dock-option-radio-dot" />}
+        </span>
+      </span>
+      <span data-slot="question-dock-option-main">
+        <span data-slot="question-dock-option-label">Type your own answer</span>
+        <textarea
+          ref={textareaRef}
+          data-slot="question-dock-custom-input"
+          placeholder="Enter a custom response"
+          value={input}
+          rows={1}
+          disabled={sending}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') { e.preventDefault(); onCancel(); return; }
+            if (e.key !== 'Enter' || e.shiftKey) return;
+            e.preventDefault();
+            onCommit();
+          }}
+          onInput={(e) => {
+            const el = e.currentTarget;
+            onInput(el.value);
+            el.style.height = '0px';
+            el.style.height = `${el.scrollHeight}px`;
+          }}
+        />
+      </span>
+    </form>
+  );
+}

--- a/apps/frontend/components/chat/SelectProviderDialog.tsx
+++ b/apps/frontend/components/chat/SelectProviderDialog.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import { X, RefreshCw, Search } from 'lucide-react';
 import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
 import { ProviderIcon } from './ProviderIcon';
-import { iconNames, type IconName } from './provider-icons/types';
+import { resolveProviderIcon } from './provider-icons/types';
 import { cn } from '@/lib/utils';
 import { Icon } from './Icon';
 
@@ -50,7 +50,6 @@ const PROVIDER_DESCRIPTIONS = [
   },
 ] as const;
 
-const resolveProviderIcon = (id: string): IconName => (iconNames.includes(id as IconName) ? (id as IconName) : 'synthetic');
 
 const getProviderDescription = (providerId: string): string | null => {
   for (const item of PROVIDER_DESCRIPTIONS) {

--- a/apps/frontend/components/chat/SelectProviderDialog.tsx
+++ b/apps/frontend/components/chat/SelectProviderDialog.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { X, RefreshCw } from 'lucide-react';
+import { X, RefreshCw, Search } from 'lucide-react';
 import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
 import { ProviderIcon } from './ProviderIcon';
 import { iconNames, type IconName } from './provider-icons/types';
@@ -171,7 +171,7 @@ export function SelectProviderDialog({ onClose, onProviderSelect }: SelectProvid
 
         <div className="px-4 pb-3">
           <div className="flex h-8 items-center gap-2 rounded-md bg-surface px-2">
-            <Icon name="magnifying-glass-menu" size="small" className="shrink-0 text-muted-foreground" />
+            <Search size={16} className="shrink-0 text-muted-foreground" />
             <input
               type="text"
               placeholder="Search providers"

--- a/apps/frontend/components/chat/ShellSubmessage.tsx
+++ b/apps/frontend/components/chat/ShellSubmessage.tsx
@@ -1,0 +1,57 @@
+
+import { memo, useEffect, useRef } from 'react';
+import { animate } from 'motion';
+
+interface ShellSubmessageProps {
+  text: string;
+  animated?: boolean;
+}
+
+export const ShellSubmessage = memo(function ShellSubmessage({
+  text,
+  animated = true,
+}: ShellSubmessageProps) {
+  const widthRef = useRef<HTMLSpanElement>(null);
+  const valueRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!animated) return;
+    const frame = requestAnimationFrame(() => {
+      if (widthRef.current) {
+        animate(
+          widthRef.current,
+          { width: 'auto' },
+          { type: 'spring', visualDuration: 0.25, bounce: 0 },
+        );
+      }
+      if (valueRef.current) {
+        animate(
+          valueRef.current,
+          { opacity: 1, filter: 'blur(0px)' },
+          { duration: 0.32, ease: [0.16, 1, 0.3, 1] },
+        );
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <span data-component="shell-submessage">
+      <span
+        ref={widthRef}
+        data-slot="shell-submessage-width"
+        style={animated ? { width: '0px' } : undefined}
+      >
+        <span data-slot="basic-tool-tool-subtitle">
+          <span
+            ref={valueRef}
+            data-slot="shell-submessage-value"
+            style={animated ? { opacity: 0, filter: 'blur(2px)' } : undefined}
+          >
+            {text}
+          </span>
+        </span>
+      </span>
+    </span>
+  );
+});

--- a/apps/frontend/components/chat/TextShimmer.tsx
+++ b/apps/frontend/components/chat/TextShimmer.tsx
@@ -1,46 +1,71 @@
 
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 
 type TextShimmerProps = {
   text: string;
   active?: boolean;
-  stepMs?: number;
-  durationMs?: number;
+  offset?: number;
   className?: string;
 };
 
 export const TextShimmer = memo(function TextShimmer({
   text,
   active = true,
-  stepMs = 45,
-  durationMs = 1200,
+  offset = 0,
   className,
 }: TextShimmerProps) {
-  const chars = useMemo(() => Array.from(text), [text]);
+  const [run, setRun] = useState(active);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    if (active) {
+      setRun(true);
+      return;
+    }
+
+    // Graceful deactivation — keep shimmer visible briefly
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setRun(false);
+    }, 220);
+
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [active]);
 
   return (
     <span
       data-component="text-shimmer"
-      data-active={active}
+      data-active={active ? 'true' : 'false'}
       className={className}
       aria-label={text}
       style={
         {
-          '--text-shimmer-step': `${stepMs}ms`,
-          '--text-shimmer-duration': `${durationMs}ms`,
+          '--text-shimmer-swap': '220ms',
+          '--text-shimmer-index': `${offset}`,
         } as React.CSSProperties
       }
     >
-      {chars.map((char, index) => (
-        <span
-          key={index}
-          data-slot="text-shimmer-char"
-          aria-hidden="true"
-          style={{ '--text-shimmer-index': `${index}` } as React.CSSProperties}
-        >
-          {char}
+      <span data-slot="text-shimmer-char">
+        <span data-slot="text-shimmer-char-base" aria-hidden="true">
+          {text}
         </span>
-      ))}
+        <span
+          data-slot="text-shimmer-char-shimmer"
+          data-run={run ? 'true' : 'false'}
+          aria-hidden="true"
+        >
+          {text}
+        </span>
+      </span>
     </span>
   );
 });

--- a/apps/frontend/components/chat/TodoDock.tsx
+++ b/apps/frontend/components/chat/TodoDock.tsx
@@ -1,0 +1,257 @@
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Todo } from '@opencode-ai/sdk/v2/client';
+import { animate, type AnimationPlaybackControls } from 'motion';
+import { AnimatedNumber } from './AnimatedNumber';
+import { prefersReducedMotion } from './message-helpers';
+
+function PulsingDot() {
+  return (
+    <svg viewBox="0 0 12 12" width="12" height="12" fill="currentColor" data-slot="todo-dot">
+      <circle cx="6" cy="6" r="3" />
+    </svg>
+  );
+}
+
+function TodoCheckbox({ todo }: { todo: Todo }) {
+  const isCompleted = todo.status === 'completed' || todo.status === 'cancelled';
+  const isInProgress = todo.status === 'in_progress';
+  const isPending = todo.status === 'pending';
+
+  return (
+    <label
+      data-component="todo-dock-checkbox"
+      data-checked={isCompleted ? '' : undefined}
+      data-in-progress={isInProgress ? '' : undefined}
+      data-state={todo.status}
+      style={{
+        opacity: isPending ? 0.94 : 1,
+      }}
+    >
+      <span data-slot="todo-dock-checkbox-control">
+        {isCompleted && (
+          <svg viewBox="0 0 12 12" fill="none" width="10" height="10" data-slot="todo-dock-check-icon">
+            <path d="M3 7.17905L5.02703 8.85135L9 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+          </svg>
+        )}
+        {isInProgress && <PulsingDot />}
+      </span>
+      <span
+        data-slot="todo-dock-content"
+        data-completed={isCompleted ? '' : undefined}
+      >
+        {todo.content}
+      </span>
+    </label>
+  );
+}
+
+function TodoList({ todos, open }: { todos: Todo[]; open: boolean }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [stuck, setStuck] = useState(false);
+  const scrollTimer = useRef<number | undefined>(undefined);
+  const scrollingRef = useRef(false);
+
+  const inProgressIdx = useMemo(
+    () => todos.findIndex((t) => t.status === 'in_progress'),
+    [todos],
+  );
+
+  useEffect(() => {
+    if (!open || inProgressIdx < 0) return;
+    requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (!el) return;
+      if (scrollingRef.current) return;
+      const target = el.querySelector('[data-in-progress]');
+      if (!(target instanceof HTMLElement)) return;
+
+      const topFade = 16;
+      const bottomFade = 44;
+      const container = el.getBoundingClientRect();
+      const rect = target.getBoundingClientRect();
+      const top = rect.top - container.top + el.scrollTop;
+      const bottom = rect.bottom - container.top + el.scrollTop;
+      const viewTop = el.scrollTop + topFade;
+      const viewBottom = el.scrollTop + el.clientHeight - bottomFade;
+
+      if (top < viewTop) {
+        el.scrollTop = Math.max(0, top - topFade);
+      } else if (bottom > viewBottom) {
+        el.scrollTop = bottom - (el.clientHeight - bottomFade);
+      }
+      setStuck(el.scrollTop > 0);
+    });
+  }, [open, inProgressIdx]);
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    setStuck(el.scrollTop > 0);
+    scrollingRef.current = true;
+    if (scrollTimer.current) window.clearTimeout(scrollTimer.current);
+    scrollTimer.current = window.setTimeout(() => {
+      scrollingRef.current = false;
+    }, 250);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (scrollTimer.current) window.clearTimeout(scrollTimer.current);
+    };
+  }, []);
+
+  return (
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        data-slot="todo-dock-list"
+        onScroll={handleScroll}
+        style={{ overflowAnchor: 'none' }}
+      >
+        {todos.map((todo, i) => (
+          <TodoCheckbox key={i} todo={todo} />
+        ))}
+      </div>
+      <div
+        data-slot="todo-dock-fade-top"
+        style={{ opacity: stuck ? 1 : 0 }}
+      />
+    </div>
+  );
+}
+
+const SPRING = { type: 'spring' as const, visualDuration: 0.3, bounce: 0 };
+const COLLAPSED_HEIGHT = 44;
+
+export const TodoDock = memo(function TodoDock({ todos }: { todos: Todo[] }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const animRef = useRef<AnimationPlaybackControls | null>(null);
+  const [contentHeight, setContentHeight] = useState(320);
+  const isFirst = useRef(true);
+
+  const total = todos.length;
+  const done = useMemo(() => todos.filter((t) => t.status === 'completed').length, [todos]);
+  const active = useMemo(
+    () =>
+      todos.find((t) => t.status === 'in_progress') ??
+      todos.find((t) => t.status === 'pending') ??
+      todos.filter((t) => t.status === 'completed').at(-1) ??
+      todos[0],
+    [todos],
+  );
+  const preview = active?.content ?? '';
+
+  // Measure content height
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const update = () => setContentHeight(el.getBoundingClientRect().height);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Animate collapse/expand
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
+      return;
+    }
+    const el = contentRef.current?.parentElement;
+    if (!el) return;
+
+    if (prefersReducedMotion()) {
+      const full = Math.max(COLLAPSED_HEIGHT, contentHeight);
+      el.style.maxHeight = collapsed ? `${COLLAPSED_HEIGHT}px` : `${full}px`;
+      return;
+    }
+
+    animRef.current?.stop();
+    const full = Math.max(COLLAPSED_HEIGHT, contentHeight);
+    const target = collapsed ? COLLAPSED_HEIGHT : full;
+    animRef.current = animate(el, { maxHeight: `${target}px` }, SPRING);
+    return () => { animRef.current?.stop(); };
+  }, [collapsed, contentHeight]);
+
+  const toggle = useCallback(() => setCollapsed((v) => !v), []);
+
+  const fullHeight = Math.max(COLLAPSED_HEIGHT, contentHeight);
+
+  return (
+    <div
+      data-component="todo-dock"
+      style={{
+        maxHeight: `${fullHeight}px`,
+        overflowX: 'visible',
+        overflowY: 'hidden',
+      }}
+    >
+      <div ref={contentRef}>
+        {/* Header */}
+        <div
+          data-slot="todo-dock-header"
+          role="button"
+          tabIndex={0}
+          onClick={toggle}
+          onKeyDown={(e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            e.preventDefault();
+            toggle();
+          }}
+        >
+          <span data-slot="todo-dock-progress" aria-label={`${done} of ${total}`}>
+            <AnimatedNumber value={done} />
+            <span> of </span>
+            <AnimatedNumber value={total} />
+          </span>
+
+          <div data-slot="todo-dock-preview">
+            {collapsed && preview && (
+              <span data-slot="todo-dock-preview-text">{preview}</span>
+            )}
+          </div>
+
+          <button
+            type="button"
+            data-slot="todo-dock-toggle"
+            onClick={(e) => {
+              e.stopPropagation();
+              toggle();
+            }}
+            aria-label={collapsed ? 'Expand todos' : 'Collapse todos'}
+          >
+            <svg
+              viewBox="0 0 20 20"
+              width="16"
+              height="16"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="square"
+              style={{
+                transform: `rotate(${collapsed ? 180 : 0}deg)`,
+                transition: 'transform 0.2s cubic-bezier(0.22, 1, 0.36, 1)',
+              }}
+            >
+              <path d="M6.6665 8.33325L9.99984 11.6666L13.3332 8.33325" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Todo list */}
+        <div
+          data-slot="todo-dock-body"
+          aria-hidden={collapsed}
+          style={{
+            opacity: collapsed ? 0 : 1,
+            visibility: collapsed ? 'hidden' : 'visible',
+            transition: 'opacity 0.2s cubic-bezier(0.22, 1, 0.36, 1)',
+          }}
+        >
+          <TodoList todos={todos} open={!collapsed} />
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/frontend/components/chat/ToolErrorCard.tsx
+++ b/apps/frontend/components/chat/ToolErrorCard.tsx
@@ -36,10 +36,11 @@ function parseError(tool: string, raw: string) {
       return {
         title: head[0].toUpperCase() + head.slice(1),
         body: parts.slice(1).join(': ').trim() || cleaned,
+        cleaned,
       };
     }
   }
-  return { title: 'Failed', body: cleaned };
+  return { title: 'Failed', body: cleaned, cleaned };
 }
 
 export const ToolErrorCard = memo(function ToolErrorCard({
@@ -49,8 +50,7 @@ export const ToolErrorCard = memo(function ToolErrorCard({
 }: ToolErrorCardProps) {
   const [open, setOpen] = useState(defaultOpen);
   const name = TOOL_NAMES[tool] ?? tool;
-  const { title, body } = parseError(tool, error);
-  const cleaned = error.replace(/^Error:\s*/, '').trim();
+  const { title, body, cleaned } = parseError(tool, error);
 
   return (
     <div data-component="tool-error-card" data-open={open ? 'true' : 'false'}>

--- a/apps/frontend/components/chat/ToolErrorCard.tsx
+++ b/apps/frontend/components/chat/ToolErrorCard.tsx
@@ -1,0 +1,87 @@
+
+import { memo, useState } from 'react';
+import { Ban } from 'lucide-react';
+import { Collapsible } from './Collapsible';
+import { CopyButton } from './CopyButton';
+
+interface ToolErrorCardProps {
+  tool: string;
+  error: string;
+  defaultOpen?: boolean;
+}
+
+const TOOL_NAMES: Record<string, string> = {
+  read: 'Read',
+  list: 'List',
+  glob: 'Glob',
+  grep: 'Grep',
+  task: 'Agent',
+  webfetch: 'Web Fetch',
+  websearch: 'Web Search',
+  bash: 'Shell',
+  edit: 'Edit',
+  write: 'Write',
+  apply_patch: 'Patch',
+  question: 'Questions',
+};
+
+function parseError(tool: string, raw: string) {
+  const cleaned = raw.replace(/^Error:\s*/, '').trim();
+  const prefix = `${tool} `;
+  const tail = cleaned.startsWith(prefix) ? cleaned.slice(prefix.length) : cleaned;
+  const parts = tail.split(': ');
+  if (parts.length > 1) {
+    const head = (parts[0] ?? '').trim();
+    if (head && head.length < 40) {
+      return {
+        title: head[0].toUpperCase() + head.slice(1),
+        body: parts.slice(1).join(': ').trim() || cleaned,
+      };
+    }
+  }
+  return { title: 'Failed', body: cleaned };
+}
+
+export const ToolErrorCard = memo(function ToolErrorCard({
+  tool,
+  error,
+  defaultOpen = false,
+}: ToolErrorCardProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const name = TOOL_NAMES[tool] ?? tool;
+  const { title, body } = parseError(tool, error);
+  const cleaned = error.replace(/^Error:\s*/, '').trim();
+
+  return (
+    <div data-component="tool-error-card" data-open={open ? 'true' : 'false'}>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <Collapsible.Trigger>
+          <div data-component="tool-trigger">
+            <div data-slot="basic-tool-tool-trigger-content">
+              <span data-slot="tool-error-card-icon">
+                <Ban size={14} />
+              </span>
+              <div data-slot="basic-tool-tool-info">
+                <div data-slot="basic-tool-tool-info-structured">
+                  <div data-slot="basic-tool-tool-info-main">
+                    <span data-slot="basic-tool-tool-title">{name}</span>
+                    <span data-slot="basic-tool-tool-subtitle">{title}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <Collapsible.Arrow />
+          </div>
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <div data-slot="tool-error-card-content">
+            <div data-slot="tool-error-card-copy">
+              <CopyButton text={cleaned} />
+            </div>
+            <p data-slot="tool-error-card-body">{body}</p>
+          </div>
+        </Collapsible.Content>
+      </Collapsible>
+    </div>
+  );
+});

--- a/apps/frontend/components/chat/ToolPartView.tsx
+++ b/apps/frontend/components/chat/ToolPartView.tsx
@@ -1,7 +1,8 @@
 
-import React, { memo, useMemo, useState } from 'react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileDiff, FilePart, ToolPart } from '@opencode-ai/sdk/v2/client';
-import { Ban, File as FileIcon } from 'lucide-react';
+import { animate, type AnimationPlaybackControls } from 'motion';
+import { File as FileIcon } from 'lucide-react';
 import { useChatStore } from '@/stores/chatStore';
 import { Collapsible } from './Collapsible';
 import { CopyButton } from './CopyButton';
@@ -10,14 +11,18 @@ import { Icon, getToolIconName } from './Icon';
 import { Markdown } from './Markdown';
 import { getDirectory, getFilename } from '@/lib/path-utils';
 import { TextShimmer } from './TextShimmer';
+import { BasicTool, type TriggerTitle } from './BasicTool';
+import { AnimatedCountList } from './AnimatedCountList';
+import { ToolStatusTitle } from './ToolStatusTitle';
+import { ShellSubmessage } from './ShellSubmessage';
+import { ToolErrorCard } from './ToolErrorCard';
+import { prefersReducedMotion } from './message-helpers';
 
-// Strip ANSI escape codes from text
 function stripAnsi(text: string): string {
   // eslint-disable-next-line no-control-regex
   return text.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
 }
 
-// Tool classification
 const INLINE_TOOLS = new Set(['read', 'glob', 'grep', 'list', 'webfetch', 'skill']);
 const BLOCK_TOOLS = new Set(['bash', 'edit', 'write', 'apply_patch', 'task', 'todowrite', 'question']);
 export const CONTEXT_GROUP_TOOLS = new Set(['read', 'glob', 'grep', 'list']);
@@ -73,6 +78,13 @@ function getRunningLabel(tool: string): string {
     case 'skill': return 'Running skill...';
     default: return 'Running...';
   }
+}
+
+function getCompletedTitle(part: ToolPart): string {
+  if (part.state?.status === 'completed' && 'title' in part.state && typeof part.state.title === 'string') {
+    return part.state.title;
+  }
+  return part.tool;
 }
 
 function getSubtitle(part: ToolPart): string | undefined {
@@ -139,7 +151,7 @@ function getFileDiff(part: ToolPart): FileDiff | undefined {
   return undefined;
 }
 
-// --- Diagnostics types ---
+// Diagnostics types
 
 interface Diagnostic {
   range: {
@@ -186,7 +198,7 @@ function DiagnosticsDisplay({ diagnostics }: { diagnostics: Diagnostic[] }) {
   );
 }
 
-// --- Apply Patch types ---
+// Apply Patch types
 
 interface ApplyPatchFile {
   filePath: string;
@@ -213,7 +225,7 @@ function getApplyPatchFiles(part: ToolPart): ApplyPatchFile[] {
   return [];
 }
 
-// --- TodoWrite types ---
+// TodoWrite types
 
 interface TodoItem {
   content: string;
@@ -234,7 +246,7 @@ function getTodos(part: ToolPart): TodoItem[] {
   return [];
 }
 
-// --- Question types ---
+// Question types
 
 interface QuestionInfo {
   question: string;
@@ -288,6 +300,8 @@ function getBashCommand(part: ToolPart): string {
   return typeof inputRecord?.command === 'string' ? inputRecord.command : '';
 }
 
+// Tool Content Components
+
 function BashToolContent({ part }: { part: ToolPart }) {
   const command = getBashCommand(part);
   const output = part.state?.status === 'completed' && 'output' in part.state ? (part.state.output as string) : '';
@@ -313,7 +327,7 @@ function BashToolContent({ part }: { part: ToolPart }) {
           </pre>
         </div>
       </div>
-      {error && <ToolError error={error} />}
+      {error && <ToolError tool={part.tool} error={error} />}
     </>
   );
 }
@@ -373,6 +387,8 @@ function truncateByLines(text: string, maxLines: number): { truncated: string; t
   return { truncated: lines.slice(0, maxLines).join('\n'), totalLines: lines.length, isTruncated: true };
 }
 
+const TRUNCATE_SPRING = { type: 'spring' as const, visualDuration: 0.35, bounce: 0 };
+
 const TruncatedOutput = memo(function TruncatedOutput({
   text,
   maxLines,
@@ -383,10 +399,38 @@ const TruncatedOutput = memo(function TruncatedOutput({
   cacheKey: string;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const heightAnim = useRef<AnimationPlaybackControls | null>(null);
+  const isFirstRender = useRef(true);
   const { truncated, totalLines, isTruncated } = useMemo(() => truncateByLines(text, maxLines), [text, maxLines]);
 
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    const el = containerRef.current;
+    if (!el || !isTruncated) return;
+
+    if (prefersReducedMotion()) {
+      el.style.height = 'auto';
+      return;
+    }
+
+    heightAnim.current?.stop();
+    el.style.overflow = 'hidden';
+    heightAnim.current = animate(el, { height: 'auto' }, TRUNCATE_SPRING);
+    heightAnim.current.finished.then(() => {
+      if (!containerRef.current) return;
+      containerRef.current.style.overflow = 'visible';
+      containerRef.current.style.height = 'auto';
+    });
+
+    return () => { heightAnim.current?.stop(); };
+  }, [expanded, isTruncated]);
+
   return (
-    <div data-component="tool-output" data-scrollable className="text-xs text-muted-foreground py-1">
+    <div ref={containerRef} data-component="tool-output" data-scrollable className="text-xs text-muted-foreground py-1">
       <Markdown text={expanded ? text : truncated} cacheKey={expanded ? cacheKey : `${cacheKey}-trunc`} />
       {isTruncated && (
         <button
@@ -401,43 +445,6 @@ const TruncatedOutput = memo(function TruncatedOutput({
   );
 });
 
-function ToolTriggerContent({
-  part,
-  isPending,
-  subtitle,
-}: {
-  part: ToolPart;
-  isPending: boolean;
-  subtitle: string | undefined;
-}) {
-  const title = part.state?.status === 'completed' && 'title' in part.state ? part.state.title : part.tool;
-  const icon = getToolIconName(part.tool);
-
-  return (
-    <div className="flex items-center gap-2 min-w-0 flex-1">
-      <Icon name={icon} size="small" />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span
-            className={`text-[14px] leading-[var(--line-height-large,1.5)] font-medium capitalize ${isPending ? 'text-shimmer' : 'text-foreground'}`}
-          >
-            {isPending ? getRunningLabel(part.tool) : title}
-          </span>
-          {!isPending && subtitle && (
-            <>
-              <span className="text-foreground/50">·</span>
-              <span className="text-[14px] leading-[var(--line-height-large,1.5)] text-foreground/70 truncate">
-                {subtitle}
-              </span>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// Lazy-loaded DiffView for edit tool content
 const LazyDiffView = React.lazy(() =>
   import('./DiffView').then((mod) => ({ default: mod.DiffView }))
 );
@@ -449,7 +456,6 @@ function EditToolContent({ part }: { part: ToolPart }) {
   const diagnostics = getDiagnosticsFromPart(part);
 
   if (!fileDiff) {
-    // Fallback: show raw output if no filediff metadata
     const output = part.state?.status === 'completed' && 'output' in part.state ? part.state.output : null;
     return (
       <>
@@ -459,7 +465,7 @@ function EditToolContent({ part }: { part: ToolPart }) {
           </div>
         )}
         <DiagnosticsDisplay diagnostics={diagnostics} />
-        {error && <div className="pl-7"><ToolError error={error} /></div>}
+        {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
       </>
     );
   }
@@ -474,7 +480,7 @@ function EditToolContent({ part }: { part: ToolPart }) {
         </ToolFileAccordion>
       </div>
       <DiagnosticsDisplay diagnostics={diagnostics} />
-      {error && <div className="pl-7"><ToolError error={error} /></div>}
+      {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
     </>
   );
 }
@@ -487,7 +493,6 @@ function WriteToolContent({ part }: { part: ToolPart }) {
   const diagnostics = getDiagnosticsFromPart(part);
 
   if (fileDiff) {
-    // If write tool has filediff (overwriting existing file), show diff
     return (
       <>
         <div data-component="edit-content">
@@ -498,7 +503,7 @@ function WriteToolContent({ part }: { part: ToolPart }) {
           </ToolFileAccordion>
         </div>
         <DiagnosticsDisplay diagnostics={diagnostics} />
-        {error && <div className="pl-7"><ToolError error={error} /></div>}
+        {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
       </>
     );
   }
@@ -513,7 +518,7 @@ function WriteToolContent({ part }: { part: ToolPart }) {
           </div>
         )}
         <DiagnosticsDisplay diagnostics={diagnostics} />
-        {error && <div className="pl-7"><ToolError error={error} /></div>}
+        {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
       </>
     );
   }
@@ -526,7 +531,7 @@ function WriteToolContent({ part }: { part: ToolPart }) {
         </ToolFileAccordion>
       </div>
       <DiagnosticsDisplay diagnostics={diagnostics} />
-      {error && <div className="pl-7"><ToolError error={error} /></div>}
+      {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
     </>
   );
 }
@@ -538,76 +543,11 @@ function ApplyPatchTypeBadge({ type }: { type: ApplyPatchFile['type'] }) {
   return <span data-slot="apply-patch-change" data-type={dataType}>{label}</span>;
 }
 
-function ApplyPatchTrigger({ part, isPending, files }: { part: ToolPart; isPending: boolean; files: ApplyPatchFile[] }) {
-  const single = files.length === 1 ? files[0] : undefined;
-
-  if (single) {
-    // Single-file: render like EditWriteTrigger
-    const filename = getFilename(single.relativePath);
-    const directory = single.relativePath.includes('/') ? getDirectory(single.relativePath) : '';
-
-    return (
-      <div data-component="edit-trigger">
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <Icon name="code-lines" size="small" />
-          <div data-slot="message-part-title-area">
-            <div data-slot="message-part-title">
-              <span data-slot="message-part-title-text" className={isPending ? 'text-shimmer' : ''}>
-                {isPending ? getRunningLabel('apply_patch') : 'Patch'}
-              </span>
-              {!isPending && filename && (
-                <span data-slot="message-part-title-filename">{filename}</span>
-              )}
-            </div>
-            {!isPending && directory && (
-              <div data-slot="message-part-path">
-                <span data-slot="message-part-directory">{directory}</span>
-              </div>
-            )}
-          </div>
-        </div>
-        <div data-slot="message-part-actions">
-          {!isPending && (
-            <DiffChanges changes={{ additions: single.additions, deletions: single.deletions }} />
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  // Multi-file: show "Patch" + file count subtitle
-  const subtitle = files.length > 0 ? `${files.length} file${files.length > 1 ? 's' : ''}` : '';
-
-  return (
-    <div className="flex items-center gap-2 min-w-0 flex-1">
-      <Icon name="code-lines" size="small" />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span
-            className={`text-[14px] leading-[var(--line-height-large,1.5)] font-medium ${isPending ? 'text-shimmer' : 'text-foreground'}`}
-          >
-            {isPending ? getRunningLabel('apply_patch') : 'Patch'}
-          </span>
-          {!isPending && subtitle && (
-            <>
-              <span className="text-foreground/50">·</span>
-              <span className="text-[14px] leading-[var(--line-height-large,1.5)] text-foreground/70 truncate">
-                {subtitle}
-              </span>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function ApplyPatchContent({ part, files }: { part: ToolPart; files: ApplyPatchFile[] }) {
   const error = part.state?.status === 'error' && 'error' in part.state ? (part.state.error as string) : null;
   const single = files.length === 1 ? files[0] : undefined;
 
   if (files.length === 0) {
-    // Fallback: show raw output if no files metadata
     const output = part.state?.status === 'completed' && 'output' in part.state ? part.state.output : null;
     return (
       <>
@@ -616,13 +556,12 @@ function ApplyPatchContent({ part, files }: { part: ToolPart; files: ApplyPatchF
             <Markdown text={output} cacheKey={`${part.id}-fallback`} />
           </div>
         )}
-        {error && <div className="pl-7"><ToolError error={error} /></div>}
+        {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
       </>
     );
   }
 
   if (single) {
-    // Single file: like edit tool content with type badge
     const actions = single.type === 'update'
       ? <DiffChanges changes={{ additions: single.additions, deletions: single.deletions }} />
       : <ApplyPatchTypeBadge type={single.type} />;
@@ -638,12 +577,11 @@ function ApplyPatchContent({ part, files }: { part: ToolPart; files: ApplyPatchF
             </div>
           </ToolFileAccordion>
         </div>
-        {error && <div className="pl-7"><ToolError error={error} /></div>}
+        {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
       </>
     );
   }
 
-  // Multi-file accordion
   return (
     <>
       <div data-component="apply-patch-files">
@@ -651,7 +589,7 @@ function ApplyPatchContent({ part, files }: { part: ToolPart; files: ApplyPatchF
           <ApplyPatchFileEntry key={file.filePath} file={file} />
         ))}
       </div>
-      {error && <div className="pl-7"><ToolError error={error} /></div>}
+      {error && <div className="pl-7"><ToolError tool={part.tool} error={error} /></div>}
     </>
   );
 }
@@ -678,14 +616,18 @@ function ApplyPatchFileEntry({ file }: { file: ApplyPatchFile }) {
             <FileIcon className="size-4 text-muted-foreground flex-shrink-0" />
             <div data-slot="apply-patch-file-name-container">
               {directory && (
-                <span data-slot="apply-patch-directory">{'\u202A' + directory + '\u202C'}</span>
+                <span data-slot="apply-patch-directory">{'\u202A' + directory + '/' + '\u202C'}</span>
               )}
               <span data-slot="apply-patch-filename">{filename}</span>
             </div>
           </div>
           <div data-slot="apply-patch-trigger-actions">
             {actions}
-            <Icon name="chevron-grabber-vertical" size="small" className="text-muted-foreground" />
+            <div data-slot="file-accordion-arrow" data-open={open || undefined}>
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M2.5 3.5L5 6.5L7.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
           </div>
         </div>
       </button>
@@ -720,14 +662,18 @@ function ToolFileAccordion({ path, actions, children }: { path: string; actions?
             <FileIcon className="size-4 text-muted-foreground flex-shrink-0" />
             <div data-slot="tool-file-name-container">
               {directory && (
-                <span data-slot="tool-file-directory">{'\u202A' + directory + '\u202C'}</span>
+                <span data-slot="tool-file-directory">{'\u202A' + directory + '/' + '\u202C'}</span>
               )}
               <span data-slot="tool-file-filename">{filename}</span>
             </div>
           </div>
           <div data-slot="tool-file-trigger-actions">
             {actions}
-            <Icon name="chevron-grabber-vertical" size="small" className="text-muted-foreground" />
+            <div data-slot="file-accordion-arrow" data-open={open || undefined}>
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M2.5 3.5L5 6.5L7.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
           </div>
         </div>
       </button>
@@ -736,45 +682,56 @@ function ToolFileAccordion({ path, actions, children }: { path: string; actions?
   );
 }
 
-function EditWriteTrigger({ part, isPending }: { part: ToolPart; isPending: boolean }) {
+// Build trigger objects
+
+function buildTriggerTitle(part: ToolPart): TriggerTitle {
+  const isPending = part.state?.status === 'pending' || part.state?.status === 'running';
+  const title = isPending ? getRunningLabel(part.tool) : getCompletedTitle(part);
+  const subtitle = isPending ? undefined : getSubtitle(part);
+  // Don't show subtitle if it matches the title (e.g. bash description = title)
+  return { title, subtitle: subtitle === title ? undefined : subtitle };
+}
+
+function buildEditTrigger(part: ToolPart): TriggerTitle {
+  const isPending = part.state?.status === 'pending' || part.state?.status === 'running';
   const filePath = getInputFilePath(part) || '';
   const filename = getFilename(filePath);
   const directory = filePath.includes('/') || filePath.includes('\\') ? getDirectory(filePath) : '';
   const fileDiff = getFileDiff(part);
   const title = part.tool === 'edit' ? 'Edit' : 'Write';
 
-  return (
-    <div data-component="edit-trigger">
-      <div className="flex items-center gap-2 min-w-0 flex-1">
-        <Icon name="code-lines" size="small" />
-        <div data-slot="message-part-title-area">
-          <div data-slot="message-part-title">
-            <span data-slot="message-part-title-text" className={isPending ? 'text-shimmer' : ''}>
-              {isPending ? getRunningLabel(part.tool) : title}
-            </span>
-            {!isPending && filename && (
-              <span data-slot="message-part-title-filename">{filename}</span>
-            )}
-          </div>
-          {!isPending && directory && (
-            <div data-slot="message-part-path">
-              <span data-slot="message-part-directory">{directory}</span>
-            </div>
-          )}
-        </div>
-      </div>
-      <div data-slot="message-part-actions">
-        {!isPending && fileDiff && <DiffChanges changes={fileDiff} />}
-      </div>
-    </div>
-  );
+  return {
+    title: isPending ? getRunningLabel(part.tool) : title,
+    subtitle: !isPending && filename ? filename : undefined,
+    args: !isPending && directory ? [directory] : undefined,
+    action: !isPending && fileDiff ? <DiffChanges changes={fileDiff} /> : undefined,
+  };
 }
 
-function toolDefaultOpen(tool: string, shellExpanded: boolean, editExpanded: boolean): boolean {
-  if (tool === 'bash') return shellExpanded;
-  if (tool === 'edit' || tool === 'write' || tool === 'apply_patch') return editExpanded;
-  return false;
+function buildApplyPatchTrigger(part: ToolPart, files: ApplyPatchFile[]): TriggerTitle {
+  const isPending = part.state?.status === 'pending' || part.state?.status === 'running';
+  const single = files.length === 1 ? files[0] : undefined;
+
+  if (single) {
+    const filename = getFilename(single.relativePath);
+    const directory = single.relativePath.includes('/') ? getDirectory(single.relativePath) : '';
+
+    return {
+      title: isPending ? getRunningLabel('apply_patch') : 'Patch',
+      subtitle: !isPending && filename ? filename : undefined,
+      args: !isPending && directory ? [directory] : undefined,
+      action: !isPending ? <DiffChanges changes={{ additions: single.additions, deletions: single.deletions }} /> : undefined,
+    };
+  }
+
+  const subtitle = files.length > 0 ? `${files.length} file${files.length > 1 ? 's' : ''}` : '';
+  return {
+    title: isPending ? getRunningLabel('apply_patch') : 'Patch',
+    subtitle: isPending ? undefined : subtitle,
+  };
 }
+
+// ToolPartView
 
 export function ToolPartView({ part }: ToolPartViewProps) {
   const status = part.state?.status ?? 'pending';
@@ -792,129 +749,144 @@ export function ToolPartView({ part }: ToolPartViewProps) {
   const hasOutput = !!output && part.tool !== 'read';
   const hasContent = hasOutput || !!error || (attachments && attachments.length > 0) || loadedFiles.length > 0;
 
-  // Inline tools: compact row, collapsible only when content exists
+  // Inline tools
   if (isInline) {
-    if (!hasContent) {
-      return (
-        <div className="flex items-center gap-5 py-1 px-2 text-left">
-          <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-        </div>
-      );
-    }
+    const triggerTitle = buildTriggerTitle(part);
+    const icon = getToolIconName(part.tool);
+    const content = hasContent ? (
+      <div className="pl-7 mt-1 space-y-1">
+        <ToolContentBody
+          part={part}
+          output={output}
+          error={error}
+          attachments={attachments}
+          loadedFiles={loadedFiles}
+          maxOutputLines={3}
+        />
+      </div>
+    ) : undefined;
 
     return (
-      <Collapsible defaultOpen={false}>
-        <Collapsible.Trigger
-          className="w-full flex items-center gap-5 py-1 px-2 rounded hover:bg-muted/30 transition-colors text-left"
-        >
-          <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-          <Collapsible.Arrow className="text-muted-foreground" />
-        </Collapsible.Trigger>
-        <Collapsible.Content className="pl-7 mt-1 space-y-1">
-          <ToolContentBody
-            part={part}
-            output={output}
-            error={error}
-            attachments={attachments}
-            loadedFiles={loadedFiles}
-            maxOutputLines={3}
-          />
-        </Collapsible.Content>
-      </Collapsible>
+      <BasicTool
+        icon={icon}
+        trigger={triggerTitle}
+        status={status}
+        defaultOpen={false}
+        hideDetails={!hasContent}
+      >
+        {content}
+      </BasicTool>
     );
   }
 
-  // Apply Patch tool: specialized multi-file accordion
+  // Apply Patch
   if (part.tool === 'apply_patch') {
     const files = getApplyPatchFiles(part);
     const defaultOpen = status === 'completed' && editExpanded;
+    const trigger = buildApplyPatchTrigger(part, files);
 
     return (
       <div data-component="apply-patch-tool">
-        <Collapsible defaultOpen={defaultOpen}>
-          <Collapsible.Trigger
-            className="w-full flex items-center gap-5 py-1.5 px-2 rounded hover:bg-muted/30 transition-colors text-left"
-          >
-            <ApplyPatchTrigger part={part} isPending={isPending} files={files} />
-            {!isPending && <Collapsible.Arrow className="text-muted-foreground" />}
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <ApplyPatchContent part={part} files={files} />
-          </Collapsible.Content>
-        </Collapsible>
+        <BasicTool
+          icon="code-lines"
+          trigger={trigger}
+          status={status}
+          defaultOpen={defaultOpen}
+          defer
+        >
+          <ApplyPatchContent part={part} files={files} />
+        </BasicTool>
       </div>
     );
   }
 
-  // Edit/Write tools: specialized rendering with diff viewer
+  // Edit/Write
   if (part.tool === 'edit' || part.tool === 'write') {
     const defaultOpen = status === 'completed' && editExpanded;
+    const trigger = buildEditTrigger(part);
 
     return (
       <div data-component={part.tool === 'edit' ? 'edit-tool' : 'write-tool'}>
-        <Collapsible defaultOpen={defaultOpen}>
-          <Collapsible.Trigger
-            className="w-full flex items-center gap-5 py-1.5 px-2 rounded hover:bg-muted/30 transition-colors text-left"
-          >
-            <EditWriteTrigger part={part} isPending={isPending} />
-            {!isPending && <Collapsible.Arrow className="text-muted-foreground" />}
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            {part.tool === 'edit' ? (
-              <EditToolContent part={part} />
-            ) : (
-              <WriteToolContent part={part} />
-            )}
-          </Collapsible.Content>
-        </Collapsible>
+        <BasicTool
+          icon="code-lines"
+          trigger={trigger}
+          status={status}
+          defaultOpen={defaultOpen}
+          defer
+        >
+          {part.tool === 'edit' ? (
+            <EditToolContent part={part} />
+          ) : (
+            <WriteToolContent part={part} />
+          )}
+        </BasicTool>
       </div>
     );
   }
 
-  // Bash tool: dedicated output block with $ command format
+  // Bash
   if (part.tool === 'bash') {
     const defaultOpen = status === 'completed' && shellExpanded;
+    const title = isPending ? getRunningLabel(part.tool) : getCompletedTitle(part);
+    const bashSubtitle = isPending ? undefined : getSubtitle(part);
+    const bashTrigger: TriggerTitle = {
+      title,
+      subtitle: undefined,
+      action: bashSubtitle && bashSubtitle !== title ? (
+        <ShellSubmessage text={bashSubtitle} animated={!isPending} />
+      ) : undefined,
+    };
 
     return (
       <div data-component="bash-tool">
-        <Collapsible defaultOpen={defaultOpen}>
-          <Collapsible.Trigger
-            className="w-full flex items-center gap-5 py-1.5 px-2 rounded hover:bg-muted/30 transition-colors text-left"
-          >
-            <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-            {!isPending && <Collapsible.Arrow className="text-muted-foreground" />}
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <BashToolContent part={part} />
-          </Collapsible.Content>
-        </Collapsible>
+        <BasicTool
+          icon="console"
+          trigger={bashTrigger}
+          status={status}
+          defaultOpen={defaultOpen}
+        >
+          <BashToolContent part={part} />
+        </BasicTool>
       </div>
     );
   }
 
-  // TodoWrite tool: always expanded, locked open
+  // TodoWrite
   if (part.tool === 'todowrite') {
+    const todos = getTodos(part);
+    const completed = todos.filter((t) => t.status === 'completed').length;
+    const subtitle = todos.length > 0 ? `${completed}/${todos.length}` : undefined;
+
     return (
       <div data-component="todowrite-tool">
-        <div className="flex items-center gap-5 py-1.5 px-2 text-left">
-          <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-        </div>
-        {!isPending && <TodoWriteToolContent part={part} />}
+        <BasicTool
+          icon="checklist"
+          trigger={{ title: 'Todos', subtitle }}
+          status={status}
+          locked
+          forceOpen
+        >
+          {!isPending && <TodoWriteToolContent part={part} />}
+        </BasicTool>
       </div>
     );
   }
 
-  // Question tool: show answered Q&A pairs when completed, or "Dismissed" for dismissed questions
+  // Question
   if (part.tool === 'question') {
     const questionError = status === 'error' && 'error' in part.state ? (part.state.error as string) : null;
     const isDismissed = questionError?.replace('Error: ', '').includes('dismissed this question');
+    const triggerTitle = buildTriggerTitle(part);
 
     if (isDismissed) {
       return (
         <div data-component="question-tool">
-          <div className="flex items-center gap-5 py-1.5 px-2 text-left">
-            <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-          </div>
+          <BasicTool
+            icon="bubble-5"
+            trigger={triggerTitle}
+            status={status}
+            hideDetails
+          />
           <div className="flex justify-end w-full px-2 pb-1">
             <span className="text-sm text-muted-foreground cursor-default">Dismissed</span>
           </div>
@@ -927,93 +899,65 @@ export function ToolPartView({ part }: ToolPartViewProps) {
 
     return (
       <div data-component="question-tool">
-        <Collapsible defaultOpen={completed}>
-          <Collapsible.Trigger
-            className="w-full flex items-center gap-5 py-1.5 px-2 rounded hover:bg-muted/30 transition-colors text-left"
-          >
-            <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-            {!isPending && <Collapsible.Arrow className="text-muted-foreground" />}
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <QuestionToolContent part={part} />
-          </Collapsible.Content>
-        </Collapsible>
+        <BasicTool
+          icon="bubble-5"
+          trigger={triggerTitle}
+          status={status}
+          defaultOpen={completed}
+        >
+          <QuestionToolContent part={part} />
+        </BasicTool>
       </div>
     );
   }
 
-  // Task/subagent tool: TextShimmer title, description subtitle, no collapsible content
+  // Task/subagent
   if (part.tool === 'task') {
     const { subagentType, description } = getTaskInfo(part);
     const title = `Agent${subagentType ? `: ${subagentType}` : ''}`;
 
     return (
       <div data-component="task-tool">
-        <div className="flex items-center gap-2 py-1.5 px-2 text-left min-w-0">
-          <Icon name="task" size="small" />
-          <div className="flex items-center gap-2 min-w-0 flex-1">
-            <span className="text-[14px] leading-[var(--line-height-large,1.5)] font-medium capitalize flex-shrink-0">
-              <TextShimmer text={title} active={isPending} />
-            </span>
-            {!isPending && description && (
-              <>
-                <span className="text-foreground/50">·</span>
-                <span className="text-[14px] leading-[var(--line-height-large,1.5)] text-foreground/70 truncate">
-                  {description}
-                </span>
-              </>
-            )}
-          </div>
-        </div>
+        <BasicTool
+          icon="task"
+          trigger={{ title, subtitle: description }}
+          status={status}
+          hideDetails
+        />
       </div>
     );
   }
 
-  // Block tools: per-tool-type default open (matching OpenCode)
-  const defaultOpen = status === 'completed' && hasContent && toolDefaultOpen(part.tool, shellExpanded, editExpanded);
+  // Fallback for unknown block tools
+  const defaultOpen = status === 'completed' && hasContent;
+  const triggerTitle = buildTriggerTitle(part);
+  const icon = getToolIconName(part.tool);
 
   return (
-    <Collapsible defaultOpen={defaultOpen}>
-      <Collapsible.Trigger
-        className="w-full flex items-center gap-5 py-1.5 px-2 rounded hover:bg-muted/30 transition-colors text-left"
-      >
-        <ToolTriggerContent part={part} isPending={isPending} subtitle={subtitle} />
-        {hasContent && (
-          <Collapsible.Arrow className="text-muted-foreground" />
-        )}
-      </Collapsible.Trigger>
-      <Collapsible.Content className="pl-7 mt-1 space-y-1">
-        <ToolContentBody
-          part={part}
-          output={output}
-          error={error}
-          attachments={attachments}
-          loadedFiles={loadedFiles}
-          maxOutputLines={part.tool === 'bash' ? 10 : 3}
-        />
-      </Collapsible.Content>
-    </Collapsible>
+    <BasicTool
+      icon={icon}
+      trigger={triggerTitle}
+      status={status}
+      defaultOpen={defaultOpen}
+    >
+      {hasContent && (
+        <div className="pl-7 mt-1 space-y-1">
+          <ToolContentBody
+            part={part}
+            output={output}
+            error={error}
+            attachments={attachments}
+            loadedFiles={loadedFiles}
+            maxOutputLines={part.tool === 'bash' ? 10 : 3}
+          />
+        </div>
+      )}
+    </BasicTool>
   );
 }
 
-function ToolError({ error }: { error: string }) {
-  const cleaned = error.replace(/^Error:\s*/, '');
-  const [title, ...rest] = cleaned.split(': ');
-  const hasStructuredTitle = title && title.length < 30 && rest.length > 0;
-
-  return (
-    <div data-component="tool-error">
-      <Ban size={14} className="tool-error-icon" />
-      {hasStructuredTitle ? (
-        <div data-slot="tool-error-content">
-          <span data-slot="tool-error-title">{title}</span>
-          <span data-slot="tool-error-message">{rest.join(': ')}</span>
-        </div>
-      ) : (
-        <span data-slot="tool-error-message">{cleaned}</span>
-      )}
-    </div>
-  );
+function ToolError({ tool, error }: { tool: string; error: string }) {
+  return <ToolErrorCard tool={tool} error={error} />;
 }
 
 function ToolContentBody({
@@ -1047,22 +991,19 @@ function ToolContentBody({
         <TruncatedOutput text={output} maxLines={maxOutputLines} cacheKey={part.id} />
       )}
       {attachments && attachments.length > 0 && <AttachmentList parts={attachments} />}
-      {error && <ToolError error={error} />}
+      {error && <ToolError tool={part.tool} error={error} />}
     </>
   );
 }
 
-// --- Context Tool Grouping ---
+// Context Tool Grouping
 
-function contextToolSummary(parts: ToolPart[], running: boolean): string[] {
-  const read = parts.filter((p) => p.tool === 'read').length;
-  const search = parts.filter((p) => p.tool === 'glob' || p.tool === 'grep').length;
-  const list = parts.filter((p) => p.tool === 'list').length;
-  return [
-    read ? (running ? `Reading ${read} file${read > 1 ? 's' : ''}` : `${read} file${read > 1 ? 's' : ''} read`) : undefined,
-    search ? (running ? `Searching ${search} pattern${search > 1 ? 's' : ''}` : `${search} pattern${search > 1 ? 's' : ''} searched`) : undefined,
-    list ? (running ? `Listing ${list} director${list > 1 ? 'ies' : 'y'}` : `${list} director${list > 1 ? 'ies' : 'y'} listed`) : undefined,
-  ].filter((v): v is string => !!v);
+function contextToolSummary(parts: ToolPart[]) {
+  return {
+    read: parts.filter((p) => p.tool === 'read').length,
+    search: parts.filter((p) => p.tool === 'glob' || p.tool === 'grep').length,
+    list: parts.filter((p) => p.tool === 'list').length,
+  };
 }
 
 function contextToolTriggerInfo(part: ToolPart): { title: string; subtitle?: string; args?: string[] } {
@@ -1075,8 +1016,8 @@ function contextToolTriggerInfo(part: ToolPart): { title: string; subtitle?: str
   const offset = typeof inputRecord?.offset === 'number' ? inputRecord.offset : undefined;
   const limit = typeof inputRecord?.limit === 'number' ? inputRecord.limit : undefined;
 
-  const getFilename = (p: string) => p.split(/[/\\]/).pop() || p;
-  const getDirectory = (p: string) => {
+  const _getFilename = (p: string) => p.split(/[/\\]/).pop() || p;
+  const _getDirectory = (p: string) => {
     const parts = p.split(/[/\\]/);
     return parts.length > 1 ? parts.slice(-2).join('/') : parts.pop() || p;
   };
@@ -1086,17 +1027,17 @@ function contextToolTriggerInfo(part: ToolPart): { title: string; subtitle?: str
       const args: string[] = [];
       if (offset !== undefined) args.push('offset=' + offset);
       if (limit !== undefined) args.push('limit=' + limit);
-      return { title: 'Read', subtitle: filePath ? getFilename(filePath) : undefined, args };
+      return { title: 'Read', subtitle: filePath ? _getFilename(filePath) : undefined, args };
     }
     case 'list':
-      return { title: 'List', subtitle: getDirectory(path) };
+      return { title: 'List', subtitle: _getDirectory(path) };
     case 'glob':
-      return { title: 'Glob', subtitle: getDirectory(path), args: pattern ? ['pattern=' + pattern] : [] };
+      return { title: 'Glob', subtitle: _getDirectory(path), args: pattern ? ['pattern=' + pattern] : [] };
     case 'grep': {
       const args: string[] = [];
       if (pattern) args.push('pattern=' + pattern);
       if (include) args.push('include=' + include);
-      return { title: 'Grep', subtitle: getDirectory(path), args };
+      return { title: 'Grep', subtitle: _getDirectory(path), args };
     }
     default:
       return { title: part.tool };
@@ -1113,8 +1054,7 @@ export const ContextToolGroup = memo(function ContextToolGroup({ parts, busy }: 
     () => !!busy || parts.some((p) => p.state?.status === 'pending' || p.state?.status === 'running'),
     [parts, busy],
   );
-  const summary = useMemo(() => contextToolSummary(parts, pending), [parts, pending]);
-  const details = summary.join(', ');
+  const summary = useMemo(() => contextToolSummary(parts), [parts]);
 
   return (
     <Collapsible defaultOpen={false}>
@@ -1122,11 +1062,23 @@ export const ContextToolGroup = memo(function ContextToolGroup({ parts, busy }: 
         <div data-component="context-tool-group-trigger">
           <span data-slot="context-tool-group-title">
             <span data-slot="context-tool-group-label">
-              {pending ? <TextShimmer text="Gathering context..." /> : 'Gathered context'}
+              <ToolStatusTitle
+                active={pending}
+                activeText="Gathering context..."
+                doneText="Gathered context"
+                split={false}
+              />
             </span>
-            {details.length > 0 && (
-              <span data-slot="context-tool-group-summary">{details}</span>
-            )}
+            <span data-slot="context-tool-group-summary">
+              <AnimatedCountList
+                items={[
+                  { key: 'read', count: summary.read, one: '{{count}} read', other: '{{count}} reads' },
+                  { key: 'search', count: summary.search, one: '{{count}} search', other: '{{count}} searches' },
+                  { key: 'list', count: summary.list, one: '{{count}} list', other: '{{count}} lists' },
+                ]}
+                fallback=""
+              />
+            </span>
           </span>
           <Collapsible.Arrow />
         </div>
@@ -1140,7 +1092,7 @@ export const ContextToolGroup = memo(function ContextToolGroup({ parts, busy }: 
               <div key={part.id} data-slot="context-tool-group-item">
                 <div data-slot="basic-tool-tool-info-main">
                   <span data-slot="basic-tool-tool-title">
-                    {running ? <TextShimmer text={info.title} /> : info.title}
+                    <TextShimmer text={info.title} active={running} />
                   </span>
                   {!running && info.subtitle && (
                     <span data-slot="basic-tool-tool-subtitle">{info.subtitle}</span>
@@ -1157,3 +1109,4 @@ export const ContextToolGroup = memo(function ContextToolGroup({ parts, busy }: 
     </Collapsible>
   );
 });
+

--- a/apps/frontend/components/chat/ToolStatusTitle.tsx
+++ b/apps/frontend/components/chat/ToolStatusTitle.tsx
@@ -1,0 +1,104 @@
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { TextShimmer } from './TextShimmer';
+
+function commonPrefix(active: string, done: string) {
+  const a = Array.from(active);
+  const b = Array.from(done);
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return {
+    prefix: a.slice(0, i).join(''),
+    active: a.slice(i).join(''),
+    done: b.slice(i).join(''),
+  };
+}
+
+function contentWidth(el: HTMLSpanElement | null) {
+  if (!el) return 0;
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  return Math.ceil(range.getBoundingClientRect().width);
+}
+
+export const ToolStatusTitle = memo(function ToolStatusTitle({
+  active,
+  activeText,
+  doneText,
+  split: splitProp = true,
+  className,
+}: {
+  active: boolean;
+  activeText: string;
+  doneText: string;
+  split?: boolean;
+  className?: string;
+}) {
+  const s = useMemo(() => commonPrefix(activeText, doneText), [activeText, doneText]);
+  const useSuffix = splitProp && s.prefix.length >= 2 && s.active.length > 0 && s.done.length > 0;
+  const prefixLen = Array.from(s.prefix).length;
+  const activeTail = useSuffix ? s.active : activeText;
+  const doneTail = useSuffix ? s.done : doneText;
+
+  const activeRef = useRef<HTMLSpanElement>(null);
+  const doneRef = useRef<HTMLSpanElement>(null);
+  const [width, setWidth] = useState('auto');
+  const [ready, setReady] = useState(false);
+
+  const measure = useCallback(() => {
+    const target = active ? activeRef.current : doneRef.current;
+    const px = contentWidth(target);
+    if (px > 0) setWidth(`${px}px`);
+  }, [active]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(measure);
+    return () => cancelAnimationFrame(frame);
+  }, [active, activeTail, doneTail, useSuffix, measure]);
+
+  useEffect(() => {
+    measure();
+    document.fonts?.ready.finally(() => {
+      measure();
+      requestAnimationFrame(() => setReady(true));
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const label = active ? activeText : doneText;
+
+  return (
+    <span
+      data-component="tool-status-title"
+      data-active={active ? 'true' : 'false'}
+      data-ready={ready ? 'true' : 'false'}
+      data-mode={useSuffix ? 'suffix' : 'swap'}
+      className={className}
+      aria-label={label}
+    >
+      {useSuffix ? (
+        <span data-slot="tool-status-suffix">
+          <span data-slot="tool-status-prefix">
+            <TextShimmer text={s.prefix} active={active} offset={0} />
+          </span>
+          <span data-slot="tool-status-tail" style={{ width }}>
+            <span data-slot="tool-status-active" ref={activeRef}>
+              <TextShimmer text={activeTail} active={active} offset={prefixLen} />
+            </span>
+            <span data-slot="tool-status-done" ref={doneRef}>
+              <TextShimmer text={doneTail} active={false} offset={prefixLen} />
+            </span>
+          </span>
+        </span>
+      ) : (
+        <span data-slot="tool-status-swap" style={{ width }}>
+          <span data-slot="tool-status-active" ref={activeRef}>
+            <TextShimmer text={activeTail} active={active} offset={0} />
+          </span>
+          <span data-slot="tool-status-done" ref={doneRef}>
+            <TextShimmer text={doneTail} active={false} offset={0} />
+          </span>
+        </span>
+      )}
+    </span>
+  );
+});

--- a/apps/frontend/components/chat/Turn.tsx
+++ b/apps/frontend/components/chat/Turn.tsx
@@ -130,7 +130,6 @@ export function Turn({ turn, sessionId, isWorking, onInteract, showThinking = tr
     return { meta, interrupted: isInterrupted(lastAssistant) };
   }, [lastAssistant, isWorking, turn.assistantMessages, turn.userMessage, providers]);
 
-  // Generation-level error: find the first non-abort error from assistant messages
   const generationError = useMemo(() => {
     const errMsg = turn.assistantMessages.find(
       (m) => m.error && m.error.name !== 'MessageAbortedError',
@@ -325,7 +324,7 @@ type AssistantPartsMessageProps = {
   footerMeta?: FooterMeta;
 };
 
-const HIDDEN_TOOLS = new Set(['todoread']);
+const HIDDEN_TOOLS = new Set(['todoread', 'todowrite']);
 
 type GroupedItem =
   | { type: 'part'; part: Part; key: string }
@@ -343,12 +342,9 @@ function groupParts(parts: Part[], showThinking: boolean): GroupedItem[] {
   };
 
   for (const part of parts) {
-    // Skip hidden tools
     if (isTool(part) && HIDDEN_TOOLS.has(part.tool)) continue;
-    // Skip reasoning when hidden
     if (isReasoning(part) && !showThinking) continue;
 
-    // Group context tools
     if (isTool(part) && CONTEXT_GROUP_TOOLS.has(part.tool)) {
       contextBuffer.push(part);
       continue;

--- a/apps/frontend/components/chat/message-helpers.ts
+++ b/apps/frontend/components/chat/message-helpers.ts
@@ -14,6 +14,10 @@ import type {
   AssistantMessage,
 } from '@opencode-ai/sdk/v2/client';
 
+export function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 export type MessageTurn = {
   userMessage: Message;
   assistantMessages: AssistantMessage[];
@@ -194,10 +198,6 @@ export function isInterrupted(message: AssistantMessage): boolean {
   return message.error?.name === 'MessageAbortedError';
 }
 
-/**
- * Recursively extract a human-readable error message from a possibly-nested
- * JSON error structure. Ported from OpenCode's session-turn.tsx `unwrap`.
- */
 export function unwrapError(message: string): string {
   const text = message.replace(/^Error:\s*/, '').trim();
 

--- a/apps/frontend/components/chat/provider-icons/types.ts
+++ b/apps/frontend/components/chat/provider-icons/types.ts
@@ -79,3 +79,6 @@ export const iconNames = [
 ] as const
 
 export type IconName = (typeof iconNames)[number]
+
+export const resolveProviderIcon = (id: string): IconName =>
+  iconNames.includes(id as IconName) ? (id as IconName) : 'synthetic';

--- a/apps/frontend/components/editor/FileHeader.tsx
+++ b/apps/frontend/components/editor/FileHeader.tsx
@@ -163,8 +163,8 @@ export function FileHeader({
     }
   }, []);
 
-  // Tangent uses --headerFontSizeFactor of ~2.5, we use 3 for bigger title
-  const fontSizeFactor = 3;
+  // Tangent uses --headerFontSizeFactor of ~2.5
+  const fontSizeFactor = 2;
   const contentPaddingX = 'var(--md-content-padding-x, 1.25em)';
   const horizontalPadding = `calc(${contentPaddingX} / ${fontSizeFactor})`;
   const headerMaxWidth =
@@ -190,7 +190,7 @@ export function FileHeader({
         margin: '0 auto',
         boxSizing: 'border-box',
         /* Scale padding from body text space to title space */
-        paddingTop: `calc(4em / ${fontSizeFactor})`,
+        paddingTop: `calc(2em / ${fontSizeFactor})`,
         paddingBottom: `calc(0.8em / ${fontSizeFactor})`,
         paddingLeft: horizontalPadding,
         paddingRight: horizontalPadding,

--- a/apps/frontend/components/quick-switcher/QuickSwitcher.tsx
+++ b/apps/frontend/components/quick-switcher/QuickSwitcher.tsx
@@ -7,6 +7,7 @@ import type { FileTreeNode } from '@cushion/types';
 import { formatShortcutList, matchShortcut, useShortcutBindings } from '@/lib/shortcuts';
 import { getBaseName, getDirectory } from '@/lib/path-utils';
 import { cn } from '@/lib/utils';
+import { FolderIcon, FileIcon } from '@/components/shared/FileIcons';
 
 interface QuickSwitcherProps {
   isOpen: boolean;
@@ -81,38 +82,6 @@ function HighlightedText({ text, matchIndices }: { text: string; matchIndices?: 
   return <>{parts}</>;
 }
 
-function FolderIcon({ className }: { className?: string }) {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
-      <path
-        d="M2.5 5.5C2.5 4.39543 3.39543 3.5 4.5 3.5H7.08579C7.35097 3.5 7.60536 3.60536 7.79289 3.79289L9.20711 5.20711C9.39464 5.39464 9.64903 5.5 9.91421 5.5H15.5C16.6046 5.5 17.5 6.39543 17.5 7.5V14.5C17.5 15.6046 16.6046 16.5 15.5 16.5H4.5C3.39543 16.5 2.5 15.6046 2.5 14.5V5.5Z"
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function FileIcon({ className }: { className?: string }) {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
-      <path
-        d="M5 3.5C4.72386 3.5 4.5 3.72386 4.5 4V16C4.5 16.2761 4.72386 16.5 5 16.5H15C15.2761 16.5 15.5 16.2761 15.5 16V7.41421C15.5 7.28161 15.4473 7.15443 15.3536 7.06066L11.9393 3.64645C11.8456 3.55268 11.7184 3.5 11.5858 3.5H5Z"
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M11.5 3.5V7C11.5 7.27614 11.7239 7.5 12 7.5H15.5"
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
 
 export function QuickSwitcher({
   isOpen,

--- a/apps/frontend/components/quick-switcher/QuickSwitcher.tsx
+++ b/apps/frontend/components/quick-switcher/QuickSwitcher.tsx
@@ -1,6 +1,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
-import { FileText, FilePlus, Folder } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { Search, Plus, X } from 'lucide-react';
 import { searchFiles, flattenFileTree } from '@/lib/wiki-link-resolver';
 import type { FileTreeNode } from '@cushion/types';
 import { formatShortcutList, matchShortcut, useShortcutBindings } from '@/lib/shortcuts';
@@ -80,6 +81,39 @@ function HighlightedText({ text, matchIndices }: { text: string; matchIndices?: 
   return <>{parts}</>;
 }
 
+function FolderIcon({ className }: { className?: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path
+        d="M2.5 5.5C2.5 4.39543 3.39543 3.5 4.5 3.5H7.08579C7.35097 3.5 7.60536 3.60536 7.79289 3.79289L9.20711 5.20711C9.39464 5.39464 9.64903 5.5 9.91421 5.5H15.5C16.6046 5.5 17.5 6.39543 17.5 7.5V14.5C17.5 15.6046 16.6046 16.5 15.5 16.5H4.5C3.39543 16.5 2.5 15.6046 2.5 14.5V5.5Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function FileIcon({ className }: { className?: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path
+        d="M5 3.5C4.72386 3.5 4.5 3.72386 4.5 4V16C4.5 16.2761 4.72386 16.5 5 16.5H15C15.2761 16.5 15.5 16.2761 15.5 16V7.41421C15.5 7.28161 15.4473 7.15443 15.3536 7.06066L11.9393 3.64645C11.8456 3.55268 11.7184 3.5 11.5858 3.5H5Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11.5 3.5V7C11.5 7.27614 11.7239 7.5 12 7.5H15.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function QuickSwitcher({
   isOpen,
   onClose,
@@ -98,7 +132,6 @@ export function QuickSwitcher({
     if (isOpen) {
       setQuery('');
       setSelectedIndex(0);
-      // Small delay to ensure the modal is rendered
       setTimeout(() => inputRef.current?.focus(), 50);
     }
   }, [isOpen]);
@@ -108,7 +141,6 @@ export function QuickSwitcher({
     const items: SearchResult[] = [];
 
     if (query.trim()) {
-      // Search with query
       const matches = searchFiles(query, fileTree, 15);
 
       for (const path of matches) {
@@ -125,7 +157,6 @@ export function QuickSwitcher({
         });
       }
 
-      // Add "Create new file" option if query doesn't exactly match a file
       const queryLower = query.toLowerCase();
       const exactMatch = items.some(
         item => item.displayName.toLowerCase() === queryLower
@@ -140,10 +171,7 @@ export function QuickSwitcher({
         });
       }
     } else {
-      // Show recent/all files when no query
       const allFiles = flattenFileTree(fileTree);
-      // Sort by modification time would be ideal, but we just show first 15 for now
-      // Prefer .md files
       const sorted = allFiles
         .sort((a, b) => {
           const aIsMd = a.endsWith('.md') ? 1 : 0;
@@ -250,109 +278,124 @@ export function QuickSwitcher({
 
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 z-overlay flex items-start justify-center pt-[15vh]">
-      {/* Backdrop */}
+  return createPortal(
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-[var(--overlay-50)] p-4" onClick={onClose}>
       <div
-        className="absolute inset-0 bg-[var(--overlay-50)]"
-        onClick={onClose}
-      />
-
-      {/* Modal */}
-      <div
-        className="relative w-full max-w-lg bg-modal-bg rounded-xl shadow-[var(--shadow-lg)] border border-modal-border overflow-hidden"
-        style={{ maxHeight: '60vh' }}
+        className="flex h-[480px] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-border bg-surface-elevated shadow-[var(--shadow-lg)]"
+        onClick={(event) => event.stopPropagation()}
       >
-        {/* Search input */}
-        <div className="p-3 border-b border-modal-border">
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Type to search for a file..."
-            className="w-full px-3 py-2 bg-modal-bg rounded-lg border border-modal-border text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-foreground-muted text-base"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-          />
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 px-4 pt-4 pb-3">
+          <h2 className="text-[15px] font-medium text-foreground">Quick switcher</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="size-6 flex items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-[var(--overlay-10)] hover:text-foreground"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
         </div>
 
-        {/* Results list */}
-        <div
-          ref={listRef}
-          className="overflow-y-auto thin-scrollbar"
-          style={{ maxHeight: 'calc(60vh - 70px)' }}
-        >
+        {/* Search bar */}
+        <div className="px-4 pb-3">
+          <div className="flex h-8 items-center gap-2 rounded-md bg-surface px-2">
+            <Search size={16} className="shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Search files..."
+              className="h-full w-full border-none bg-transparent text-[14px] text-foreground placeholder:text-muted-foreground focus:outline-none"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+            />
+            {query.trim().length > 0 && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                className="size-5 flex items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <X className="size-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Results */}
+        <div className="flex-1 overflow-y-auto no-scrollbar px-2 pb-2">
           {results.length === 0 ? (
-            <div className="p-6 text-center text-foreground-muted">
-              No files found. Try a different search.
+            <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+              No files found
             </div>
           ) : (
-            results.map((item, index) => (
-              <div
-                key={item.type === 'create' ? `create-${item.path}` : item.path}
-                className={cn(
-                  "flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors rounded-md mx-2",
-                  index === selectedIndex
-                    ? "bg-[var(--overlay-10)] text-foreground"
-                    : "hover:bg-[var(--overlay-10)]"
-                )}
-                onClick={() => handleItemClick(item)}
-                onMouseEnter={() => setSelectedIndex(index)}
-              >
-                {/* Icon */}
-                <div className={cn("flex-shrink-0", index === selectedIndex ? "text-foreground" : "text-foreground-muted")}>
-                  {item.type === 'create' ? (
-                    <FilePlus size={18} />
-                  ) : item.path.endsWith('.md') ? (
-                    <FileText size={18} />
-                  ) : (
-                    <Folder size={18} />
+            <div ref={listRef} className="space-y-0.5">
+              {results.map((item, index) => (
+                <div
+                  key={item.type === 'create' ? `create-${item.path}` : item.path}
+                  className={cn(
+                    'flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 transition-colors',
+                    index === selectedIndex
+                      ? 'bg-[var(--overlay-10)] text-foreground'
+                      : 'hover:bg-[var(--overlay-10)]'
                   )}
-                </div>
-
-                {/* File info */}
-                <div className="flex-1 min-w-0">
-                  <div className="truncate">
+                  onClick={() => handleItemClick(item)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                >
+                  <div className={cn('shrink-0', index === selectedIndex ? 'text-foreground' : 'text-muted-foreground')}>
                     {item.type === 'create' ? (
-                      <span>
-                        Create "<span className="font-medium">{item.displayName}</span>"
-                      </span>
+                      <Plus size={20} />
+                    ) : item.directory ? (
+                      <FolderIcon />
                     ) : (
-                      <HighlightedText
-                        text={item.displayName}
-                        matchIndices={index === selectedIndex ? undefined : item.matchIndices}
-                      />
+                      <FileIcon />
                     )}
                   </div>
-                  {item.directory && (
-                    <div className="text-xs truncate text-foreground-muted">
-                      {item.directory}
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[14px] text-foreground">
+                      {item.type === 'create' ? (
+                        <span>
+                          Create "<span className="font-medium">{item.displayName}</span>"
+                        </span>
+                      ) : (
+                        <HighlightedText
+                          text={item.displayName}
+                          matchIndices={index === selectedIndex ? undefined : item.matchIndices}
+                        />
+                      )}
                     </div>
-                  )}
+                    {item.directory && (
+                      <div className="truncate text-xs text-muted-foreground">
+                        {item.directory}
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))
+              ))}
+            </div>
           )}
         </div>
 
-        {/* Footer with shortcuts */}
-        <div className="px-4 py-2 border-t border-modal-border flex gap-4 text-xs text-foreground-muted">
+        {/* Footer shortcuts */}
+        <div className="px-4 py-2.5 flex gap-4 text-xs text-muted-foreground">
           {(prevLabel || nextLabel) && (
             <span>
-              {prevLabel && <kbd className="px-1 py-0.5 bg-surface-elevated rounded">{prevLabel}</kbd>}
-              {nextLabel && <kbd className="px-1 py-0.5 bg-surface-elevated rounded ml-1">{nextLabel}</kbd>}
+              {prevLabel && <kbd className="px-1 py-0.5 rounded bg-surface text-[11px]">{prevLabel}</kbd>}
+              {nextLabel && <kbd className="px-1 py-0.5 rounded bg-surface text-[11px] ml-1">{nextLabel}</kbd>}
               {' '}Navigate
             </span>
           )}
-          {openLabel && <span><kbd className="px-1 py-0.5 bg-surface-elevated rounded">{openLabel}</kbd> Open</span>}
-          {autocompleteLabel && <span><kbd className="px-1 py-0.5 bg-surface-elevated rounded">{autocompleteLabel}</kbd> Autocomplete</span>}
-          {closeLabel && <span><kbd className="px-1 py-0.5 bg-surface-elevated rounded">{closeLabel}</kbd> Close</span>}
+          {openLabel && <span><kbd className="px-1 py-0.5 rounded bg-surface text-[11px]">{openLabel}</kbd> Open</span>}
+          {autocompleteLabel && <span><kbd className="px-1 py-0.5 rounded bg-surface text-[11px]">{autocompleteLabel}</kbd> Autocomplete</span>}
+          {closeLabel && <span><kbd className="px-1 py-0.5 rounded bg-surface text-[11px]">{closeLabel}</kbd> Close</span>}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/apps/frontend/components/shared/FileIcons.tsx
+++ b/apps/frontend/components/shared/FileIcons.tsx
@@ -1,0 +1,51 @@
+
+/** Shared file/folder SVG icons used by FileTree and QuickSwitcher. */
+
+export function FolderIcon({ open, className }: { open?: boolean; className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M2.5 5.5C2.5 4.39543 3.39543 3.5 4.5 3.5H7.08579C7.35097 3.5 7.60536 3.60536 7.79289 3.79289L9.20711 5.20711C9.39464 5.39464 9.64903 5.5 9.91421 5.5H15.5C16.6046 5.5 17.5 6.39543 17.5 7.5V14.5C17.5 15.6046 16.6046 16.5 15.5 16.5H4.5C3.39543 16.5 2.5 15.6046 2.5 14.5V5.5Z"
+        fill={open ? "currentColor" : "none"}
+        fillOpacity={open ? 0.12 : 0}
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function FileIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M5 3.5C4.72386 3.5 4.5 3.72386 4.5 4V16C4.5 16.2761 4.72386 16.5 5 16.5H15C15.2761 16.5 15.5 16.2761 15.5 16V7.41421C15.5 7.28161 15.4473 7.15443 15.3536 7.06066L11.9393 3.64645C11.8456 3.55268 11.7184 3.5 11.5858 3.5H5Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11.5 3.5V7C11.5 7.27614 11.7239 7.5 12 7.5H15.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/frontend/components/workspace/FileTree.tsx
+++ b/apps/frontend/components/workspace/FileTree.tsx
@@ -5,6 +5,7 @@ import { FileTreeItemActions } from './FileTreeItemActions';
 import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { FolderIcon, FileIcon } from '@/components/shared/FileIcons';
 
 interface FileTreeProps {
   nodes: FileTreeNode[];
@@ -27,56 +28,6 @@ interface FileTreeProps {
   onRootCreationDone?: () => void;
 }
 
-// Folder icon component - 20px (Affine-style)
-function FolderIcon({ open, className }: { open: boolean; className?: string }) {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-    >
-      <path
-        d="M2.5 5.5C2.5 4.39543 3.39543 3.5 4.5 3.5H7.08579C7.35097 3.5 7.60536 3.60536 7.79289 3.79289L9.20711 5.20711C9.39464 5.39464 9.64903 5.5 9.91421 5.5H15.5C16.6046 5.5 17.5 6.39543 17.5 7.5V14.5C17.5 15.6046 16.6046 16.5 15.5 16.5H4.5C3.39543 16.5 2.5 15.6046 2.5 14.5V5.5Z"
-        fill={open ? "currentColor" : "none"}
-        fillOpacity={open ? 0.12 : 0}
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-// File icon component - 20px (Affine-style document)
-function FileIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-    >
-      <path
-        d="M5 3.5C4.72386 3.5 4.5 3.72386 4.5 4V16C4.5 16.2761 4.72386 16.5 5 16.5H15C15.2761 16.5 15.5 16.2761 15.5 16V7.41421C15.5 7.28161 15.4473 7.15443 15.3536 7.06066L11.9393 3.64645C11.8456 3.55268 11.7184 3.5 11.5858 3.5H5Z"
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M11.5 3.5V7C11.5 7.27614 11.7239 7.5 12 7.5H15.5"
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
 
 export function FileTree({
   nodes,

--- a/apps/frontend/components/workspace/WorkspacePicker.tsx
+++ b/apps/frontend/components/workspace/WorkspacePicker.tsx
@@ -55,7 +55,7 @@ export function WorkspacePicker({ onWorkspaceOpened }: WorkspacePickerProps) {
 
   return (
     <div className="workspace-picker">
-      <style jsx>{`
+      <style>{`
         .workspace-picker {
           min-height: 100vh;
           width: 100%;

--- a/apps/frontend/hooks/usePromptEditor.ts
+++ b/apps/frontend/hooks/usePromptEditor.ts
@@ -81,21 +81,23 @@ export function usePromptEditor({ disabled, trigger, setTriggerState, updateTrig
     const hasNonText = rawParts.some((part) => part.type !== 'text');
     const shouldReset = trimmed.length === 0 && !hasNonText;
 
+    const syncContextItems = () => {
+      if (contextItems.length === 0) return;
+      const remainingPaths = new Set(
+        rawParts.filter((p) => p.type === 'file').map((p) => (p as { path: string }).path)
+      );
+      for (const item of contextItems) {
+        if (!remainingPaths.has(item.path)) removeContextItem(item.id);
+      }
+    };
+
     if (shouldReset) {
       setTriggerState(null);
       if (promptText !== '') {
         mirror.current.input = true;
         setPromptText('');
       }
-      // Remove all context items whose pills were cleared
-      if (contextItems.length > 0) {
-        const remainingPaths = new Set(
-          rawParts.filter((p) => p.type === 'file').map((p) => (p as { path: string }).path)
-        );
-        for (const item of contextItems) {
-          if (!remainingPaths.has(item.path)) removeContextItem(item.id);
-        }
-      }
+      syncContextItems();
       return;
     }
 
@@ -107,15 +109,7 @@ export function usePromptEditor({ disabled, trigger, setTriggerState, updateTrig
       setPromptText(rawText);
     }
 
-    // Remove context items for file pills that were deleted
-    if (contextItems.length > 0) {
-      const remainingPaths = new Set(
-        rawParts.filter((p) => p.type === 'file').map((p) => (p as { path: string }).path)
-      );
-      for (const item of contextItems) {
-        if (!remainingPaths.has(item.path)) removeContextItem(item.id);
-      }
-    }
+    syncContextItems();
   };
 
   const refreshTriggerFromSelection = () => {

--- a/apps/frontend/hooks/usePromptEditor.ts
+++ b/apps/frontend/hooks/usePromptEditor.ts
@@ -27,6 +27,7 @@ export function usePromptEditor({ disabled, trigger, setTriggerState, updateTrig
   const promptText = useChatStore((state) => state.promptText);
   const setPromptText = useChatStore((state) => state.setPromptText);
   const contextItems = useChatStore((state) => state.contextItems);
+  const removeContextItem = useChatStore((state) => state.removeContextItem);
   const agents = useChatStore((state) => state.agents);
 
   const editorRef = useRef<HTMLDivElement | null>(null);
@@ -86,6 +87,15 @@ export function usePromptEditor({ disabled, trigger, setTriggerState, updateTrig
         mirror.current.input = true;
         setPromptText('');
       }
+      // Remove all context items whose pills were cleared
+      if (contextItems.length > 0) {
+        const remainingPaths = new Set(
+          rawParts.filter((p) => p.type === 'file').map((p) => (p as { path: string }).path)
+        );
+        for (const item of contextItems) {
+          if (!remainingPaths.has(item.path)) removeContextItem(item.id);
+        }
+      }
       return;
     }
 
@@ -95,6 +105,16 @@ export function usePromptEditor({ disabled, trigger, setTriggerState, updateTrig
     if (rawText !== promptText) {
       mirror.current.input = true;
       setPromptText(rawText);
+    }
+
+    // Remove context items for file pills that were deleted
+    if (contextItems.length > 0) {
+      const remainingPaths = new Set(
+        rawParts.filter((p) => p.type === 'file').map((p) => (p as { path: string }).path)
+      );
+      for (const item of contextItems) {
+        if (!remainingPaths.has(item.path)) removeContextItem(item.id);
+      }
     }
   };
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -43,6 +43,8 @@
     "katex": "^0.16.28",
     "lucide-react": "^0.546.0",
     "marked": "^17.0.1",
+    "morphdom": "^2.7.8",
+    "motion": "^12.38.0",
     "pdfjs-dist": "^5.4.530",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/frontend/stores/chat-connection.ts
+++ b/apps/frontend/stores/chat-connection.ts
@@ -178,6 +178,16 @@ export async function handleConnect(
   });
 
   unsubscribeEvents = onOpenCodeEvent(directory, (event, eventDirectory) => {
+    if (event.type === 'permission.asked' && get().autoAccept) {
+      const perm = event.properties;
+      if (perm?.sessionID && perm?.id) {
+        get().respondToPermission({
+          sessionID: perm.sessionID,
+          permissionID: perm.id,
+          response: 'once',
+        }).catch(() => undefined);
+      }
+    }
     get().applyEvent(event, eventDirectory);
   });
 }

--- a/apps/frontend/stores/chat-event-handler.ts
+++ b/apps/frontend/stores/chat-event-handler.ts
@@ -111,12 +111,27 @@ export function handleApplyEvent(
     }
     case 'session.status': {
       const { sessionID, status } = event.properties;
-      set((state) => ({
-        sessionStatus: {
-          ...state.sessionStatus,
-          [sessionID]: status,
-        },
-      }));
+      const isNowIdle = status.type !== 'busy' && status.type !== 'retry';
+      set((state) => {
+        const next: Partial<typeof state> = {
+          sessionStatus: {
+            ...state.sessionStatus,
+            [sessionID]: status,
+          },
+        };
+        // Clear stale questions/permissions when session stops being busy
+        if (isNowIdle) {
+          const qList = state.questions[sessionID];
+          if (qList && qList.length > 0) {
+            next.questions = { ...state.questions, [sessionID]: [] };
+          }
+          const pList = state.permissions[sessionID];
+          if (pList && pList.length > 0) {
+            next.permissions = { ...state.permissions, [sessionID]: [] };
+          }
+        }
+        return next;
+      });
       break;
     }
     case 'session.diff': {

--- a/apps/frontend/stores/chat-session-actions.ts
+++ b/apps/frontend/stores/chat-session-actions.ts
@@ -230,6 +230,9 @@ export async function handleCompactSession(get: ChatStoreGet, set: ChatStoreSet)
     modelID: model.modelID,
     directory,
   });
+  set((prev) => ({
+    compactedSessions: { ...prev.compactedSessions, [sessionID]: true },
+  }));
 }
 
 export async function handleShareSession(

--- a/apps/frontend/stores/chat-store-utils.ts
+++ b/apps/frontend/stores/chat-store-utils.ts
@@ -19,9 +19,7 @@ import {
   type OpenCodeConnectionState,
 } from '@/lib/shared-opencode-client';
 
-// ---------------------------------------------------------------------------
 // Types
-// ---------------------------------------------------------------------------
 
 export type OpenCodeDirectory = string;
 
@@ -109,6 +107,8 @@ export type ChatState = {
   permissions: Record<string, PermissionRequest[]>;
   questions: Record<string, QuestionRequest[]>;
   sessionErrors: Record<string, string | undefined>;
+  compactedSessions: Record<string, boolean>;
+  autoAccept: boolean;
 };
 
 export type ChatActions = {
@@ -144,6 +144,7 @@ export type ChatActions = {
   toggleShowThinking: () => void;
   toggleShellToolPartsExpanded: () => void;
   toggleEditToolPartsExpanded: () => void;
+  toggleAutoAccept: () => void;
 };
 
 export type ChatStore = ChatState & ChatActions;
@@ -153,18 +154,14 @@ export type ChatStoreSet = (
   updater: Partial<ChatState> | ((state: ChatStore) => Partial<ChatState>)
 ) => void;
 
-// ---------------------------------------------------------------------------
 // Constants
-// ---------------------------------------------------------------------------
 
 export const MAX_CONTEXT_ITEMS = 20;
 export const DEFAULT_MESSAGE_LIMIT = 200;
 export const WORKSPACE_SESSION_KEY = '__workspace__';
 export const MAX_PROMPT_SESSIONS = 20;
 
-// ---------------------------------------------------------------------------
 // Initial state
-// ---------------------------------------------------------------------------
 
 export const DEFAULT_DISPLAY_PREFERENCES: DisplayPreferences = {
   showThinking: true,
@@ -207,11 +204,11 @@ export const initialState: ChatState = {
   permissions: {},
   questions: {},
   sessionErrors: {},
+  compactedSessions: {},
+  autoAccept: false,
 };
 
-// ---------------------------------------------------------------------------
 // List utilities
-// ---------------------------------------------------------------------------
 
 export function insertSortedById<T>(list: T[], item: T, getId: (value: T) => string) {
   const id = getId(item);
@@ -270,9 +267,7 @@ export function removeMessage(list: Message[], messageId: string) {
   return list.filter((item) => item.id !== messageId);
 }
 
-// ---------------------------------------------------------------------------
 // Prompt session utilities
-// ---------------------------------------------------------------------------
 
 export function getPromptKey(directory: string, sessionId: string | null) {
   const normalized = directory.replace(/\\/g, '/');
@@ -334,9 +329,7 @@ export function prunePromptSessions(
   };
 }
 
-// ---------------------------------------------------------------------------
 // Model visibility
-// ---------------------------------------------------------------------------
 
 export function getModelVisibilityKey(model: SelectedModel) {
   return `${model.providerID}:${model.modelID}`;
@@ -349,9 +342,7 @@ export function resolveModelVisibility(map: Record<string, ModelVisibility>, mod
   return true;
 }
 
-// ---------------------------------------------------------------------------
 // API helpers
-// ---------------------------------------------------------------------------
 
 type ResultData<T> = { data: T };
 

--- a/apps/frontend/stores/chat-store-utils.ts
+++ b/apps/frontend/stores/chat-store-utils.ts
@@ -158,7 +158,7 @@ export type ChatStoreSet = (
 
 export const MAX_CONTEXT_ITEMS = 20;
 export const DEFAULT_MESSAGE_LIMIT = 200;
-export const WORKSPACE_SESSION_KEY = '__workspace__';
+const WORKSPACE_SESSION_KEY = '__workspace__';
 export const MAX_PROMPT_SESSIONS = 20;
 
 // Initial state

--- a/apps/frontend/stores/chatStore.ts
+++ b/apps/frontend/stores/chatStore.ts
@@ -378,10 +378,27 @@ export const useChatStore = create<ChatState & ChatActions>()(
         },
       }));
     },
+
+    toggleAutoAccept: () => {
+      const next = !get().autoAccept;
+      set({ autoAccept: next });
+      if (next) {
+        // Retroactively auto-respond to any pending permissions
+        const { permissions, activeSessionId } = get();
+        const pending = activeSessionId ? permissions[activeSessionId] ?? [] : [];
+        for (const perm of pending) {
+          get().respondToPermission({
+            sessionID: perm.sessionID,
+            permissionID: perm.id,
+            response: 'once',
+          }).catch(() => undefined);
+        }
+      }
+    },
       }),
       {
         name: 'cushion-chat',
-        version: 3,
+        version: 4,
         partialize: (state) => ({
           baseUrl: state.baseUrl,
           contextBySession: state.contextBySession,
@@ -393,10 +410,14 @@ export const useChatStore = create<ChatState & ChatActions>()(
           selectedVariantByDirectory: state.selectedVariantByDirectory,
           modelVisibility: state.modelVisibility,
           displayPreferences: state.displayPreferences,
+          autoAccept: state.autoAccept,
         }),
         migrate: (state, version) => {
           if (!state || typeof state !== 'object') return state as ChatState;
-          if (version >= 3) return state as ChatState;
+          if (version >= 4) return state as ChatState;
+          if (version === 3) {
+            return { ...state, autoAccept: false } as ChatState;
+          }
           const legacy = state as ChatState & {
             contextByDirectory?: Record<string, PromptContextItem[]>;
             promptSessionOrder?: string[];

--- a/apps/frontend/stores/workspaceStore.ts
+++ b/apps/frontend/stores/workspaceStore.ts
@@ -32,7 +32,7 @@ interface WorkspaceActions {
   closeWorkspace: () => void;
 
   // File operations
-  openFile: (filePath: string, content: string) => void;
+  openFile: (filePath: string, content: string, forceNewTab?: boolean) => void;
   closeFile: (filePath: string) => void;
   updateFileContent: (filePath: string, content: string) => void;
   markFileDirty: (filePath: string) => void;

--- a/apps/frontend/styles/opencode-chat.css
+++ b/apps/frontend/styles/opencode-chat.css
@@ -1,0 +1,1012 @@
+/*
+ * OpenCode Chat Color System
+ * ---------------------------
+ * Extracted from OpenCode's Tauri app (packages/ui/src/styles/).
+ * Provides the full semantic token layer + chat component overrides.
+ *
+ * Toggle: import/remove this file from globals.css to switch themes.
+ * When active, these tokens override the Cushion defaults *inside* the
+ * chat sidebar only (scoped to [data-chat-theme="opencode"]).
+ *
+ * To activate: add data-chat-theme="opencode" to the chat sidebar root,
+ * AND import this file in globals.css.
+ */
+
+/* ================================================================
+   1. OPENCODE SEMANTIC TOKENS — Light
+   ================================================================ */
+[data-chat-theme="opencode"] {
+  /* ---- Typography ---- */
+  --oc-font-size-small: 13px;
+  --oc-font-size-base: 14px;
+  --oc-font-size-large: 16px;
+
+  /* ---- Motion ---- */
+  --tool-motion-spring-ms: 480ms;
+  --tool-motion-fade-ms: 240ms;
+  --tool-motion-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --tool-motion-blur: 2px;
+
+  /* ---- Backgrounds ---- */
+  --oc-background-base: #f9f9f9;
+  --oc-background-weak: #f3f3f3;
+  --oc-background-strong: #ffffff;
+  --oc-background-stronger: #f9f9f9;
+
+  /* ---- Surfaces ---- */
+  --oc-surface-base: rgba(0, 0, 0, 0.031);
+  --oc-surface-base-hover: rgba(0, 0, 0, 0.059);
+  --oc-surface-base-active: rgba(0, 0, 0, 0.051);
+  --oc-surface-inset-base: rgba(0, 0, 0, 0.034);
+  --oc-surface-raised-base: rgba(0, 0, 0, 0.031);
+  --oc-surface-raised-base-hover: rgba(0, 0, 0, 0.051);
+  --oc-surface-raised-strong: #ffffff;
+  --oc-surface-raised-stronger: #ffffff;
+  --oc-surface-raised-stronger-non-alpha: #ffffff;
+  --oc-surface-float-base: #161616;
+  --oc-surface-weak: rgba(0, 0, 0, 0.051);
+  --oc-surface-weaker: rgba(0, 0, 0, 0.071);
+  --oc-surface-strong: #ffffff;
+
+  /* Brand / interactive / status surfaces */
+  --oc-surface-brand-base: #dcde8d;
+  --oc-surface-brand-hover: #d0d283;
+  --oc-surface-interactive-base: #f0ecff;
+  --oc-surface-interactive-hover: #e4dfff;
+  --oc-surface-interactive-weak: #f8f7ff;
+  --oc-surface-success-base: #dbfed7;
+  --oc-surface-success-weak: #f0feee;
+  --oc-surface-success-strong: #12c905;
+  --oc-surface-warning-base: #fcf3cb;
+  --oc-surface-warning-weak: #fdfaec;
+  --oc-surface-warning-strong: #fbdd46;
+  --oc-surface-critical-base: #fff2f0;
+  --oc-surface-critical-weak: #fff8f6;
+  --oc-surface-critical-strong: #fc533a;
+  --oc-surface-info-base: #fdecfe;
+  --oc-surface-info-weak: #fef7ff;
+  --oc-surface-info-strong: #a753ae;
+
+  /* Diff surfaces */
+  --oc-surface-diff-add-base: #e3fae1;
+  --oc-surface-diff-add-weak: #f4fcf3;
+  --oc-surface-diff-add-strong: #c2eebf;
+  --oc-surface-diff-add-stronger: #9ff29a;
+  --oc-surface-diff-delete-base: #feefeb;
+  --oc-surface-diff-delete-weak: #fff8f6;
+  --oc-surface-diff-delete-strong: #fdc3b7;
+  --oc-surface-diff-delete-stronger: #fc533a;
+  --oc-surface-diff-hidden-base: #eaf4ff;
+  --oc-surface-diff-hidden-strong: #cae3ff;
+
+  /* ---- Text ---- */
+  --oc-text-base: #6f6f6f;
+  --oc-text-weak: #8f8f8f;
+  --oc-text-weaker: #c7c7c7;
+  --oc-text-strong: #171717;
+  --oc-text-interactive-base: #7c3aed;
+  --oc-text-on-brand-base: rgba(0, 0, 0, 0.574);
+  --oc-text-on-critical-base: #ed4831;
+  --oc-text-on-critical-weak: #fe806a;
+  --oc-text-on-critical-strong: #601a0f;
+  --oc-text-on-success-base: #2dba26;
+  --oc-text-on-warning-base: rgba(0, 0, 0, 0.574);
+  --oc-text-on-info-base: rgba(0, 0, 0, 0.574);
+  --oc-text-diff-add-base: #3a8437;
+  --oc-text-diff-delete-base: #ed4831;
+  --oc-text-invert-strong: #ffffff;
+
+  /* ---- Buttons ---- */
+  --oc-button-primary-base: #171717;
+  --oc-button-secondary-base: #ffffff;
+  --oc-button-secondary-hover: #f3f3f3;
+  --oc-button-ghost-hover: rgba(0, 0, 0, 0.031);
+
+  /* ---- Borders ---- */
+  --oc-border-base: rgba(0, 0, 0, 0.162);
+  --oc-border-hover: rgba(0, 0, 0, 0.236);
+  --oc-border-weak-base: #e5e5e5;
+  --oc-border-strong-base: rgba(0, 0, 0, 0.151);
+  --oc-border-weaker-base: #f0f0f0;
+  --oc-border-interactive-base: #c4a3fd;
+  --oc-border-success-base: #96ec8e;
+  --oc-border-critical-base: #fdc3b7;
+  --oc-border-critical-selected: #fc533a;
+  --oc-border-warning-base: #e8d479;
+  --oc-border-info-base: #f4bdf8;
+
+  /* ---- Icons ---- */
+  --oc-icon-base: #8f8f8f;
+  --oc-icon-hover: #6f6f6f;
+  --oc-icon-active: #171717;
+  --oc-icon-weak-base: #dbdbdb;
+  --oc-icon-weaker: #dbdbdb;
+  --oc-icon-strong-base: #171717;
+  --oc-icon-interactive-base: #7c3aed;
+  --oc-icon-success-base: #7add71;
+  --oc-icon-critical-base: #ed4831;
+  --oc-icon-warning-base: #ebb76e;
+  --oc-icon-info-base: #e6a8ea;
+  --oc-icon-diff-add-base: #3a8437;
+  --oc-icon-diff-delete-base: #ed4831;
+  --oc-icon-diff-modified-base: #ff8c00;
+  --oc-icon-agent-plan-base: #a753ae;
+  --oc-icon-agent-docs-base: #fcb239;
+  --oc-icon-agent-ask-base: #8b5cf6;
+  --oc-icon-agent-build-base: #7c3aed;
+
+  /* ---- Input ---- */
+  --oc-input-base: #ffffff;
+  --oc-input-hover: #f3f3f3;
+  --oc-input-active: #fdfcff;
+
+  /* ---- Syntax highlighting ---- */
+  --oc-syntax-comment: var(--oc-text-weak);
+  --oc-syntax-string: #6d28d9;
+  --oc-syntax-keyword: var(--oc-text-weak);
+  --oc-syntax-primitive: #fb4804;
+  --oc-syntax-operator: var(--oc-text-base);
+  --oc-syntax-variable: var(--oc-text-strong);
+  --oc-syntax-property: #ed6dc8;
+  --oc-syntax-type: #596600;
+  --oc-syntax-constant: #007b80;
+  --oc-syntax-success: #2dba26;
+  --oc-syntax-warning: #efa72e;
+  --oc-syntax-critical: #ed4831;
+  --oc-syntax-info: #0092a8;
+  --oc-syntax-diff-add: #3a8437;
+  --oc-syntax-diff-delete: #ca2d17;
+
+  /* ---- Shadows ---- */
+  --oc-shadow-xs:
+    0 1px 2px -0.5px hsl(0 0% 0% / 0.04),
+    0 0.5px 1.5px 0 hsl(0 0% 0% / 0.025),
+    0 1px 3px 0 hsl(0 0% 0% / 0.05);
+  --oc-shadow-xs-border:
+    0 0 0 1px var(--oc-border-base), 0 1px 2px -1px rgba(19, 16, 16, 0.04),
+    0 1px 2px 0 rgba(19, 16, 16, 0.06), 0 1px 3px 0 rgba(19, 16, 16, 0.08);
+  --oc-shadow-xs-border-base:
+    0 0 0 1px var(--oc-border-weak-base), 0 1px 2px -1px rgba(19, 16, 16, 0.04),
+    0 1px 2px 0 rgba(19, 16, 16, 0.06), 0 1px 3px 0 rgba(19, 16, 16, 0.08);
+
+  /* ---- Radii ---- */
+  --oc-radius-xs: 0.125rem;
+  --oc-radius-sm: 0.25rem;
+  --oc-radius-md: 0.375rem;
+  --oc-radius-lg: 0.5rem;
+  --oc-radius-xl: 0.625rem;
+
+  /* =============================================================
+     MAP OC TOKENS → CUSHION CSS VARIABLES
+     These overrides make all existing chat components pick up
+     OpenCode colors without touching component CSS.
+     ============================================================= */
+  --background: var(--oc-background-base);
+  --sidebar-bg: var(--oc-background-base);
+  --surface: var(--oc-background-stronger);
+  --surface-elevated: var(--oc-surface-strong);
+  --surface-tertiary: var(--oc-background-weak);
+  --foreground: var(--oc-text-strong);
+  --foreground-muted: var(--oc-text-base);
+  --text-normal: var(--oc-text-strong);
+  --text-muted: var(--oc-text-base);
+  --text-faint: var(--oc-text-weak);
+  --muted-foreground: var(--oc-text-base);
+  --border: var(--oc-border-weak-base);
+  --background-modifier-border: var(--oc-border-weak-base);
+  --background-modifier-border-hover: var(--oc-border-weaker-base);
+  --background-modifier-border-focus: var(--oc-border-base);
+  --interactive-accent: var(--oc-text-interactive-base);
+  --interactive-accent-hover: #0240d9;
+  --accent-primary: var(--oc-text-interactive-base);
+  --accent-green: var(--oc-surface-success-strong);
+  --accent-red: var(--oc-surface-critical-strong);
+  --accent-yellow: var(--oc-surface-warning-strong);
+  --accent-green-12: var(--oc-surface-success-weak);
+  --accent-red-12: var(--oc-surface-critical-weak);
+  --overlay-10: var(--oc-surface-base);
+  --overlay-20: var(--oc-surface-base-hover);
+  --text-accent: var(--oc-text-interactive-base);
+}
+
+/* ================================================================
+   2. OPENCODE SEMANTIC TOKENS — Dark
+   ================================================================ */
+.dark [data-chat-theme="opencode"],
+[data-chat-theme="opencode"].dark {
+  --oc-background-base: #262626;
+  --oc-background-weak: #1e1e1e;
+  --oc-background-strong: #121212;
+  --oc-background-stronger: #262626;
+
+  --oc-surface-base: rgba(255, 255, 255, 0.031);
+  --oc-surface-base-hover: rgba(255, 255, 255, 0.039);
+  --oc-surface-base-active: rgba(255, 255, 255, 0.059);
+  --oc-surface-inset-base: rgba(0, 0, 0, 0.5);
+  --oc-surface-raised-base: rgba(255, 255, 255, 0.059);
+  --oc-surface-raised-base-hover: rgba(255, 255, 255, 0.078);
+  --oc-surface-raised-strong: rgba(255, 255, 255, 0.078);
+  --oc-surface-raised-stronger: rgba(255, 255, 255, 0.129);
+  --oc-surface-raised-stronger-non-alpha: #1c1c1c;
+  --oc-surface-float-base: #161616;
+  --oc-surface-weak: rgba(255, 255, 255, 0.078);
+  --oc-surface-weaker: rgba(255, 255, 255, 0.102);
+  --oc-surface-strong: rgba(255, 255, 255, 0.169);
+
+  --oc-surface-brand-base: #fab283;
+  --oc-surface-brand-hover: #eda779;
+  --oc-surface-interactive-base: #1f0952;
+  --oc-surface-interactive-weak: #150b30;
+  --oc-surface-success-base: #062d04;
+  --oc-surface-success-weak: #0a1e08;
+  --oc-surface-success-strong: #12c905;
+  --oc-surface-warning-base: #fdf3cf;
+  --oc-surface-warning-weak: #fdfaed;
+  --oc-surface-warning-strong: #fcd53a;
+  --oc-surface-critical-base: #1f0603;
+  --oc-surface-critical-weak: #28110c;
+  --oc-surface-critical-strong: #fc533a;
+  --oc-surface-info-base: #feecfe;
+  --oc-surface-info-weak: #fdf7fe;
+  --oc-surface-info-strong: #edb2f1;
+
+  --oc-surface-diff-add-base: #1a2919;
+  --oc-surface-diff-add-weak: #1f351e;
+  --oc-surface-diff-add-strong: #264024;
+  --oc-surface-diff-add-stronger: #9bcd97;
+  --oc-surface-diff-delete-base: #42120b;
+  --oc-surface-diff-delete-weak: #580f06;
+  --oc-surface-diff-delete-strong: #6a1206;
+  --oc-surface-diff-delete-stronger: #faa494;
+  --oc-surface-diff-hidden-base: #0c1928;
+  --oc-surface-diff-hidden-strong: #073966;
+
+  --oc-text-base: rgba(255, 255, 255, 0.618);
+  --oc-text-weak: rgba(255, 255, 255, 0.422);
+  --oc-text-weaker: rgba(255, 255, 255, 0.284);
+  --oc-text-strong: rgba(255, 255, 255, 0.936);
+  --oc-text-interactive-base: #be9dfe;
+  --oc-text-on-brand-base: rgba(255, 255, 255, 0.603);
+  --oc-text-on-critical-base: #fc533a;
+  --oc-text-on-critical-weak: #b72d1a;
+  --oc-text-on-critical-strong: #ffe0da;
+  --oc-text-on-success-base: #12c905;
+  --oc-text-on-warning-base: rgba(255, 255, 255, 0.603);
+  --oc-text-on-info-base: rgba(255, 255, 255, 0.603);
+  --oc-text-diff-add-base: #9bcd97;
+  --oc-text-diff-delete-base: #fc533a;
+  --oc-text-invert-strong: #ededed;
+
+  --oc-button-primary-base: #ededed;
+  --oc-button-secondary-base: #1c1c1c;
+  --oc-button-secondary-hover: rgba(255, 255, 255, 0.039);
+  --oc-button-ghost-hover: rgba(255, 255, 255, 0.031);
+
+  --oc-border-base: rgba(255, 255, 255, 0.195);
+  --oc-border-hover: rgba(255, 255, 255, 0.284);
+  --oc-border-weak-base: #282828;
+  --oc-border-strong-base: rgba(255, 255, 255, 0.266);
+  --oc-border-weaker-base: #202020;
+  --oc-border-interactive-base: #c4a3fd;
+  --oc-border-success-base: #96ec8e;
+  --oc-border-critical-base: #6a1206;
+  --oc-border-critical-selected: #fc533a;
+  --oc-border-warning-base: #e9d282;
+  --oc-border-info-base: #eac5ec;
+
+  --oc-icon-base: #7e7e7e;
+  --oc-icon-hover: #a0a0a0;
+  --oc-icon-active: #ededed;
+  --oc-icon-weak-base: #343434;
+  --oc-icon-weaker: #343434;
+  --oc-icon-strong-base: #ededed;
+  --oc-icon-interactive-base: #7c3aed;
+  --oc-icon-success-base: #12c905;
+  --oc-icon-critical-base: #fc533a;
+  --oc-icon-warning-base: #fbb73c;
+  --oc-icon-info-base: #68446b;
+  --oc-icon-diff-add-base: #9bcd97;
+  --oc-icon-diff-delete-base: #fc533a;
+  --oc-icon-diff-modified-base: #ffba92;
+  --oc-icon-agent-plan-base: #edb2f1;
+  --oc-icon-agent-docs-base: #fbb73c;
+  --oc-icon-agent-ask-base: #a78bfa;
+  --oc-icon-agent-build-base: #be9dfe;
+
+  --oc-input-base: #1c1c1c;
+  --oc-input-hover: #1c1c1c;
+  --oc-input-active: #120923;
+
+  --oc-syntax-string: #be9dfe;
+  --oc-syntax-primitive: #ffba92;
+  --oc-syntax-property: #ff9ae2;
+  --oc-syntax-type: #ecf58c;
+  --oc-syntax-constant: #93e9f6;
+  --oc-syntax-success: #35c02d;
+  --oc-syntax-warning: #f5b238;
+  --oc-syntax-critical: #f54f36;
+  --oc-syntax-info: #93e9f6;
+  --oc-syntax-diff-add: #9bcd97;
+  --oc-syntax-diff-delete: #faa494;
+
+  --oc-shadow-xs:
+    0 1px 2px -0.5px hsl(0 0% 0% / 0.06),
+    0 0.5px 1.5px 0 hsl(0 0% 0% / 0.08),
+    0 1px 3px 0 hsl(0 0% 0% / 0.1);
+  --oc-shadow-xs-border:
+    0 0 0 1px var(--oc-border-base), 0 1px 2px -1px rgba(19, 16, 16, 0.04),
+    0 1px 2px 0 rgba(19, 16, 16, 0.06), 0 1px 3px 0 rgba(19, 16, 16, 0.08);
+
+  /* Re-map Cushion vars for dark */
+  --background: var(--oc-background-base);
+  --sidebar-bg: var(--oc-background-base);
+  --surface: var(--oc-background-stronger);
+  --surface-elevated: var(--oc-surface-raised-stronger-non-alpha);
+  --surface-tertiary: var(--oc-background-weak);
+  --foreground: var(--oc-text-strong);
+  --foreground-muted: var(--oc-text-base);
+  --text-normal: var(--oc-text-strong);
+  --text-muted: var(--oc-text-base);
+  --text-faint: var(--oc-text-weak);
+  --muted-foreground: var(--oc-text-base);
+  --border: var(--oc-border-weak-base);
+  --background-modifier-border: var(--oc-border-weak-base);
+  --background-modifier-border-hover: var(--oc-border-weaker-base);
+  --background-modifier-border-focus: var(--oc-border-base);
+  --interactive-accent: var(--oc-text-interactive-base);
+  --interactive-accent-hover: #7ea9ff;
+  --accent-primary: var(--oc-text-interactive-base);
+  --accent-green: var(--oc-surface-success-strong);
+  --accent-red: var(--oc-surface-critical-strong);
+  --accent-yellow: var(--oc-surface-warning-strong);
+  --accent-green-12: var(--oc-surface-success-weak);
+  --accent-red-12: var(--oc-surface-critical-weak);
+  --overlay-10: var(--oc-surface-base);
+  --overlay-20: var(--oc-surface-base-hover);
+  --text-accent: var(--oc-text-interactive-base);
+}
+
+/* ================================================================
+   3. CHAT COMPONENT OVERRIDES
+   Scoped to [data-chat-theme="opencode"] so they only affect
+   the chat sidebar when the theme is active.
+   ================================================================ */
+
+/* --- Chat sidebar background --- */
+[data-chat-theme="opencode"] {
+  background-color: var(--oc-background-base);
+}
+
+/* --- User message bubble --- */
+[data-chat-theme="opencode"] [data-slot="user-message-text"] {
+  background: var(--oc-surface-raised-base);
+  border-color: var(--oc-border-base);
+  color: var(--oc-text-strong);
+}
+
+/* --- Sticky turn headers --- */
+[data-chat-theme="opencode"] [data-slot="session-turn-sticky"] {
+  background-color: var(--oc-background-stronger);
+}
+
+[data-chat-theme="opencode"] [data-slot="session-turn-sticky"]::before {
+  background-color: var(--oc-background-stronger);
+}
+
+[data-chat-theme="opencode"] [data-slot="session-turn-sticky"]::after {
+  background: linear-gradient(to bottom, var(--oc-background-stronger), transparent);
+}
+
+/* --- Markdown in chat --- */
+[data-chat-theme="opencode"] [data-component="markdown"] {
+  color: var(--oc-text-strong);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] a {
+  color: var(--oc-text-interactive-base);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] :not(pre) > code {
+  color: var(--oc-syntax-string);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] blockquote {
+  border-left-color: var(--oc-border-weak-base);
+  color: var(--oc-text-weak);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] pre,
+[data-chat-theme="opencode"] [data-component="markdown"] .shiki {
+  border-color: var(--oc-border-weak-base);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] th {
+  color: var(--oc-text-strong);
+  border-bottom-color: var(--oc-border-weak-base);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] td {
+  border-bottom-color: var(--oc-border-weaker-base);
+}
+
+[data-chat-theme="opencode"] [data-component="markdown"] li::marker {
+  color: var(--oc-text-weak);
+}
+
+/* --- Reasoning / thinking --- */
+[data-chat-theme="opencode"] [data-component="reasoning-part"] {
+  color: var(--oc-text-base);
+}
+
+[data-chat-theme="opencode"] [data-component="reasoning-part"] [data-component="markdown"] {
+  color: var(--oc-text-weak);
+}
+
+/* --- Tool triggers (BasicTool) --- */
+[data-chat-theme="opencode"] [data-slot="basic-tool-tool-title"] {
+  color: var(--oc-text-strong);
+}
+
+[data-chat-theme="opencode"] [data-slot="basic-tool-tool-subtitle"] {
+  color: var(--oc-text-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="basic-tool-tool-spinner"] {
+  color: var(--oc-text-weak);
+}
+
+/* --- Tool status title --- */
+[data-chat-theme="opencode"] [data-component="tool-status-title"] [data-slot="tool-status-done"] {
+  color: var(--oc-text-strong);
+}
+
+/* --- Text shimmer --- */
+[data-chat-theme="opencode"] [data-component="text-shimmer"] {
+  --text-shimmer-base-color: var(--oc-text-weak);
+  --text-shimmer-peak-color: var(--oc-text-strong);
+}
+
+/* --- Collapsible triggers --- */
+[data-chat-theme="opencode"] [data-component="collapsible"] [data-slot="collapsible-trigger"] {
+  color: var(--oc-text-base);
+}
+
+[data-chat-theme="opencode"] [data-component="collapsible"] [data-slot="collapsible-arrow-icon"] {
+  color: var(--oc-icon-weak-base);
+}
+
+/* --- Collapsible arrow: hidden by default, revealed on hover/expanded --- */
+[data-chat-theme="opencode"] [data-slot="collapsible-arrow"] {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+[data-chat-theme="opencode"] [data-slot="collapsible-arrow-icon"] {
+  transform: translateZ(0) rotate(-90deg);
+  transition: transform 0.15s ease;
+  will-change: transform;
+}
+
+[data-chat-theme="opencode"] [data-slot="collapsible-trigger"]:hover [data-slot="collapsible-arrow"],
+[data-chat-theme="opencode"] [data-slot="collapsible-trigger"][aria-expanded="true"] [data-slot="collapsible-arrow"] {
+  opacity: 1;
+}
+
+[data-chat-theme="opencode"] [data-slot="collapsible-trigger"][aria-expanded="true"] [data-slot="collapsible-arrow-icon"] {
+  transform: translateZ(0) rotate(0deg);
+}
+
+/* --- Sticky tool headers for long-output tools --- */
+[data-chat-theme="opencode"] [data-component="edit-tool"] > [data-component="collapsible"] > [data-slot="collapsible-trigger"][aria-expanded="true"],
+[data-chat-theme="opencode"] [data-component="write-tool"] > [data-component="collapsible"] > [data-slot="collapsible-trigger"][aria-expanded="true"],
+[data-chat-theme="opencode"] [data-component="apply-patch-tool"] > [data-component="collapsible"] > [data-slot="collapsible-trigger"][aria-expanded="true"],
+[data-chat-theme="opencode"] [data-component="bash-tool"] > [data-component="collapsible"] > [data-slot="collapsible-trigger"][aria-expanded="true"] {
+  position: sticky;
+  top: var(--sticky-accordion-top, 0px);
+  z-index: 20;
+  padding-bottom: 8px;
+  background-color: var(--oc-background-stronger);
+}
+
+/* --- File accordion arrow (apply-patch / tool-file) --- */
+[data-chat-theme="opencode"] [data-slot="file-accordion-arrow"] {
+  color: var(--oc-icon-weak-base);
+  transform: translateZ(0) rotate(-90deg);
+  transition: transform 0.15s ease;
+  will-change: transform;
+  display: flex;
+  align-items: center;
+}
+
+[data-chat-theme="opencode"] [data-slot="file-accordion-arrow"][data-open] {
+  transform: translateZ(0) rotate(0deg);
+}
+
+/* --- Error cards --- */
+[data-chat-theme="opencode"] [data-component="tool-error-card"] {
+  background-color: var(--oc-surface-critical-weak);
+  border-color: var(--oc-border-critical-base);
+  color: var(--oc-text-on-critical-base);
+}
+
+[data-chat-theme="opencode"] [data-component="tool-error-card"] [data-component="icon"] {
+  color: var(--oc-icon-critical-base);
+}
+
+[data-chat-theme="opencode"] [data-component="generation-error"] {
+  background-color: var(--oc-surface-critical-weak);
+  border-color: var(--oc-border-critical-base);
+  color: var(--oc-text-on-critical-base);
+}
+
+/* --- Diagnostics (LSP errors) --- */
+[data-chat-theme="opencode"] [data-component="diagnostics"] {
+  background-color: var(--oc-surface-critical-weak);
+  border-top-color: var(--oc-border-critical-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="diagnostic-label"] {
+  color: var(--oc-text-on-critical-base);
+}
+
+/* --- Copy button: hidden by default, revealed on hover --- */
+[data-chat-theme="opencode"] [data-component="markdown-code"] [data-slot="markdown-copy-button"],
+[data-chat-theme="opencode"] [data-component="tool-output"] [data-component="copy-button"] {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  will-change: opacity;
+}
+
+[data-chat-theme="opencode"] [data-component="markdown-code"]:hover [data-slot="markdown-copy-button"],
+[data-chat-theme="opencode"] [data-component="markdown-code"]:focus-within [data-slot="markdown-copy-button"],
+[data-chat-theme="opencode"] [data-component="tool-output"]:hover [data-component="copy-button"],
+[data-chat-theme="opencode"] [data-component="tool-output"]:focus-within [data-component="copy-button"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* --- Copy button --- */
+[data-chat-theme="opencode"] [data-component="copy-button"] {
+  border-color: var(--oc-border-weak-base);
+  background: var(--oc-background-base);
+  color: var(--oc-text-base);
+}
+
+[data-chat-theme="opencode"] [data-component="copy-button"]:hover {
+  background: var(--oc-background-stronger);
+  color: var(--oc-text-strong);
+}
+
+[data-chat-theme="opencode"] [data-component="copy-button"][data-copied="true"] {
+  color: var(--oc-surface-success-strong);
+  border-color: var(--oc-border-success-base);
+}
+
+/* --- Diff change indicators --- */
+[data-chat-theme="opencode"] [data-slot="apply-patch-change"][data-type="added"] {
+  color: var(--oc-icon-diff-add-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="apply-patch-change"][data-type="removed"] {
+  color: var(--oc-icon-diff-delete-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="apply-patch-change"][data-type="modified"] {
+  color: var(--oc-icon-diff-modified-base);
+}
+
+/* --- Diff view backgrounds --- */
+[data-chat-theme="opencode"] {
+  --diffs-bg: var(--oc-surface-raised-stronger-non-alpha);
+  --diffs-bg-context: color-mix(in lab, var(--oc-background-stronger) 96%, var(--oc-text-strong));
+}
+
+/* --- Message divider (compaction) --- */
+[data-chat-theme="opencode"] [data-slot="compaction-part-line"] {
+  background: var(--oc-border-weak-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="compaction-part-label"] {
+  color: var(--oc-text-base);
+}
+
+/* --- Session turn thinking --- */
+[data-chat-theme="opencode"] [data-slot="session-turn-thinking"] {
+  color: var(--oc-text-weak);
+}
+
+/* --- Dock surface (prompt input area) --- */
+[data-chat-theme="opencode"] .chat-dock-panel {
+  background-color: var(--oc-surface-raised-stronger-non-alpha);
+  box-shadow: var(--oc-shadow-xs-border);
+  border-color: var(--oc-border-weak-base);
+}
+
+/* --- Card component (used for tool error cards, etc.) --- */
+[data-chat-theme="opencode"] [data-component="card"]::before {
+  background-color: var(--oc-icon-active);
+}
+
+[data-chat-theme="opencode"] [data-component="card"][data-kind="tool-error-card"]::before {
+  background-color: var(--oc-icon-critical-base);
+}
+
+[data-chat-theme="opencode"] [data-component="card"] [data-slot="card-description"] {
+  color: var(--oc-text-base);
+}
+
+/* --- Scrollbar thumb --- */
+[data-chat-theme="opencode"] .thin-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--oc-surface-base-hover);
+}
+
+[data-chat-theme="opencode"] .thin-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--oc-surface-weak);
+}
+
+/* --- User message meta & text-part meta --- */
+[data-chat-theme="opencode"] [data-slot="user-message-meta"],
+[data-chat-theme="opencode"] [data-slot="text-part-meta"] {
+  color: var(--oc-text-base);
+}
+
+/* --- Session turn collapsible trigger content --- */
+[data-chat-theme="opencode"] [data-slot="session-turn-collapsible-trigger-content"] {
+  color: var(--oc-text-base);
+}
+
+/* ================================================================
+   4. QUESTION DOCK
+   OpenCode-style question dock with shell + tray layout.
+   ================================================================ */
+
+[data-chat-theme="opencode"] [data-component="question-dock"] {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 0;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-shell"] {
+  background-color: var(--oc-surface-raised-stronger-non-alpha);
+  box-shadow: var(--oc-shadow-xs-border);
+  border-radius: 12px;
+  overflow: clip;
+  position: relative;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 8px 8px 0;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-tray"] {
+  background-color: var(--oc-background-base);
+  border: 1px solid var(--oc-border-weak-base);
+  border-radius: 0 0 12px 12px;
+  margin-top: -0.875rem;
+  overflow: clip;
+  position: relative;
+  z-index: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 32px 8px 8px;
+}
+
+/* --- Header --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-header"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 10px;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-title"] {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--oc-text-strong);
+  min-width: 0;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-progress"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-segment"] {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-segment"]::after {
+  content: "";
+  width: 16px;
+  height: 2px;
+  border-radius: 999px;
+  background-color: var(--oc-icon-weak-base);
+  transition: background-color 0.2s ease;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-segment"][data-active]::after {
+  background-color: var(--oc-icon-strong-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-segment"][data-answered]::after {
+  background-color: var(--oc-icon-interactive-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-segment"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* --- Content --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-content"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-text"] {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--oc-text-strong);
+  padding: 0 10px;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-hint"] {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--oc-text-weak);
+  padding: 0 10px;
+}
+
+/* --- Options list --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-options"] {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 1px 1px 8px;
+  flex: 1;
+  min-height: 0;
+  max-height: 40vh;
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-options"]::-webkit-scrollbar {
+  display: none;
+}
+
+/* --- Option button --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-option"] {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 8px 8px 8px 10px;
+  background-color: var(--oc-surface-raised-stronger-non-alpha);
+  border: 1px solid var(--oc-border-weak-base);
+  border-radius: 6px;
+  box-shadow: none;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  font-size: 14px;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option"]:hover:not([data-picked]) {
+  background-color: var(--oc-background-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option"][data-picked] {
+  background-color: var(--oc-surface-interactive-weak);
+  border-color: transparent;
+  box-shadow: var(--oc-shadow-xs-border);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* --- Checkbox / radio indicator --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-option-check"] {
+  display: inline-flex;
+  transform: translateY(2px);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"] {
+  width: 16px;
+  height: 16px;
+  padding: 2px;
+  border-radius: var(--oc-radius-sm);
+  border: 1px solid var(--oc-border-weak-base);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background-color: transparent;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"] [data-slot="question-dock-check-icon"] {
+  opacity: 0;
+  color: var(--oc-icon-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"][data-type="radio"] {
+  border-radius: 999px;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-radio-dot"] {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background-color: var(--oc-background-stronger);
+  opacity: 0;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"][data-picked] {
+  border-color: var(--oc-icon-interactive-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"][data-picked] [data-slot="question-dock-check-icon"] {
+  opacity: 1;
+  color: var(--oc-text-invert-strong);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"][data-picked][data-type="checkbox"] {
+  background-color: var(--oc-icon-interactive-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"][data-picked][data-type="radio"] {
+  background-color: var(--oc-icon-interactive-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-box"][data-picked] [data-slot="question-dock-option-radio-dot"] {
+  opacity: 1;
+}
+
+/* --- Option label / description --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-option-main"] {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-label"] {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--oc-text-strong);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-option-desc"] {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--oc-text-base);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+/* --- Custom textarea input --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-custom-input"] {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  outline: none;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--oc-text-base);
+  min-width: 0;
+  cursor: text;
+  resize: none;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-custom-input"]::placeholder {
+  color: var(--oc-text-weak);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-custom-input"]:focus-visible {
+  outline: 1px solid var(--oc-border-interactive-base);
+  outline-offset: 2px;
+  border-radius: var(--oc-radius-xs);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-custom-input"]:disabled {
+  opacity: 0.6;
+}
+
+/* --- Footer buttons --- */
+[data-chat-theme="opencode"] [data-slot="question-dock-actions"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"] {
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"][data-variant="ghost"] {
+  background: transparent;
+  color: var(--oc-text-base);
+  border-color: transparent;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"][data-variant="ghost"]:hover:not(:disabled) {
+  background: var(--oc-button-ghost-hover);
+  color: var(--oc-text-strong);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"][data-variant="secondary"] {
+  background: var(--oc-button-secondary-base);
+  color: var(--oc-text-strong);
+  border-color: var(--oc-border-weak-base);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"][data-variant="secondary"]:hover:not(:disabled) {
+  background: var(--oc-button-secondary-hover);
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"][data-variant="primary"] {
+  background: var(--oc-button-primary-base);
+  color: var(--oc-background-base);
+  border-color: transparent;
+}
+
+[data-chat-theme="opencode"] [data-slot="question-dock-btn"][data-variant="primary"]:hover:not(:disabled) {
+  opacity: 0.9;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,8 @@
         "katex": "^0.16.28",
         "lucide-react": "^0.546.0",
         "marked": "^17.0.1",
+        "morphdom": "^2.7.8",
+        "motion": "^12.38.0",
         "pdfjs-dist": "^5.4.530",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -810,6 +812,8 @@
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "frontend": ["frontend@workspace:apps/frontend"],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
@@ -999,6 +1003,14 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
+
+    "morphdom": ["morphdom@2.7.8", "", {}, "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg=="],
+
+    "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 


### PR DESCRIPTION
## Summary
- New tool rendering system with dedicated components: ShellSubmessage, ToolErrorCard, BasicTool, ToolStatusTitle, MessageDivider
- Animated UI elements: AnimatedCountLabel, AnimatedCountList, AnimatedNumber
- Interactive docks: QuestionDock, TodoDock
- Refactored Markdown, Collapsible, ToolPartView, ChatSidebar, PromptInput, and QuickSwitcher
- Added opencode-chat.css stylesheet and expanded globals.css with chat-specific styles
- Updated chat stores for new event handling and session management

## Test plan
- [ ] Verify chat sidebar renders correctly with new styling
- [ ] Test tool calls display (shell commands, errors, diffs)
- [ ] Test animated counters and collapsible sections
- [ ] Test prompt input and model selector
- [ ] Verify QuickSwitcher still works after refactor