### PR TITLE
Add PDF export and chat UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ nul
 
 # IDE
 .vscode/
+.cushion/
 
 # Testing
 coverage/

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -10,7 +10,8 @@
     "type-check": "tsc -b"
   },
   "dependencies": {
-    "@cushion/types": "workspace:*"
+    "@cushion/types": "workspace:*",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain, dialog, nativeImage } from 'electron';
+import './pdf-export';
 import { join } from 'path';
 import windowStateKeeper from 'electron-window-state';
 import { startCoordinator, stopCoordinator, getCoordinatorPort } from './coordinator';

--- a/apps/electron/src/main/pdf-export.ts
+++ b/apps/electron/src/main/pdf-export.ts
@@ -1,0 +1,131 @@
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { writeFile } from 'fs/promises';
+import { PDFDocument, PDFDict, PDFName, PDFString, PDFArray, PDFRef } from 'pdf-lib';
+
+interface PdfExportOptions {
+  pageSize: 'A4' | 'Letter' | 'Legal';
+  orientation: 'portrait' | 'landscape';
+  margins: 'default' | 'narrow' | 'none';
+  showLinkUrls: boolean;
+}
+
+interface ExportPdfPayload {
+  html: string;
+  title: string;
+  options: PdfExportOptions;
+}
+
+interface HeadingInfo {
+  level: number;
+  text: string;
+}
+
+function parseHeadings(html: string): HeadingInfo[] {
+  const headings: HeadingInfo[] = [];
+  const re = /<h([1-6])[^>]*>(.*?)<\/h[1-6]>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const text = match[2].replace(/<[^>]*>/g, '').trim();
+    if (text) {
+      headings.push({ level: Number(match[1]), text });
+    }
+  }
+  return headings;
+}
+
+async function addPdfMetadataAndOutline(
+  pdfBuffer: Buffer,
+  title: string,
+  headings: HeadingInfo[],
+): Promise<Uint8Array> {
+  const doc = await PDFDocument.load(pdfBuffer);
+
+  doc.setTitle(title);
+  doc.setCreationDate(new Date());
+  doc.setProducer('Cushion');
+
+  if (headings.length > 0) {
+    const pages = doc.getPages();
+    const firstPageRef = doc.getPage(0).ref;
+
+    const outlineItemRefs: PDFRef[] = [];
+    const outlineItems: PDFDict[] = [];
+
+    for (const heading of headings) {
+      const item = doc.context.obj({
+        Title: PDFString.of(heading.text),
+        Dest: [firstPageRef, PDFName.of('Fit')],
+      });
+      const ref = doc.context.register(item);
+      outlineItemRefs.push(ref);
+      outlineItems.push(item);
+    }
+
+    // Link items as a flat linked list
+    for (let i = 0; i < outlineItems.length; i++) {
+      if (i > 0) outlineItems[i].set(PDFName.of('Prev'), outlineItemRefs[i - 1]);
+      if (i < outlineItems.length - 1) outlineItems[i].set(PDFName.of('Next'), outlineItemRefs[i + 1]);
+    }
+
+    const outline = doc.context.obj({
+      Type: PDFName.of('Outlines'),
+      First: outlineItemRefs[0],
+      Last: outlineItemRefs[outlineItemRefs.length - 1],
+      Count: outlineItems.length,
+    });
+    const outlineRef = doc.context.register(outline);
+
+    // Set Parent on all items
+    for (const item of outlineItems) {
+      item.set(PDFName.of('Parent'), outlineRef);
+    }
+
+    doc.catalog.set(PDFName.of('Outlines'), outlineRef);
+  }
+
+  return doc.save();
+}
+
+ipcMain.handle('export:pdf', async (_event, { html, title, options }: ExportPdfPayload) => {
+  const { canceled, filePath } = await dialog.showSaveDialog({
+    defaultPath: `${title}.pdf`,
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+  });
+
+  if (canceled || !filePath) return null;
+
+  const win = new BrowserWindow({
+    show: false,
+    width: 800,
+    height: 600,
+    webPreferences: { offscreen: true },
+  });
+
+  try {
+    await win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const pdfBuffer = await win.webContents.printToPDF({
+      pageSize: options.pageSize,
+      landscape: options.orientation === 'landscape',
+      printBackground: true,
+      preferCSSPageSize: true,
+      generateTaggedPDF: true,
+    });
+
+    const headings = parseHeadings(html);
+    const finalBuffer = await addPdfMetadataAndOutline(
+      Buffer.from(pdfBuffer),
+      title,
+      headings,
+    );
+
+    await writeFile(filePath, finalBuffer);
+    return { success: true, path: filePath };
+  } catch (err) {
+    console.error('[pdf-export] Failed:', err);
+    return { success: false, path: filePath };
+  } finally {
+    win.destroy();
+  }
+});

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -9,4 +9,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onOpenWorkspace: (callback: (path: string) => void) => {
     ipcRenderer.on('open-workspace', (_event, path) => callback(path));
   },
