### PR TITLE
Optimize decoration updates and tweak chat defaults

### DIFF
--- a/apps/coordinator/src/providers/opencode-config.ts
+++ b/apps/coordinator/src/providers/opencode-config.ts
@@ -7,7 +7,6 @@ export function getOpenCodeConfigDir(): string {
   return path.join(xdgConfig, 'opencode');
 }
 
-// Sets default permissions in opencode.json if not already configured
 export async function ensurePermissionDefaults(): Promise<void> {
   const configPath = path.join(getOpenCodeConfigDir(), 'opencode.json');
   let config: Record<string, unknown> = {};

--- a/apps/frontend/components/chat/ChatSidebar.tsx
+++ b/apps/frontend/components/chat/ChatSidebar.tsx
@@ -44,12 +44,10 @@ export function ChatSidebar() {
       return;
     }
     if (!isBusy && !allDone) {
-      // Session ended but todos not complete — clear after brief delay
       setShowDock(false);
       return;
     }
     if (allDone) {
-      // All done — close after 400ms
       closeTimer.current = window.setTimeout(() => setShowDock(false), 400);
       return;
     }

--- a/apps/frontend/components/chat/CustomizeDialog.tsx
+++ b/apps/frontend/components/chat/CustomizeDialog.tsx
@@ -101,7 +101,6 @@ function TabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
   );
 }
 
