### PR TITLE
Improve file tree drag-and-drop handling

### DIFF
--- a/apps/frontend/components/workspace/FileTree.tsx
+++ b/apps/frontend/components/workspace/FileTree.tsx
@@ -331,7 +331,6 @@ export function FileTree({
     const target = getDragTarget(e);
     setDragOverDir(target);
 
-    // Auto-expand collapsed folders after 500ms hover
     if (target !== '__root__' && target !== lastAutoExpandTarget.current
       && !useExplorerStore.getState().expandedDirs.has(target)) {
       if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
@@ -354,7 +353,6 @@ export function FileTree({
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
-    // Only clear when leaving the tree container entirely
     if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
       dragActiveRef.current = false;
       setDragOverDir(null);
@@ -406,7 +404,6 @@ export function FileTree({
     if (renamingPath === prevRenamingRef.current) return;
     prevRenamingRef.current = renamingPath;
     if (!renamingPath) return;
-    // Find node in flatRows
     const row = flatRows.find((r) => r.kind === 'item' && r.path === renamingPath);
     if (row && row.kind === 'item') {
       const name = row.node.name;
@@ -509,7 +506,6 @@ export function FileTree({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      {/* Virtualized container */}
       <div
         ref={treeContainerRef}
         style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}

--- a/apps/frontend/components/workspace/FileTree.tsx
+++ b/apps/frontend/components/workspace/FileTree.tsx
@@ -96,8 +96,10 @@ export function FileTree({
   const [newFileName, setNewFileName] = useState('');
   const [newFolderName, setNewFolderName] = useState('');
   const [dragOverDir, setDragOverDir] = useState<string | null>(null);
-  const dragEnterCount = useRef(0);
+  const dragActiveRef = useRef(false);
   const autoExpandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastAutoExpandTarget = useRef<string | null>(null);
+  const treeContainerRef = useRef<HTMLDivElement>(null);
 
   const selectedPaths = useExplorerStore((s) => s.selectedPaths);
   const clipboard = useExplorerStore((s) => s.clipboard);
@@ -291,9 +293,10 @@ export function FileTree({
   }, [selectedPaths]);
 
   const handleDragEnd = useCallback(() => {
-    dragEnterCount.current = 0;
+    dragActiveRef.current = false;
     setDragOverDir(null);
     if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
+    lastAutoExpandTarget.current = null;
   }, []);
 
   const canDropOnFolder = useCallback((sourcePath: string, targetPath: string) => {
@@ -304,23 +307,19 @@ export function FileTree({
     return true;
   }, []);
 
-  const handleDragEnter = useCallback((e: React.DragEvent, targetPath: string) => {
-    const hasInternal = e.dataTransfer.types.includes('application/x-cushion-path') || e.dataTransfer.types.includes('application/x-cushion-paths');
-    const hasExternal = e.dataTransfer.types.includes('Files');
-    if (!hasInternal && !hasExternal) return;
-    e.preventDefault();
-    dragEnterCount.current++;
-    if (dragOverDir !== targetPath) {
-      dragEnterCount.current = 1;
-      setDragOverDir(targetPath);
-      if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
-      if (targetPath !== '__root__' && !useExplorerStore.getState().expandedDirs.has(targetPath)) {
-        autoExpandTimer.current = setTimeout(() => {
-          toggleDirectory(targetPath);
-        }, 500);
-      }
-    }
-  }, [dragOverDir, toggleDirectory]);
+  const getDragTarget = useCallback((e: React.DragEvent): string => {
+    const el = treeContainerRef.current;
+    if (!el) return '__root__';
+    const rect = el.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const rowIndex = Math.floor(y / 30);
+    if (rowIndex < 0 || rowIndex >= flatRows.length) return '__root__';
+    const row = flatRows[rowIndex];
+    if (row.kind !== 'item') return '__root__';
+    if (row.type === 'directory') return row.path;
+    const slashIdx = row.path.lastIndexOf('/');
+    return slashIdx > 0 ? row.path.slice(0, slashIdx) : '__root__';
+  }, [flatRows]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const hasInternal = e.dataTransfer.types.includes('application/x-cushion-path') || e.dataTransfer.types.includes('application/x-cushion-paths');
@@ -328,23 +327,50 @@ export function FileTree({
     if (!hasInternal && !hasExternal) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = hasInternal ? 'move' : 'copy';
+
+    const target = getDragTarget(e);
+    setDragOverDir(target);
+
+    // Auto-expand collapsed folders after 500ms hover
+    if (target !== '__root__' && target !== lastAutoExpandTarget.current
+      && !useExplorerStore.getState().expandedDirs.has(target)) {
+      if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
+      lastAutoExpandTarget.current = target;
+      autoExpandTimer.current = setTimeout(() => {
+        toggleDirectory(target);
+      }, 500);
+    } else if (target !== lastAutoExpandTarget.current) {
+      if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
+      lastAutoExpandTarget.current = target;
+    }
+  }, [getDragTarget, toggleDirectory]);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    const hasInternal = e.dataTransfer.types.includes('application/x-cushion-path') || e.dataTransfer.types.includes('application/x-cushion-paths');
+    const hasExternal = e.dataTransfer.types.includes('Files');
+    if (!hasInternal && !hasExternal) return;
+    e.preventDefault();
+    dragActiveRef.current = true;
   }, []);
 
-  const handleDragLeave = useCallback((e: React.DragEvent, targetPath: string) => {
-    dragEnterCount.current--;
-    if (dragEnterCount.current <= 0) {
-      dragEnterCount.current = 0;
-      if (dragOverDir === targetPath) setDragOverDir(null);
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    // Only clear when leaving the tree container entirely
+    if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
+      dragActiveRef.current = false;
+      setDragOverDir(null);
       if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
+      lastAutoExpandTarget.current = null;
     }
-  }, [dragOverDir]);
+  }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent, targetPath: string) => {
+  const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    dragEnterCount.current = 0;
+    const targetPath = getDragTarget(e);
     setDragOverDir(null);
+    dragActiveRef.current = false;
     if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
+    lastAutoExpandTarget.current = null;
 
     const multiPaths = e.dataTransfer.getData('application/x-cushion-paths');
     if (multiPaths) {
@@ -373,7 +399,7 @@ export function FileTree({
       const destDir = targetPath === '__root__' ? '.' : targetPath;
       onExternalDrop(e.dataTransfer.files, destDir);
     }
-  }, [onRename, onExternalDrop, canDropOnFolder]);
+  }, [onRename, onExternalDrop, canDropOnFolder, getDragTarget]);
 
   const prevRenamingRef = useRef<string | null>(null);
   useEffect(() => {
@@ -459,7 +485,9 @@ export function FileTree({
 
   return (
     <div
-      className="text-sm select-none outline-none"
+      className={cn("text-sm select-none outline-none rounded transition-colors duration-150 min-h-full",
+        dragOverDir === '__root__' && "ring-1 ring-inset ring-accent/40 bg-[var(--accent-primary-12)]"
+      )}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       onClick={(e) => {
@@ -476,13 +504,14 @@ export function FileTree({
           setContextMenu({ path: '__root__', name: '', type: 'directory', position: { x: e.clientX, y: e.clientY } });
         }
       }}
-      onDragEnter={(e) => handleDragEnter(e, '__root__')}
+      onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
-      onDragLeave={(e) => handleDragLeave(e, '__root__')}
-      onDrop={(e) => handleDrop(e, '__root__')}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
     >
       {/* Virtualized container */}
       <div
+        ref={treeContainerRef}
         style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}
       >
         {virtualItems.map((vi) => {
@@ -562,10 +591,6 @@ export function FileTree({
                 onStartCreateFolder={handleStartCreateFolder}
                 onDragStart={handleDragStart}
                 onDragEnd={handleDragEnd}
-                onDragEnter={handleDragEnter}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
                 onContextMenu={handleContextMenu}
                 flatOrder={flatOrder}
                 dragOverDir={dragOverDir}

--- a/apps/frontend/components/workspace/FileTreeItemActions.tsx
+++ b/apps/frontend/components/workspace/FileTreeItemActions.tsx
@@ -106,13 +106,11 @@ export function buildMenuItems(node: FileTreeNode, callbacks: MenuItemCallbacks)
 
 interface FileTreeItemActionsProps {
   node: FileTreeNode;
-  isVisible: boolean;
   onAddFile?: () => void;
 }
 
 export function FileTreeItemActions({
   node,
-  isVisible,
   onAddFile,
 }: FileTreeItemActionsProps) {
   const handleAddClick = (e: React.MouseEvent) => {
@@ -136,7 +134,7 @@ export function FileTreeItemActions({
         className={cn(
           "flex items-center gap-0.5 ml-auto",
           "transition-opacity duration-150",
-          isVisible ? "opacity-100" : "opacity-0 pointer-events-none"
+          "opacity-0 pointer-events-none group-hover/item:opacity-100 group-hover/item:pointer-events-auto"
         )}
       >
         {node.type === 'directory' && (

--- a/apps/frontend/components/workspace/FileTreeRow.tsx
+++ b/apps/frontend/components/workspace/FileTreeRow.tsx
@@ -17,10 +17,6 @@ interface FileTreeRowProps {
   onStartCreateFolder: (parentPath: string) => void;
   onDragStart: (e: React.DragEvent, node: FileTreeNode) => void;
   onDragEnd: () => void;
-  onDragEnter: (e: React.DragEvent, targetPath: string) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragLeave: (e: React.DragEvent, targetPath: string) => void;
-  onDrop: (e: React.DragEvent, targetPath: string) => void;
   onContextMenu: (e: React.MouseEvent, node: FileTreeNode) => void;
   flatOrder: string[];
   dragOverDir: string | null;
@@ -40,10 +36,6 @@ export const FileTreeRow = memo(function FileTreeRow({
   onStartCreateFolder,
   onDragStart,
   onDragEnd,
-  onDragEnter,
-  onDragOver,
-  onDragLeave,
-  onDrop,
   onContextMenu,
   flatOrder,
   dragOverDir,
@@ -71,6 +63,11 @@ export const FileTreeRow = memo(function FileTreeRow({
   const isCut = clipboard?.operation === 'cut' && clipboard.paths.includes(path);
   const isRenaming = renamingPath === path;
   const indentPx = depth * 20 + 6;
+
+  const isDragHighlighted = dragOverDir !== null && (
+    dragOverDir === path ||
+    (dragOverDir !== '__root__' && path.startsWith(dragOverDir + '/'))
+  );
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -102,18 +99,15 @@ export const FileTreeRow = memo(function FileTreeRow({
           : (isActive && selectedPaths.size === 0 && focusedPath !== null) ? "bg-nav-bg-selected text-nav-item-active"
           : "text-nav-item",
         isCut && "opacity-50",
-        isFolder && dragOverDir === path && "bg-nav-bg-hover ring-1 ring-foreground/20"
+        isDragHighlighted && (isFolder && dragOverDir === path
+          ? "bg-[var(--accent-primary-12)] ring-1 ring-accent/40"
+          : "bg-[var(--accent-primary-12)]"
+        )
       )}
       style={{ paddingLeft: `${indentPx}px` }}
       draggable={!isRenaming}
       onDragStart={(e) => onDragStart(e, node)}
       onDragEnd={onDragEnd}
-      {...(isFolder ? {
-        onDragEnter: (e: React.DragEvent) => onDragEnter(e, path),
-        onDragOver: onDragOver,
-        onDragLeave: (e: React.DragEvent) => onDragLeave(e, path),
-        onDrop: (e: React.DragEvent) => onDrop(e, path),
-      } : {})}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onContextMenu={(e) => onContextMenu(e, node)}

--- a/apps/frontend/components/workspace/FileTreeRow.tsx
+++ b/apps/frontend/components/workspace/FileTreeRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import type { FileTreeNode } from '@cushion/types';
 import { FileTreeItemActions } from './FileTreeItemActions';
 import { ChevronDown } from 'lucide-react';
@@ -44,7 +44,6 @@ export const FileTreeRow = memo(function FileTreeRow({
   onRenameSubmit,
   onRenameCancel,
 }: FileTreeRowProps) {
-  const [isHovered, setIsHovered] = useState(false);
   const { node, depth, path } = item;
   const isFolder = node.type === 'directory';
 
@@ -108,8 +107,6 @@ export const FileTreeRow = memo(function FileTreeRow({
       draggable={!isRenaming}
       onDragStart={(e) => onDragStart(e, node)}
       onDragEnd={onDragEnd}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
       onContextMenu={(e) => onContextMenu(e, node)}
       onClick={handleClick}
       title={path}
@@ -119,16 +116,12 @@ export const FileTreeRow = memo(function FileTreeRow({
           <>
             <FolderIcon
               open={isExpanded}
-              className={cn(
-                "absolute transition-opacity duration-150",
-                isHovered ? "opacity-0" : "opacity-100"
-              )}
+              className="absolute transition-opacity duration-150 opacity-100 group-hover/item:opacity-0"
             />
             <ChevronDown
               size={16}
               className={cn(
-                "absolute transition-all duration-200",
-                isHovered ? "opacity-100" : "opacity-0",
+                "absolute transition-all duration-200 opacity-0 group-hover/item:opacity-100",
                 !isExpanded && "-rotate-90"
               )}
             />
@@ -168,11 +161,12 @@ export const FileTreeRow = memo(function FileTreeRow({
         )}
       </div>
 
-      <FileTreeItemActions
-        node={node}
-        isVisible={isHovered && !isRenaming}
-        onAddFile={() => onStartCreateFile(path)}
-      />
+      {!isRenaming && (
+        <FileTreeItemActions
+          node={node}
+          onAddFile={() => onStartCreateFile(path)}
+        />
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- Replace per-row drag event handlers with container-level coordinate-based hit detection
- Fix flickering drag highlights and unreliable drop targets caused by enter/leave counting
- Add auto-expand on 500ms hover, root drop zone visual ring, and ancestor path highlighting

## Test plan
- [ ] Drag files between folders — highlight should be stable, no flickering
- [ ] Drag over collapsed folder — should auto-expand after 500ms
- [ ] Drag to root area — should show ring indicator
- [ ] Drop on folder, root, and nested targets all work correctly
- [ ] Multi-select drag-and-drop still works
- [ ] External file drop still works