+  exportPdf: (data: { html: string; title: string; options: unknown }) =>
+    ipcRenderer.invoke('export:pdf', data),
 });

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -847,8 +847,6 @@ body {
 
 [data-slot="session-turn-sticky"] {
   width: calc(100% + 9px);
-  position: sticky;
-  top: var(--session-title-height, 0px);
   z-index: 20;
   background-color: var(--sidebar-bg);
   margin-left: -9px;
@@ -891,24 +889,6 @@ body {
   border-color: var(--background-modifier-border-focus);
 }
 
-[data-slot="session-turn-sticky"]::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-color: var(--sidebar-bg);
-  z-index: -1;
-}
-
-[data-slot="session-turn-sticky"]::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  height: 32px;
-  background: linear-gradient(to bottom, var(--sidebar-bg), transparent);
-  pointer-events: none;
-}
 
 [data-slot="session-turn-message-content"] {
   margin-top: 0;

--- a/apps/frontend/components/editor/EditorNavRow.tsx
+++ b/apps/frontend/components/editor/EditorNavRow.tsx
@@ -10,6 +10,7 @@ interface EditorNavRowProps {
   onGoForward: () => void;
   focusModeEnabled?: boolean;
   onToggleFocusMode?: () => void;
+  onShare?: () => void;
   centerContent?: ReactNode;
   centerTitle?: string;
 }
@@ -21,6 +22,7 @@ export function EditorNavRow({
   onGoForward,
   focusModeEnabled,
   onToggleFocusMode,
+  onShare,
   centerContent,
   centerTitle,
 }: EditorNavRowProps) {
@@ -88,6 +90,7 @@ export function EditorNavRow({
         )}
 
         <button
+          onClick={onShare}
           className={cn(
             'h-8 w-8 flex-shrink-0 flex items-center justify-center rounded',
             'text-muted-foreground hover:text-foreground',

--- a/apps/frontend/components/editor/EditorPanel.tsx
+++ b/apps/frontend/components/editor/EditorPanel.tsx
@@ -22,6 +22,9 @@ import { BINARY_FILE_EXTENSIONS } from '@/lib/binary-extensions';
 import type { WikiLinkNavigateCallback } from '@/lib/codemirror-wysiwyg';
 import { DiffReviewBar } from './DiffReviewBar';
 import { useDiffReviewStore } from '@/stores/diffReviewStore';
+import { exportToPdf } from '@/lib/pdf-export';
+import { ExportOptionsDialog } from './ExportOptionsDialog';
+import type { PdfExportOptions } from '@cushion/types';
 
 interface EditorPanelProps {
   client: CoordinatorClient;
@@ -169,6 +172,7 @@ export function EditorPanel({
   const openedUrisRef = useRef<Set<string>>(new Set());
   const [pdfData, setPdfData] = useState<PdfDataState | null>(null);
   const [imageData, setImageData] = useState<{ filePath: string; base64: string; mimeType: string } | null>(null);
+  const [showExportDialog, setShowExportDialog] = useState(false);
 
   useEffect(() => {
     historyRef.current = {
@@ -460,6 +464,22 @@ export function EditorPanel({
     );
   }, []);
 
+  const handleShare = useCallback(() => {
+    if (!currentFile) return;
+    setShowExportDialog(true);
+  }, [currentFile]);
+
+  const handleExportPdf = useCallback(async (options: PdfExportOptions) => {
+    setShowExportDialog(false);
+    if (!currentFile) return;
+    const file = useWorkspaceStore.getState().openFiles.get(currentFile);
+    if (!file) return;
+    const pathParts = currentFile.split(/[/\\]/);
+    const fileName = pathParts[pathParts.length - 1];
+    const baseName = fileName.includes('.') ? fileName.slice(0, fileName.lastIndexOf('.')) : fileName;
+    await exportToPdf(file.content, baseName, options);
+  }, [currentFile]);
+
   const pdfFilePath = pdfData?.filePath ?? currentFile ?? null;
 
   const readPdfChunk = useCallback(
@@ -523,6 +543,7 @@ export function EditorPanel({
             onGoForward={goForward}
             focusModeEnabled={focusModeEnabled}
             onToggleFocusMode={onToggleFocusMode}
+            onShare={handleShare}
             centerContent={breadcrumb.text}
             centerTitle={breadcrumb.title}
           />
@@ -646,6 +667,12 @@ export function EditorPanel({
           </div>
         )}
       </div>
+
+      <ExportOptionsDialog
+        isOpen={showExportDialog}
+        onClose={() => setShowExportDialog(false)}
+        onExport={handleExportPdf}
+      />
     </div>
   );
 }

--- a/apps/frontend/components/editor/ExportOptionsDialog.tsx
+++ b/apps/frontend/components/editor/ExportOptionsDialog.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import { FileDown, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type {
+  PdfExportOptions,
+  PdfPageSize,
+  PdfOrientation,
+  PdfMarginPreset,
+} from '@cushion/types';
+
+interface ExportOptionsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExport: (options: PdfExportOptions) => void;
+}
+
+const PAGE_SIZES: { value: PdfPageSize; label: string }[] = [
+  { value: 'A4', label: 'A4' },
+  { value: 'Letter', label: 'Letter' },
+  { value: 'Legal', label: 'Legal' },
+];
+
+const ORIENTATIONS: { value: PdfOrientation; label: string }[] = [
+  { value: 'portrait', label: 'Portrait' },
+  { value: 'landscape', label: 'Landscape' },
+];
+
+const MARGINS: { value: PdfMarginPreset; label: string }[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'narrow', label: 'Narrow' },
+  { value: 'none', label: 'None' },
+];
+
+export function ExportOptionsDialog({
+  isOpen,
+  onClose,
+  onExport,
+}: ExportOptionsDialogProps) {
+  const [pageSize, setPageSize] = useState<PdfPageSize>('A4');
+  const [orientation, setOrientation] = useState<PdfOrientation>('portrait');
+  const [margins, setMargins] = useState<PdfMarginPreset>('default');
+  const [showLinkUrls, setShowLinkUrls] = useState(false);
+  const [headerText, setHeaderText] = useState('');
+  const [footerText, setFooterText] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleExport = () => {
+    onExport({ pageSize, orientation, margins, showLinkUrls, headerText, footerText });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-confirm flex items-center justify-center bg-[var(--overlay-50)]"
+      onClick={onClose}
+    >
+      <div
+        className="bg-modal-bg rounded-lg w-[520px] max-w-[90%] flex flex-col shadow-lg animate-slide-in border border-modal-border"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start gap-3 px-5 pt-5 pb-4">
+          <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-border-subtle text-foreground-muted">
+            <FileDown size={20} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-base font-semibold text-foreground">
+              Export PDF
+            </h3>
+            <p className="text-sm text-foreground-muted leading-normal">
+              Configure export settings
+            </p>
+          </div>
+          <button
+            className="shrink-0 p-1 rounded cursor-pointer flex items-center justify-center text-foreground-muted hover:bg-[var(--overlay-10)] hover:text-foreground transition-all"
+            onClick={onClose}
+            title="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 pb-4 space-y-4">
+          <OptionRow label="Page size">
+            <SegmentedControl
+              options={PAGE_SIZES}
+              value={pageSize}
+              onChange={setPageSize}
+            />
+          </OptionRow>
+
+          <OptionRow label="Orientation">
+            <SegmentedControl
+              options={ORIENTATIONS}
+              value={orientation}
+              onChange={setOrientation}
+            />
+          </OptionRow>
+
+          <OptionRow label="Margins">
+            <SegmentedControl
+              options={MARGINS}
+              value={margins}
+              onChange={setMargins}
+            />
+          </OptionRow>
+
+          <OptionRow label="Header">
+            <input
+              type="text"
+              value={headerText}
+              onChange={(e) => setHeaderText(e.target.value)}
+              placeholder="Optional"
+              className="w-48 px-2.5 py-1.5 rounded text-sm bg-transparent border border-modal-border text-foreground placeholder:text-foreground-muted/50 outline-none focus:border-accent transition-colors"
+            />
+          </OptionRow>
+
+          <OptionRow label="Footer">
+            <input
+              type="text"
+              value={footerText}
+              onChange={(e) => setFooterText(e.target.value)}
+              placeholder="Optional"
+              className="w-48 px-2.5 py-1.5 rounded text-sm bg-transparent border border-modal-border text-foreground placeholder:text-foreground-muted/50 outline-none focus:border-accent transition-colors"
+            />
+          </OptionRow>
+
+          <OptionRow label="Show link URLs">
+            <button
+              onClick={() => setShowLinkUrls(!showLinkUrls)}
+              className={cn(
+                'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border transition-colors',
+                showLinkUrls
+                  ? 'bg-accent border-accent'
+                  : 'bg-[var(--border-subtle)] border-border',
+              )}
+            >
+              <span
+                className={cn(
+                  'inline-block size-4 rounded-full bg-surface shadow transition-transform',
+                  showLinkUrls ? 'translate-x-4' : 'translate-x-0.5',
+                )}
+              />
+            </button>
+          </OptionRow>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 pt-4 pb-5">
+          <button
+            className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border border-modal-border bg-transparent text-foreground hover:bg-[var(--overlay-10)] transition-all"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border-none bg-accent text-surface hover:bg-accent-hover transition-all"
+            onClick={handleExport}
+            autoFocus
+          >
+            Export
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OptionRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-sm text-foreground-muted">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="flex gap-1">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            'px-3 py-1.5 rounded text-sm cursor-pointer transition-all',
+            opt.value === value
+              ? 'bg-accent text-surface'
+              : 'bg-transparent border border-modal-border text-foreground-muted hover:bg-[var(--overlay-10)]',
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/lib/pdf-export.ts
+++ b/apps/frontend/lib/pdf-export.ts
@@ -1,69 +1,235 @@
-import { marked } from 'marked';
+import { marked, Renderer } from 'marked';
+import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript';
+import typescript from 'highlight.js/lib/languages/typescript';
+import python from 'highlight.js/lib/languages/python';
+import css from 'highlight.js/lib/languages/css';
+import json from 'highlight.js/lib/languages/json';
+import bash from 'highlight.js/lib/languages/bash';
+import xml from 'highlight.js/lib/languages/xml';
+import go from 'highlight.js/lib/languages/go';
+import rust from 'highlight.js/lib/languages/rust';
+import sql from 'highlight.js/lib/languages/sql';
+import yaml from 'highlight.js/lib/languages/yaml';
+import markdown from 'highlight.js/lib/languages/markdown';
+import hljsTheme from 'highlight.js/styles/github.css?raw';
+import type { PdfExportOptions } from '@cushion/types';
 
-export async function exportToPdf(markdownContent: string, filename: string): Promise<void> {
-  const htmlContent = await marked(markdownContent);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('js', javascript);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('ts', typescript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('py', python);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('sh', bash);
+hljs.registerLanguage('shell', bash);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('html', xml);
+hljs.registerLanguage('go', go);
+hljs.registerLanguage('rust', rust);
+hljs.registerLanguage('rs', rust);
+hljs.registerLanguage('sql', sql);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('yml', yaml);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('md', markdown);
 
-  const printWindow = window.open('', '_blank');
-  if (!printWindow) {
-    alert('Please allow popups to export PDF');
-    return;
-  }
+const MARGIN_MAP: Record<PdfExportOptions['margins'], string> = {
+  default: '25mm 20mm',
+  narrow: '15mm 10mm',
+  none: '0',
+};
 
-  printWindow.document.write(`<!DOCTYPE html>
+export async function exportToPdf(
+  markdown: string,
+  title: string,
+  options: PdfExportOptions,
+): Promise<void> {
+  const html = buildPdfHtml(markdown, title, options);
+  await window.electronAPI!.exportPdf({ html, title, options });
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]*>/g, '')
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+function buildPdfHtml(
+  source: string,
+  title: string,
+  options: PdfExportOptions,
+): string {
+  const renderer = new Renderer();
+
+  renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
+    let highlighted: string;
+    if (lang && hljs.getLanguage(lang)) {
+      highlighted = hljs.highlight(text, { language: lang }).value;
+    } else {
+      highlighted = hljs.highlightAuto(text).value;
+    }
+    const langClass = lang ? ` class="language-${escapeHtml(lang)}"` : '';
+    return `<pre><code${langClass}>${highlighted}</code></pre>\n`;
+  };
+
+  renderer.heading = ({ text, depth }: { text: string; depth: number }) => {
+    const id = slugify(text);
+    return `<h${depth} id="${escapeHtml(id)}">${text}</h${depth}>\n`;
+  };
+
+  const body = marked.parse(source, { async: false, renderer }) as string;
+
+  const pageSize = options.pageSize;
+  const orientation =
+    options.orientation === 'landscape' ? ' landscape' : '';
+  const margin = MARGIN_MAP[options.margins];
+
+  const linkUrlRule = options.showLinkUrls
+    ? 'a[href^="http"]::after { content: " (" attr(href) ")"; font-size: 0.85em; color: #666666; }'
+    : '';
+
+  return `<!DOCTYPE html>
 <html>
 <head>
-<title>${filename}</title>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
 <style>
-  :root {
-    --N0: #ffffff;
-    --N1: #fafafa;
-    --N2: #f5f5f5;
-    --N3: #f0f0f0;
-    --N4: #e0e0e0;
-    --N7: #6b6b6b;
-    --N8: #333333;
-    --A500: #3b82f6;
-    --background: var(--N1);
-    --surface: var(--N0);
-    --foreground: var(--N8);
-    --foreground-muted: var(--N7);
-    --border: var(--N4);
-    --border-subtle: var(--N3);
-    --code-bg: var(--N2);
-    --accent-primary: var(--A500);
+  @page {
+    size: ${pageSize}${orientation};
+    margin: ${margin};
+    @bottom-center {
+      content: counter(page);
+      font-size: 9pt;
+      color: #1a1a1a;
+    }${options.headerText ? `
+    @top-left {
+      content: "${escapeHtml(options.headerText).replace(/"/g, '\\"')}";
+      font-size: 9pt;
+      color: #1a1a1a;
+    }` : ''}${options.footerText ? `
+    @bottom-left {
+      content: "${escapeHtml(options.footerText).replace(/"/g, '\\"')}";
+      font-size: 9pt;
+      color: #1a1a1a;
+    }` : ''}
   }
+
+  * { box-sizing: border-box; }
+
   body {
     font-family: Georgia, 'Times New Roman', serif;
-    max-width: 800px;
-    margin: 40px auto;
-    padding: 0 20px;
+    font-size: 12pt;
     line-height: 1.6;
-    color: var(--foreground);
-    background: var(--surface);
-    font-size: 14px;
+    color: #1a1a1a;
+    background: #ffffff;
+    margin: 0;
+    padding: 0;
   }
-  h1, h2, h3, h4, h5, h6 { font-family: -apple-system, sans-serif; margin-top: 1.5em; color: var(--foreground); }
-  h1 { font-size: 2em; border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
-  h2 { font-size: 1.5em; border-bottom: 1px solid var(--border-subtle); padding-bottom: 0.2em; }
-  a { color: var(--accent-primary); }
-  code { background: var(--code-bg); padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
-  pre { background: var(--code-bg); padding: 16px; border-radius: 6px; overflow-x: auto; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid var(--border); margin-left: 0; padding-left: 16px; color: var(--foreground-muted); }
-  table { border-collapse: collapse; width: 100%; }
-  th, td { border: 1px solid var(--border); padding: 8px; text-align: left; }
-  th { background: var(--border-subtle); }
-  img { max-width: 100%; }
-  @media print {
-    body { margin: 0; padding: 20px; }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+    color: #111111;
+    page-break-after: avoid;
   }
+
+  h1 { font-size: 2em; }
+  h2 { font-size: 1.5em; }
+  h3 { font-size: 1.25em; }
+
+  body > :first-child { margin-top: 0; }
+
+  p {
+    margin: 0.8em 0;
+    orphans: 3;
+    widows: 3;
+  }
+
+  a { color: #2563eb; text-decoration: none; }
+  ${linkUrlRule}
+
+  code {
+    background: #f3f3f3;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.9em;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  }
+
+  pre {
+    background: #f6f6f6;
+    border: 1px solid #e0e0e0;
+    padding: 14px 16px;
+    border-radius: 6px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    page-break-inside: avoid;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+  }
+
+  blockquote {
+    border-left: 4px solid #d0d0d0;
+    margin: 1em 0;
+    padding: 0.5em 0 0.5em 16px;
+    color: #555555;
+    page-break-inside: avoid;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+    page-break-inside: avoid;
+  }
+
+  th, td {
+    border: 1px solid #d0d0d0;
+    padding: 8px 12px;
+    text-align: left;
+  }
+
+  th { background: #f0f0f0; font-weight: 600; }
+
+  img {
+    max-width: 100%;
+    page-break-inside: avoid;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid #d0d0d0;
+    margin: 2em 0;
+  }
+
+  ul, ol { padding-left: 2em; }
+  li { margin: 0.3em 0; }
+
+  ${hljsTheme}
 </style>
 </head>
-<body>${htmlContent}</body>
-</html>`);
+<body>${body}</body>
+</html>`;
+}
 
-  printWindow.document.close();
-  setTimeout(() => {
-    printWindow.print();
-  }, 250);
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -41,6 +41,7 @@
     "diff": "^8.0.3",
     "dompurify": "^3.3.1",
     "fuzzysort": "^3.1.0",
+    "highlight.js": "^11.11.1",
     "katex": "^0.16.28",
     "lucide-react": "^0.546.0",
     "marked": "^17.0.1",

--- a/apps/frontend/src/electron.d.ts
+++ b/apps/frontend/src/electron.d.ts
@@ -10,6 +10,13 @@ export interface ElectronAPI {
 
   // Open workspace from OS
   onOpenWorkspace: (callback: (path: string) => void) => void;
+
+  // PDF export
+  exportPdf: (data: {
+    html: string;
+    title: string;
+    options: import('@cushion/types').PdfExportOptions;
+  }) => Promise<{ success: boolean; path: string } | null>;
 }
 
 declare global {

--- a/apps/frontend/stores/chat-store-utils.ts
+++ b/apps/frontend/stores/chat-store-utils.ts
@@ -166,7 +166,7 @@ export const MAX_PROMPT_SESSIONS = 20;
 
 export const DEFAULT_DISPLAY_PREFERENCES: DisplayPreferences = {
   showThinking: true,
-  shellToolPartsExpanded: true,
+  shellToolPartsExpanded: false,
   editToolPartsExpanded: false,
 };
 

--- a/apps/frontend/styles/opencode-chat.css
+++ b/apps/frontend/styles/opencode-chat.css
@@ -71,7 +71,7 @@
   --oc-text-weak: #8f8f8f;
   --oc-text-weaker: #c7c7c7;
   --oc-text-strong: #171717;
-  --oc-text-interactive-base: #7c3aed;
+  --oc-text-interactive-base: var(--accent-primary);
   --oc-text-on-brand-base: rgba(0, 0, 0, 0.574);
   --oc-text-on-critical-base: #ed4831;
   --oc-text-on-critical-weak: #fe806a;
@@ -109,7 +109,7 @@
   --oc-icon-weak-base: #dbdbdb;
   --oc-icon-weaker: #dbdbdb;
   --oc-icon-strong-base: #171717;
-  --oc-icon-interactive-base: #7c3aed;
+  --oc-icon-interactive-base: var(--accent-primary);
   --oc-icon-success-base: #7add71;
   --oc-icon-critical-base: #ed4831;
   --oc-icon-warning-base: #ebb76e;
@@ -120,10 +120,10 @@
   --oc-icon-agent-plan-base: #a753ae;
   --oc-icon-agent-docs-base: #fcb239;
   --oc-icon-agent-ask-base: #8b5cf6;
-  --oc-icon-agent-build-base: #7c3aed;
+  --oc-icon-agent-build-base: var(--accent-primary);
 
   /* ---- Syntax highlighting ---- */
-  --oc-syntax-string: #6d28d9;
+  --oc-syntax-string: var(--accent-primary);
 
   /* ---- Shadows ---- */
   --oc-shadow-xs-border:
@@ -157,9 +157,6 @@
   --background-modifier-border: var(--oc-border-weak-base);
   --background-modifier-border-hover: var(--oc-border-weaker-base);
   --background-modifier-border-focus: var(--oc-border-base);
-  --interactive-accent: var(--oc-text-interactive-base);
-  --interactive-accent-hover: #0240d9;
-  --accent-primary: var(--oc-text-interactive-base);
   --accent-green: var(--oc-surface-success-strong);
   --accent-red: var(--oc-surface-critical-strong);
   --accent-yellow: var(--oc-surface-warning-strong);
@@ -167,7 +164,6 @@
   --accent-red-12: var(--oc-surface-critical-weak);
   --overlay-10: var(--oc-surface-base);
   --overlay-20: var(--oc-surface-base-hover);
-  --text-accent: var(--oc-text-interactive-base);
 }
 
 /* ================================================================
@@ -226,7 +222,7 @@
   --oc-text-weak: rgba(255, 255, 255, 0.422);
   --oc-text-weaker: rgba(255, 255, 255, 0.284);
   --oc-text-strong: rgba(255, 255, 255, 0.936);
-  --oc-text-interactive-base: #be9dfe;
+  --oc-text-interactive-base: var(--accent-primary);
   --oc-text-on-brand-base: rgba(255, 255, 255, 0.603);
   --oc-text-on-critical-base: #fc533a;
   --oc-text-on-critical-weak: #b72d1a;
@@ -261,7 +257,7 @@
   --oc-icon-weak-base: #343434;
   --oc-icon-weaker: #343434;
   --oc-icon-strong-base: #ededed;
-  --oc-icon-interactive-base: #7c3aed;
+  --oc-icon-interactive-base: var(--accent-primary);
   --oc-icon-success-base: #12c905;
   --oc-icon-critical-base: #fc533a;
   --oc-icon-warning-base: #fbb73c;
@@ -272,9 +268,9 @@
   --oc-icon-agent-plan-base: #edb2f1;
   --oc-icon-agent-docs-base: #fbb73c;
   --oc-icon-agent-ask-base: #a78bfa;
-  --oc-icon-agent-build-base: #be9dfe;
+  --oc-icon-agent-build-base: var(--accent-primary);
 
-  --oc-syntax-string: #be9dfe;
+  --oc-syntax-string: var(--accent-primary);
 
   --oc-shadow-xs-border:
     0 0 0 1px var(--oc-border-base), 0 1px 2px -1px rgba(19, 16, 16, 0.04),
@@ -296,9 +292,6 @@
   --background-modifier-border: var(--oc-border-weak-base);
   --background-modifier-border-hover: var(--oc-border-weaker-base);
   --background-modifier-border-focus: var(--oc-border-base);
-  --interactive-accent: var(--oc-text-interactive-base);
-  --interactive-accent-hover: #7ea9ff;
-  --accent-primary: var(--oc-text-interactive-base);
   --accent-green: var(--oc-surface-success-strong);
   --accent-red: var(--oc-surface-critical-strong);
   --accent-yellow: var(--oc-surface-warning-strong);
@@ -306,7 +299,6 @@
   --accent-red-12: var(--oc-surface-critical-weak);
   --overlay-10: var(--oc-surface-base);
   --overlay-20: var(--oc-surface-base-hover);
-  --text-accent: var(--oc-text-interactive-base);
 }
 
 /* ================================================================
@@ -327,26 +319,13 @@
   color: var(--oc-text-strong);
 }
 
-/* --- Sticky turn headers --- */
-[data-chat-theme="opencode"] [data-slot="session-turn-sticky"] {
-  background-color: var(--oc-background-stronger);
-}
-
-[data-chat-theme="opencode"] [data-slot="session-turn-sticky"]::before {
-  background-color: var(--oc-background-stronger);
-}
-
-[data-chat-theme="opencode"] [data-slot="session-turn-sticky"]::after {
-  background: linear-gradient(to bottom, var(--oc-background-stronger), transparent);
-}
-
 /* --- Markdown in chat --- */
 [data-chat-theme="opencode"] [data-component="markdown"] {
   color: var(--oc-text-strong);
 }
 
 [data-chat-theme="opencode"] [data-component="markdown"] a {
-  color: var(--oc-text-interactive-base);
+  color: var(--accent-primary);
 }
 
 [data-chat-theme="opencode"] [data-component="markdown"] :not(pre) > code {
@@ -361,6 +340,7 @@
 [data-chat-theme="opencode"] [data-component="markdown"] pre,
 [data-chat-theme="opencode"] [data-component="markdown"] .shiki {
   border-color: var(--oc-border-weak-base);
+  background: var(--oc-surface-base-hover);
 }
 
 [data-chat-theme="opencode"] [data-component="markdown"] th {
@@ -507,6 +487,13 @@
 [data-chat-theme="opencode"] [data-component="tool-output"]:focus-within [data-component="copy-button"] {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* --- Bash output box --- */
+[data-chat-theme="opencode"] [data-component="bash-output"] [data-slot="bash-pre"] {
+  border: 1px solid var(--oc-border-base);
+  border-radius: 6px;
+  padding: 6px 8px;
 }
 
 /* --- Copy button --- */

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@cushion/types": "workspace:*",
+        "pdf-lib": "^1.17.1",
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
@@ -75,6 +76,7 @@
         "diff": "^8.0.3",
         "dompurify": "^3.3.1",
         "fuzzysort": "^3.1.0",
+        "highlight.js": "^11.11.1",
         "katex": "^0.16.28",
         "lucide-react": "^0.546.0",
         "marked": "^17.0.1",
@@ -408,6 +410,10 @@
     "@npmcli/fs": ["@npmcli/fs@4.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.6", "", {}, "sha512-dWMF8Aku4h7fh8sw5tQ2FtbqRLbIFT8FcsukpxTird49ax7oUXP+gzqxM/VdxHjfksQvzLBjLZyMdDStc5g7xA=="],
+
+    "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
+
+    "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -867,6 +873,8 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "1.12.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
@@ -1061,6 +1069,8 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "6.0.1" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
@@ -1072,6 +1082,8 @@
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
 
     "pdfjs-dist": ["pdfjs-dist@5.4.530", "", { "optionalDependencies": { "@napi-rs/canvas": "0.1.88" } }, "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q=="],
 
@@ -1285,7 +1297,7 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+    "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "0.27.2", "get-tsconfig": "4.13.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
@@ -1433,6 +1445,8 @@
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "framer-motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -1449,6 +1463,8 @@
 
     "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "node-abi/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "node-api-version/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -1462,6 +1478,8 @@
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "rxjs/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "simple-update-notifier/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -251,3 +251,4 @@ export type ConnectionState = 'connected' | 'disconnected' | 'reconnecting';
 
 export * from './rpc.js';
 export * from './config.js';
+export * from './pdf-export.js';

--- a/packages/types/src/pdf-export.ts
+++ b/packages/types/src/pdf-export.ts
@@ -1,0 +1,12 @@
+export type PdfPageSize = 'A4' | 'Letter' | 'Legal';
+export type PdfOrientation = 'portrait' | 'landscape';
+export type PdfMarginPreset = 'default' | 'narrow' | 'none';
+
+export interface PdfExportOptions {
+  pageSize: PdfPageSize;
+  orientation: PdfOrientation;
+  margins: PdfMarginPreset;
+  showLinkUrls: boolean;
+  headerText: string;
+  footerText: string;
+}


### PR DESCRIPTION
## Summary
- PDF export via Electron's `printToPDF` with options dialog (page size, orientation, margins, custom header/footer, link URLs toggle)
- Syntax highlighting for code blocks in exported PDFs using highlight.js
- PDF metadata and heading-based bookmarks via pdf-lib
- CSS `@page` margin boxes for page numbers
- Chat accent colors now inherit from global accent setting instead of hardcoded purple
- Removed sticky user message behavior in chat
- Added visible border to bash output boxes in dark mode
- Shell and edit tool outputs default to collapsed

## Test plan
- [ ] Export a multi-page markdown file to PDF and verify page numbers appear
- [ ] Test custom header/footer text in export dialog
- [ ] Verify all page size/orientation/margin options work
- [ ] Change accent color in settings and confirm chat colors update
- [ ] Verify bash output boxes are visible in dark mode
- [ ] Confirm user messages no longer stick to top when scrolling chat