-// Shared toggle component used by both panels
 type VisibilityToggleProps = {
   checked: boolean;
   label: string;

--- a/apps/frontend/components/chat/ManageModelsDialog.tsx
+++ b/apps/frontend/components/chat/ManageModelsDialog.tsx
@@ -65,7 +65,7 @@ export function ManageModelsDialog({ onClose, onConnectProvider }: ManageModelsD
       : models;
 
     return filtered.sort(createModelSorter(POPULAR_PROVIDER_IDS));
-  }, [providers, searchQuery, POPULAR_PROVIDER_IDS]);
+  }, [providers, searchQuery]);
 
   const groupedModels = useMemo(() => {
     const groups: ProviderGroup[] = [];
@@ -90,10 +90,6 @@ export function ManageModelsDialog({ onClose, onConnectProvider }: ManageModelsD
 
     return groups;
   }, [allModels]);
-
-  const handleToggle = (model: SelectedModel, next: boolean) => {
-    setModelVisibility(model, next);
-  };
 
   const isProviderVisible = (group: ProviderGroup) => {
     return group.models.every((model) => isModelVisible({ providerID: group.providerID, modelID: model.modelID }));
@@ -214,16 +210,16 @@ export function ManageModelsDialog({ onClose, onConnectProvider }: ManageModelsD
                         className="flex w-full cursor-pointer items-center gap-4 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--overlay-10)]"
                         role="button"
                         tabIndex={0}
-                        onClick={() => handleToggle(key, !visible)}
+                        onClick={() => setModelVisibility(key, !visible)}
                         onKeyDown={(event) => {
                           if (event.key !== 'Enter' && event.key !== ' ') return;
                           event.preventDefault();
-                          handleToggle(key, !visible);
+                          setModelVisibility(key, !visible);
                         }}
                       >
                         <span className="min-w-0 flex-1 truncate text-[14px] text-foreground">{model.modelName}</span>
                         <div className="flex w-9 shrink-0 justify-end" onClick={(event) => event.stopPropagation()}>
-                          <VisibilityToggle checked={visible} label={label} onChange={(next) => handleToggle(key, next)} />
+                          <VisibilityToggle checked={visible} label={label} onChange={(next) => setModelVisibility(key, next)} />
                         </div>
                       </div>
                     );

--- a/apps/frontend/components/chat/McpsPanel.tsx
+++ b/apps/frontend/components/chat/McpsPanel.tsx
@@ -30,7 +30,6 @@ export function McpsPanel() {
   const [authingMcp, setAuthingMcp] = useState<string | null>(null);
   const [authLoading, setAuthLoading] = useState(false);
 
-  // AbortController to cancel auth request on unmount
   const authAbortRef = useRef<AbortController | null>(null);
   useEffect(() => () => { authAbortRef.current?.abort(); }, []);
 
@@ -75,8 +74,7 @@ export function McpsPanel() {
     const ctx = getClient();
     if (!ctx) return;
     try {
-      // Write enabled state to config first so it persists across server restarts,
-      // then connect/disconnect to apply immediately.
+      // Persist to config then apply immediately
       if (currentlyConnected) {
         await ctx.client.global.config.update({ config: { mcp: { [name]: { enabled: false } } } });
         await ctx.client.mcp.disconnect({ name, directory: ctx.directory });

--- a/apps/frontend/components/chat/ModelSelector.tsx
+++ b/apps/frontend/components/chat/ModelSelector.tsx
@@ -43,7 +43,6 @@ export function ModelSelector({ disabled = false, compactLevel }: ModelSelectorP
   const providers = useChatStore((state) => state.providers);
   const selectedModel = useChatStore((state) => state.selectedModel);
   const setSelectedModel = useChatStore((state) => state.setSelectedModel);
-  const modelVisibility = useChatStore((state) => state.modelVisibility);
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [showSelectProviderDialog, setShowSelectProviderDialog] = useState(false);
@@ -97,7 +96,7 @@ export function ModelSelector({ disabled = false, compactLevel }: ModelSelectorP
       : models;
 
     return filtered.sort(createModelSorter(POPULAR_PROVIDER_IDS));
-  }, [providers, searchQuery, modelVisibility, POPULAR_PROVIDER_IDS]);
+  }, [providers, searchQuery, isModelVisible]);
 
   const groupedModels = useMemo(() => {
     const groups: Record<string, typeof allModels> = {};

--- a/apps/frontend/components/chat/NotebookLmPanel.tsx
+++ b/apps/frontend/components/chat/NotebookLmPanel.tsx
@@ -34,7 +34,6 @@ export function NotebookLmPanel() {
     setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, ...update } : s)));
   };
 
-  // Auto-check on mount: if notebooklm is already installed and authenticated, mark all done
   useEffect(() => {
     (async () => {
       try {
@@ -58,10 +57,8 @@ export function NotebookLmPanel() {
   const runSetup = async () => {
     setRunning(true);
 
-    // Reset all steps
     setSteps((prev) => prev.map((s) => ({ ...s, status: 'pending' as const, error: undefined, output: undefined })));
 
-    // Step 1: Check Python
     updateStep('check', { status: 'running' });
     let pythonCmd = '';
     try {
@@ -84,7 +81,6 @@ export function NotebookLmPanel() {
       return;
     }
 
-    // Step 2: Install package (use python -m pip to match the found Python)
     updateStep('install', { status: 'running' });
     try {
       const pip = await shellExec(pythonCmd, ['-m', 'pip', 'install', 'notebooklm-py[browser]']);
@@ -106,7 +102,6 @@ export function NotebookLmPanel() {
       return;
     }
 
-    // Step 3: Install skill
     updateStep('skill', { status: 'running' });
     try {
       const result = await shellExec('notebooklm', ['skill', 'install']);
@@ -122,7 +117,6 @@ export function NotebookLmPanel() {
       return;
     }
 
-    // Step 4: Open login browser
     updateStep('login', { status: 'running' });
     try {
       const coordinator = await getSharedCoordinatorClient();
@@ -138,14 +132,12 @@ export function NotebookLmPanel() {
   const verifyLogin = async () => {
     setRunning(true);
 
-    // Close the login browser
     try {
       const coordinator = await getSharedCoordinatorClient();
       await coordinator.call('shell/login-finish');
     } catch { /* may already be closed */ }
     setBrowserOpen(false);
 
-    // Check auth
     updateStep('login', { status: 'running' });
     try {
       const result = await shellExec('notebooklm', ['list', '--json']);
@@ -156,7 +148,6 @@ export function NotebookLmPanel() {
       }
       updateStep('login', { status: 'done' });
 
-      // Step 5: Verify
       updateStep('verify', { status: 'running' });
       const parsed = JSON.parse(result.stdout);
       const count = parsed?.notebooks?.length ?? 0;
@@ -183,7 +174,6 @@ export function NotebookLmPanel() {
   return (
     <>
       <div className="flex-1 overflow-y-auto no-scrollbar px-4 pb-4">
-        {/* Unofficial badge */}
         <div className="mb-3 flex items-center gap-2 rounded-md bg-[var(--overlay-10)] px-3 py-2">
           <AlertTriangle className="size-4 shrink-0 text-yellow-500" />
           <span className="text-[12px] text-muted-foreground">
@@ -191,20 +181,16 @@ export function NotebookLmPanel() {
           </span>
         </div>
 
-        {/* Description */}
         <p className="mb-4 text-[13px] text-muted-foreground">
           Gives the AI agent full access to Google NotebookLM — create notebooks, add sources, generate podcasts, videos, quizzes, and more.
         </p>
 
-        {/* Capabilities */}
         <CapabilitiesSection />
 
-        {/* Global install warning */}
         <p className="mb-4 text-[12px] text-muted-foreground">
           Setup will install <span className="font-medium text-foreground">notebooklm-py</span> and <span className="font-medium text-foreground">Chromium</span> globally via pip. These are not installed in a virtual environment.
         </p>
 
-        {/* Steps */}
         <div className="space-y-1">
           {steps.map((step) => (
             <div key={step.id} className="rounded-md px-3 py-2">
@@ -225,7 +211,6 @@ export function NotebookLmPanel() {
           ))}
         </div>
 
-        {/* Login instructions — shown when browser is open */}
         {isAtLoginStep && (
           <div className="mt-4 rounded-lg border border-border bg-surface p-4">
             <p className="mb-2 text-[13px] font-medium text-foreground">
@@ -241,7 +226,6 @@ export function NotebookLmPanel() {
         )}
       </div>
 
-      {/* Footer actions */}
       <div className="border-t border-border px-4 py-3">
         {allDone ? (
           <div className="flex items-center justify-between">

--- a/apps/frontend/components/chat/SelectProviderDialog.tsx
+++ b/apps/frontend/components/chat/SelectProviderDialog.tsx
@@ -118,14 +118,14 @@ export function SelectProviderDialog({ onClose, onProviderSelect }: SelectProvid
 
         return a.name.localeCompare(b.name);
       });
-  }, [providers, POPULAR_PROVIDER_IDS, searchQuery]);
+  }, [providers, searchQuery]);
 
   const groups = useMemo(
     () => ({
       popular: filteredProviders.filter((provider) => POPULAR_PROVIDER_IDS.includes(provider.id)),
       other: filteredProviders.filter((provider) => !POPULAR_PROVIDER_IDS.includes(provider.id)),
     }),
-    [filteredProviders, POPULAR_PROVIDER_IDS]
+    [filteredProviders]
   );
 
   return createPortal(

--- a/apps/frontend/components/chat/SkillsPanel.tsx
+++ b/apps/frontend/components/chat/SkillsPanel.tsx
@@ -88,7 +88,6 @@ export function SkillsPanel() {
       const zip = await JSZip.loadAsync(file);
       const entries = Object.keys(zip.files);
 
-      // Find SKILL.md at root or one level deep
       const skillMd = entries.find((e) => {
         const parts = e.split('/').filter(Boolean);
         const name = parts[parts.length - 1];
@@ -101,7 +100,6 @@ export function SkillsPanel() {
         return;
       }
 
-      // Read SKILL.md to extract name from frontmatter
       const skillMdContent = await zip.files[skillMd].async('string');
       const nameMatch = skillMdContent.match(/^---[\s\S]*?name:\s*(.+?)$/m);
       const skillName = nameMatch?.[1]?.trim().replace(/^["']|["']$/g, '');
@@ -112,11 +110,9 @@ export function SkillsPanel() {
         return;
       }
 
-      // Determine the prefix to strip (if SKILL.md is nested one level)
       const skillMdParts = skillMd.split('/').filter(Boolean);
       const prefix = skillMdParts.length > 1 ? skillMdParts[0] + '/' : '';
 
-      // Extract all files
       const files: Array<{ path: string; content: string }> = [];
       for (const [entryPath, zipEntry] of Object.entries(zip.files)) {
         if (zipEntry.dir) continue;
@@ -126,11 +122,9 @@ export function SkillsPanel() {
         files.push({ path: relativePath, content });
       }
 
-      // Send to coordinator
       const coordinator = await getSharedCoordinatorClient();
       await coordinator.call('skill/install-zip', { skillName, files });
 
-      // Refresh and close add zone
       setShowAddZone(false);
       await handleRefresh();
     } catch (err) {
@@ -155,7 +149,6 @@ export function SkillsPanel() {
 
   return (
     <>
-      {/* Search + actions */}
       <div className="flex items-center gap-2 px-4 pb-3">
         <div className="flex h-8 flex-1 items-center gap-2 rounded-md bg-surface px-2">
           <Search size={16} className="shrink-0 text-muted-foreground" />
@@ -205,9 +198,7 @@ export function SkillsPanel() {
         </button>
       </div>
 
-      {/* Scrollable list */}
       <div className="flex-1 overflow-y-auto no-scrollbar px-2 pb-2">
-        {/* Drop zone */}
         {showAddZone && (
           <div className="px-2 pb-2">
             <div
@@ -292,7 +283,6 @@ export function SkillsPanel() {
         )}
       </div>
 
-      {/* Footer */}
       {!loading && skills.length > 0 && (
         <div className="border-t border-border px-4 py-2.5 text-xs text-muted-foreground">
           {enabledCount} of {skills.length} skills enabled

--- a/apps/frontend/components/editor/CodeEditor.tsx
+++ b/apps/frontend/components/editor/CodeEditor.tsx
@@ -255,7 +255,6 @@ export function CodeEditor({ filePath }: CodeEditorProps) {
     });
   }, [formatShortcuts]);
 
-  // Keep callback refs up to date without re-creating the editor
   onChangeRef.current = onChange;
   onSaveRef.current = onSave;
   onWikiLinkNavigateRef.current = onWikiLinkNavigate;
@@ -348,10 +347,9 @@ export function CodeEditor({ filePath }: CodeEditorProps) {
 
     const mixedContent = view.state.doc.toString();
 
-    // Mark before dispatching to prevent re-entry from update listener
+    // prevent re-entry
     isReviewingRef.current = false;
 
-    // Exit merge view, clear keymap
     exitDiffReview(view, mergeViewCompartmentRef.current);
     view.dispatch({
       effects: diffKeymapCompartmentRef.current.reconfigure([]),
@@ -642,7 +640,6 @@ export function CodeEditor({ filePath }: CodeEditorProps) {
         extensions.push(langExt);
       }
 
-      // Add WYSIWYG rendering for markdown files
       const fileExt = filePath.split('.').pop()?.toLowerCase() || '';
       if (fileExt === 'md' || fileExt === 'markdown') {
         extensions.push(wysiwygExtension());
@@ -693,7 +690,7 @@ export function CodeEditor({ filePath }: CodeEditorProps) {
         viewRef.current = null;
       }
     };
-    // Re-create editor when filePath or language changes; content is initial only per file
+    // content intentionally omitted — initial-value only
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filePath, language]);
 

--- a/apps/frontend/components/editor/EditorPanel.tsx
+++ b/apps/frontend/components/editor/EditorPanel.tsx
@@ -449,9 +449,7 @@ export function EditorPanel({
   return (
     <EditorPanelProvider value={contextValue}>
     <div className="flex flex-col w-full h-full bg-background">
-      {/* Header rows */}
       {!focusModeEnabled && (
-        <>
           <EditorNavRow
             canGoBack={canGoBack}
             canGoForward={canGoForward}
@@ -463,7 +461,6 @@ export function EditorPanel({
             centerContent={breadcrumb.text}
             centerTitle={breadcrumb.title}
           />
-        </>
       )}
 
       <div ref={searchPanelContainerRef} className="flex-shrink-0" />
@@ -476,7 +473,6 @@ export function EditorPanel({
         />
       )}
 
-      {/* Editor content with rounded top corners */}
       <div
         className="flex-1 min-h-0 min-w-0 overflow-auto rounded-tl-lg thin-scrollbar"
         ref={editorContainerRef}

--- a/apps/frontend/components/editor/ExcalidrawView.tsx
+++ b/apps/frontend/components/editor/ExcalidrawView.tsx
@@ -107,9 +107,8 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
   const filesRef = useRef<Record<string, any>>(initialData.files ?? {});
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const filePathRef = useRef(filePath);
-  // Store last saved JSON so we can distinguish our own saves from external changes
+  // skip our own saves
   const lastSavedJsonRef = useRef<string | null>(null);
-  // Skip the very first onChange (Excalidraw fires it on mount with initialData)
   const mountedRef = useRef(false);
 
   useEffect(() => {
@@ -149,7 +148,6 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
     saveTimerRef.current = setTimeout(flush, 1000);
   }, [flush]);
 
-  // Flush pending save on unmount
   useEffect(() => {
     return () => {
       if (saveTimerRef.current) {
@@ -159,7 +157,7 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
     };
   }, [flush]);
 
-  // Watch for external file changes and update the scene via imperative API
+  // Watch for external file changes
   useEffect(() => {
     let unsubDisk: (() => void) | undefined;
     let unsubFiles: (() => void) | undefined;
@@ -206,7 +204,6 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
       appStateRef.current = appState;
       filesRef.current = files ?? {};
 
-      // Skip the initial mount onChange — Excalidraw fires it with initialData
       if (!mountedRef.current) {
         mountedRef.current = true;
         return;

--- a/apps/frontend/components/editor/ImageViewer.tsx
+++ b/apps/frontend/components/editor/ImageViewer.tsx
@@ -53,14 +53,7 @@ function ImageViewerInner({ filePath, base64Data, mimeType }: ImageViewerInnerPr
   const zoomOut = useCallback(() => setScale(s => Math.max(s / 1.25, 0.1)), []);
   const resetView = useCallback(() => { setScale(1); setPosition({ x: 0, y: 0 }); }, []);
 
-  // Ctrl/Cmd + Scroll wheel zoom (non-customizable platform gesture).
-  // This is intentionally NOT part of the shortcut registry because:
-  //  - Wheel events are continuous gestures, not discrete key presses.
-  //  - Ctrl+Scroll-to-zoom is a universal platform convention (browsers, PDF
-  //    viewers, image editors) and users expect it to work without configuration.
-  //  - Keyboard alternatives (image.zoom.in / image.zoom.out) are registry-driven
-  //    and fully customizable in Settings.
-  // Policy: US-D2 — classified as non-customizable gesture.
+  // Ctrl+Scroll zoom — non-customizable platform gesture, not in shortcut registry
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;

--- a/apps/frontend/components/editor/MonacoEditor.tsx
+++ b/apps/frontend/components/editor/MonacoEditor.tsx
@@ -5,7 +5,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useAppearanceStore } from '@/stores/appearanceStore';
 import { useEditorPanelContext } from './EditorPanelContext';
 
-/** Map store language IDs to Monaco language IDs */
+// Map store language IDs to Monaco language IDs
 function toMonacoLanguage(lang: string | undefined): string {
   if (!lang) return 'plaintext';
   const map: Record<string, string> = {
@@ -43,7 +43,6 @@ export default function MonacoEditor({ filePath }: MonacoEditorProps) {
   const handleMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
 
-    // Ctrl+S to save
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
       handleSave();
     });

--- a/apps/frontend/components/editor/PdfViewerNative.tsx
+++ b/apps/frontend/components/editor/PdfViewerNative.tsx
@@ -388,7 +388,6 @@ function PdfViewerInner({
     }
   }, [filePath]);
 
-  // Load CSS on mount
   useEffect(() => {
     const existingLink = document.querySelector('link[href="/pdfjs/pdf_viewer.css"]');
     if (!existingLink) {
@@ -399,7 +398,6 @@ function PdfViewerInner({
     }
   }, []);
 
-  // Initialize PDF viewer
   useEffect(() => {
     let cancelled = false;
     let loadingTask: any = null;
@@ -669,7 +667,6 @@ function PdfViewerInner({
     telemetrySession,
   ]);
 
-  // Handle editor mode changes
   useEffect(() => {
     const viewer = pdfViewerRef.current;
     if (!viewer) return;
@@ -787,7 +784,6 @@ function PdfViewerInner({
     }
   }, [base64Data, persistPdfBytes]);
 
-  // Keyboard shortcuts
   const pdfHandlers = useMemo(() => ({
     'pdf.search.open': () => { openSearch(); },
     'pdf.search.close': () => {
@@ -904,7 +900,7 @@ function PdfViewerInner({
         />
       )}
 
-      {/* PDF Viewer Container - structure required by pdf.js */}
+      {/* required by pdf.js */}
       <div className="flex-1 relative min-h-0">
         <div
           ref={containerRef}
@@ -921,7 +917,6 @@ function PdfViewerInner({
         </div>
       </div>
 
-      {/* Mode indicator */}
       {editorMode !== 'none' && (
         <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-tab-container text-foreground px-4 py-2 rounded-full text-sm shadow-lg border border-border flex items-center gap-2 z-50">
           {editorMode === 'freetext' && <><Type size={16} /> Click to add text</>}

--- a/apps/frontend/lib/codemirror-wysiwyg/heading-fold.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/heading-fold.ts
@@ -303,8 +303,11 @@ export const headingFoldDecorationsField = StateField.define<DecorationSet>({
       e => e.is(toggleHeadingFoldEffect) || e.is(setHeadingFoldsEffect)
     );
 
-    if (tr.docChanged || foldChanged || treeChanged) {
+    if (foldChanged || treeChanged) {
       return buildHeadingFoldDecorations(tr.state);
+    }
+    if (tr.docChanged) {
+      return value.map(tr.changes);
     }
     return value;
   },

--- a/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
@@ -796,13 +796,25 @@ export const widgetDecorationsField = StateField.define<DecorationSet>({
     return buildWidgetDecorations(state);
   },
   update(value, tr) {
-    if (tr.docChanged || tr.selection) {
-      return buildWidgetDecorations(tr.state);
-    }
-    if (syntaxTree(tr.state) !== syntaxTree(tr.startState)) {
-      return buildWidgetDecorations(tr.state);
-    }
     if (tr.effects.some(e => e.is(embedSourceRevealEffect) || e.is(mouseSelectEffect))) {
+      return buildWidgetDecorations(tr.state);
+    }
+    const treeChanged = syntaxTree(tr.state) !== syntaxTree(tr.startState);
+    if (tr.docChanged) {
+      // Map positions through changes first to preserve stable decorations.
+      // Only do a full rebuild when the tree actually changed (Lezer finished
+      // reparsing) or an explicit selection transaction arrived in the same
+      // update.  This avoids a full-document rebuild on every keystroke that
+      // would use a potentially-incomplete tree and cause scroll jumps.
+      if (treeChanged || tr.selection) {
+        return buildWidgetDecorations(tr.state);
+      }
+      return value.map(tr.changes);
+    }
+    if (tr.selection) {
+      return buildWidgetDecorations(tr.state);
+    }
+    if (treeChanged) {
       return buildWidgetDecorations(tr.state);
     }
     return value;

--- a/apps/frontend/lib/codemirror-wysiwyg/widgets/image-widget.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/widgets/image-widget.ts
@@ -5,6 +5,10 @@ import { commitImageResize } from '../image-resize';
 
 const heightCache = new Map<string, number>();
 
+function heightKey(src: string, width: number | null): string {
+  return width ? `${src}|w=${width}` : src;
+}
+
 function showError(wrapper: HTMLElement, img: HTMLImageElement) {
   wrapper.classList.remove('cm-image-loading');
   wrapper.classList.add('cm-image-error');
@@ -29,13 +33,15 @@ export class ImageWidget extends WidgetType {
   }
 
   get estimatedHeight() {
-    return heightCache.get(this.src) ?? 200;
+    return heightCache.get(heightKey(this.src, this.width)) ?? 200;
   }
 
   toDOM() {
-    const cachedHeight = heightCache.get(this.src);
+    const key = heightKey(this.src, this.width);
+    const cachedHeight = heightCache.get(key);
     const knownImage = cachedHeight !== undefined;
     const src = this.src;
+    const width = this.width;
 
     const wrapper = document.createElement('div');
     wrapper.className = knownImage ? 'cm-image-widget' : 'cm-image-widget cm-image-loading';
@@ -52,10 +58,13 @@ export class ImageWidget extends WidgetType {
 
     img.onload = () => {
       wrapper.classList.remove('cm-image-loading');
-      wrapper.style.minHeight = '';
       queueMicrotask(() => {
         if (wrapper.isConnected) {
-          heightCache.set(src, wrapper.getBoundingClientRect().height);
+          const h = wrapper.getBoundingClientRect().height;
+          heightCache.set(heightKey(src, width), h);
+          // Keep minHeight in sync with actual height to avoid geometry
+          // flicker when the widget exits and re-enters the viewport.
+          wrapper.style.minHeight = `${h}px`;
           getEditorView(wrapper)?.requestMeasure();
         }
       });
@@ -112,7 +121,9 @@ export class ImageWidget extends WidgetType {
           document.body.style.userSelect = '';
           wrapper.classList.remove('cm-image-resizing');
 
-          heightCache.set(src, wrapper.getBoundingClientRect().height);
+          const h = wrapper.getBoundingClientRect().height;
+          heightCache.set(heightKey(src, width), h);
+          wrapper.style.minHeight = `${h}px`;
 
           const view = getEditorView(wrapper);
           if (!view) return;

--- a/apps/frontend/lib/config-defaults.test.ts
+++ b/apps/frontend/lib/config-defaults.test.ts
@@ -123,7 +123,7 @@ describe('DEFAULT_CHAT', () => {
 
   it('displayPreferences has valid defaults', () => {
     expect(DEFAULT_CHAT.displayPreferences).toEqual({
-      showThinking: true,
+      showThinking: false,
       shellToolPartsExpanded: true,
       editToolPartsExpanded: false,
     });

--- a/apps/frontend/lib/config-defaults.ts
+++ b/apps/frontend/lib/config-defaults.ts
@@ -44,7 +44,7 @@ export const DEFAULT_CHAT: Required<CushionChat> = {
   selectedAgent: null,
   selectedVariant: null,
   displayPreferences: {
-    showThinking: true,
+    showThinking: false,
     shellToolPartsExpanded: true,
     editToolPartsExpanded: false,
   },

--- a/apps/frontend/src/Home.tsx
+++ b/apps/frontend/src/Home.tsx
@@ -98,14 +98,12 @@ export default function Home() {
   const fileBrowserRef = useRef<FileBrowserHandle>(null);
   const autoOpenAttempted = useRef(false);
 
-  // File tree and connection state from useFileTree hook
   const { fileTree, connectionState, fetchFileTree } = useFileTree({
     client,
     metadata,
     onFilesChanged: () => fileBrowserRef.current?.refreshFileList(),
   });
 
-  // Link index from useLinkIndex hook
   const linkIndex = useLinkIndex({
     client,
     metadata,
@@ -113,7 +111,6 @@ export default function Home() {
     openFiles,
   });
 
-  // Config sync lifecycle (settings, workspace, appearance, chat)
   const { workspaceConfigLoadedRef } = useConfigSync({
     client,
     metadata,
@@ -128,7 +125,6 @@ export default function Home() {
     }, []),
   });
 
-  // Bridge: chat diffs → inline editor review
   useDiffReviewBridge();
 
   const appShortcuts = useShortcutBindings(APP_SHORTCUT_IDS);
@@ -439,7 +435,7 @@ export default function Home() {
   const backlinksShortcutLabel = formatShortcutList(appShortcuts['app.backlinks.toggle']);
   const graphShortcutLabel = formatShortcutList(appShortcuts['app.graph.toggle']);
 
-  // Feature 3/4: listen for workspace-open events from Electron
+  // Listen for workspace-open events from Electron
   useEffect(() => {
     if (!window.electronAPI?.onOpenWorkspace) return;
     window.electronAPI.onOpenWorkspace((path) => {

--- a/apps/frontend/stores/chat-connection.ts
+++ b/apps/frontend/stores/chat-connection.ts
@@ -94,8 +94,7 @@ function captureEditSnapshot(perm: Record<string, unknown>) {
     return;
   }
 
-  // edit tool: metadata.filepath + metadata.diff — no explicit after available
-  // Fall back to reading current editor content as before; after will come from disk later
+  // edit tool: fall back to current editor content; after will come from disk
   const filepath = metadata.filepath as string | undefined;
   if (filepath) {
     const patterns = (perm.patterns as string[] | undefined) ?? [];
@@ -179,9 +178,7 @@ export async function handleConnect(
   if (!isCurrent()) return;
   const commandData = commandResult ? unwrap(commandResult) : undefined;
   const commands = commandData ?? state.commands;
-  // Sync disabled skills to OpenCode config on connect.
-  // Fetch all skills so we can explicitly "allow" non-disabled ones,
-  // clearing any stale "deny" entries left in opencode.json.
+  // Sync disabled skills: build explicit allow/deny map, clearing stale entries
   const disabledSkills = get().disabledSkills;
   const skillsResult = await localClient.app.skills({ directory }).catch(() => undefined);
   if (!isCurrent()) return;
@@ -275,7 +272,7 @@ export async function handleConnect(
         const reviewMode = get().reviewMode;
         const isEdit = perm.permission === 'edit';
 
-        // Always auto-accept (edits are never blocked now)
+        // Always auto-accept
         get().respondToPermission({
           sessionID: perm.sessionID,
           permissionID: perm.id,

--- a/apps/frontend/stores/chat-store-utils.ts
+++ b/apps/frontend/stores/chat-store-utils.ts
@@ -170,7 +170,7 @@ export const MAX_PROMPT_SESSIONS = 20;
 // Initial state
 
 const DEFAULT_DISPLAY_PREFERENCES: DisplayPreferences = {
-  showThinking: true,
+  showThinking: false,
   shellToolPartsExpanded: false,
   editToolPartsExpanded: false,
 };

--- a/apps/frontend/stores/chatStore.ts
+++ b/apps/frontend/stores/chatStore.ts
@@ -329,7 +329,6 @@ export const useChatStore = create<ChatState & ChatActions>()(
           diffStore.finishReview();
         }
       }
-      // Switching ON: no action needed — snapshots will be captured on next edit permission
     },
 
     setSkillDisabled: (name: string, disabled: boolean) => {

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -1,8 +1,6 @@
 /* Markdown Editor Theme - Inspired by Tangent */
 
-/* ============================================
-   CSS Custom Properties (Theming System)
-   ============================================ */
+/* --- CSS Custom Properties --- */
 
 :root {
   /* Typography */
@@ -64,7 +62,7 @@
   --md-code-boolean: var(--color-purple);
   --md-code-null: var(--color-purple);
 
-  /* Colors - Highlights (unchanged) */
+  /* Colors - Highlights */
   --md-highlight-yellow: rgba(255, 235, 59, 0.3);
   --md-highlight-green: rgba(76, 175, 80, 0.3);
   --md-highlight-blue: rgba(33, 150, 243, 0.3);
@@ -123,7 +121,7 @@
   --md-code-boolean: var(--color-purple);
   --md-code-null: var(--color-purple);
 
-  /* Colors - Highlights (unchanged) */
+  /* Colors - Highlights */
   --md-highlight-yellow: rgba(255, 235, 59, 0.4);
   --md-highlight-green: rgba(76, 175, 80, 0.4);
   --md-highlight-blue: rgba(33, 150, 243, 0.4);
@@ -145,9 +143,7 @@
   --md-hr-color: var(--text-faint);
 }
 
-/* ============================================
-   Editor Container
-   ============================================ */
+/* --- Editor Container --- */
 
 .cm-editor.cm-markdown-wysiwyg {
   background: transparent;  /* Inherit from parent */
@@ -230,9 +226,7 @@
   background: transparent;
 }
 
-/* ============================================
-   Typography - Headings
-   ============================================ */
+/* --- Typography - Headings --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-heading-1 {
   font-size: 1.618em;
@@ -286,15 +280,7 @@
   color: var(--md-text-muted);
 }
 
-/* ============================================
-   Hidden System (purrmd Single-Phase Pattern)
-   ============================================
-   Single-phase hiding:
-   - Add .cm-hidden ONLY when cursor is NOT in range
-   - When cursor IS in range, no decoration = syntax visible
-   This eliminates the race condition where CM resolves click
-   positions before decorations update.
-   ============================================ */
+/* --- Hidden System (single-phase: no decoration = cursor in range) --- */
 
 /* Hidden state - applied only when cursor NOT in range.
    !important guards against specificity conflicts with styling classes
@@ -307,9 +293,7 @@
   display: inline;
 }
 
-/* ============================================
-   Typography - Inline formatting
-   ============================================ */
+/* --- Typography - Inline formatting --- */
 
 /* Lezer-provided classes (syntax highlighting) */
 .cm-editor.cm-markdown-wysiwyg .cm-strong {
@@ -353,9 +337,7 @@
   border-radius: var(--md-border-radius-sm);
 }
 
-/* ============================================
-   Links
-   ============================================ */
+/* --- Links --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-link {
   color: var(--md-link-color);
@@ -377,9 +359,7 @@
   color: var(--md-text-faint);
 }
 
-/* ============================================
-   Blockquotes
-   ============================================ */
+/* --- Blockquotes --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-blockquote {
   border-left: 2px solid var(--md-blockquote-border);
@@ -397,9 +377,7 @@
   border-left-width: 9px;
 }
 
-/* ============================================
-   Lists
-   ============================================ */
+/* --- Lists --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-list-item {
   position: relative;
@@ -505,9 +483,7 @@
   color: var(--md-accent);
 }
 
-/* ============================================
-   Code Blocks
-   ============================================ */
+/* --- Code Blocks --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-code-block {
   position: relative;
@@ -647,9 +623,7 @@
   color: var(--md-text) !important;
 }
 
-/* ============================================
-   Horizontal Rule
-   ============================================ */
+/* --- Horizontal Rule --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-hr-line {
   position: relative;
@@ -680,9 +654,7 @@
   color: var(--md-text-faint) !important;
 }
 
-/* ============================================
-   Images
-   ============================================ */
+/* --- Images --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-image-widget {
   display: block;
@@ -821,9 +793,7 @@
   display: block;
 }
 
-/* ============================================
-   Tags (pill style)
-   ============================================ */
+/* --- Tags --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-tag {
   display: inline-flex;
@@ -847,9 +817,7 @@
   opacity: 0.7;
 }
 
-/* ============================================
-   Front Matter
-   ============================================ */
+/* --- Front Matter --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-frontmatter {
   position: relative;
@@ -874,9 +842,7 @@
   border-bottom: 1px solid var(--md-border);
 }
 
-/* ============================================
-   Math (KaTeX)
-   ============================================ */
+/* --- Math (KaTeX) --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-math-syntax {
   color: var(--md-accent);
@@ -1003,17 +969,13 @@
   color: var(--md-text-faint) !important;
 }
 
-/* ============================================
-   Syntax Reveal (when cursor on line)
-   ============================================ */
+/* --- Syntax Reveal --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-syntax-revealed {
   color: var(--md-text-faint);
 }
 
-/* ============================================
-   Animations & Transitions
-   ============================================ */
+/* --- Animations & Transitions --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-line {
   transition: opacity 0.2s ease;
@@ -1025,9 +987,7 @@
   transition: all 0.15s ease;
 }
 
-/* ============================================
-   File Header (Title)
-   ============================================ */
+/* --- File Header (Title) --- */
 
 .file-header {
   /* No background - inherits from parent container */
@@ -1056,11 +1016,7 @@
   background: var(--md-bg);
 }
 
-/* ============================================
-   Wiki-Links [[link]]
-   Inspired by Tangent's link styling
-   Click to navigate (like Obsidian)
-   ============================================ */
+/* --- Wiki-Links [[link]] --- */
 
 /* Base wiki-link styling */
 .cm-editor.cm-markdown-wysiwyg .cm-wiki-link {
@@ -1120,10 +1076,7 @@
   position: relative;
 }
 
-/* ============================================
-   Wiki-Link Autocomplete
-   Inspired by Tangent's autocomplete styling
-   ============================================ */
+/* --- Wiki-Link Autocomplete --- */
 
 /* Autocomplete tooltip container */
 .cm-editor .cm-tooltip-autocomplete {
@@ -1260,10 +1213,7 @@
 }
 
 
-/* ============================================
-   Heading Folding
-   Notion/Obsidian-style collapsible headings
-   ============================================ */
+/* --- Heading Folding --- */
 
 /* Base foldable heading - positions chevron in left margin */
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-heading-foldable {
@@ -1357,9 +1307,7 @@
   color: var(--md-text-muted);
 }
 
-/* ============================================
-   Shared Embed Source Toggle
-   ============================================ */
+/* --- Shared Embed Source Toggle --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-embed-source-toggle {
   position: absolute;
@@ -1404,9 +1352,7 @@
   display: flex;
 }
 
-/* ============================================
-   PDF Widget
-   ============================================ */
+/* --- PDF Widget --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-pdf-widget {
   display: block;
@@ -1539,9 +1485,7 @@
   font-size: 14px;
 }
 
-/* ============================================
-   Note Embed Widget
-   ============================================ */
+/* --- Note Embed Widget --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-note-embed-widget {
   display: block;
@@ -1648,9 +1592,7 @@
   font-style: italic;
 }
 
-/* ============================================
-   Unsupported Embed Widget
-   ============================================ */
+/* --- Unsupported Embed Widget --- */
 
 .cm-editor.cm-markdown-wysiwyg .cm-unsupported-embed-widget {
   display: flex;


### PR DESCRIPTION
## Summary
- **CodeMirror perf**: Map heading-fold and widget decorations through document changes instead of doing full rebuilds on every keystroke, reducing unnecessary work
- **Image widget**: Key height cache by src+width to avoid stale entries on resize; keep `minHeight` in sync with actual height to prevent viewport flicker
- **Chat defaults**: Default `showThinking` to `false`

## Test plan
- [ ] Verify heading folding still works correctly after editing within folded sections
- [ ] Confirm image widgets don't flicker when scrolling in/out of viewport
- [ ] Check that resized images maintain correct cached height
- [ ] Verify chat sidebar defaults to hiding thinking blocks