### PR TITLE
Add trash system with soft-delete and restore

### DIFF
--- a/apps/electron/src/main/coordinator/handlers/trash.ts
+++ b/apps/electron/src/main/coordinator/handlers/trash.ts
@@ -1,0 +1,31 @@
+import type { TrashItem } from '@cushion/types';
+import type { WorkspaceManager } from '../workspace-manager';
+
+export async function handleTrashRestore(
+  workspaceManager: WorkspaceManager,
+  params: { ids: string[] }
+): Promise<{ success: boolean; restoredPaths: string[] }> {
+  const restoredPaths = await workspaceManager.restoreFromTrash(params.ids);
+  return { success: true, restoredPaths };
+}
+
+export function handleTrashList(
+  workspaceManager: WorkspaceManager
+): { items: TrashItem[] } {
+  return { items: workspaceManager.listTrash() };
+}
+
+export async function handleTrashPermanentDelete(
+  workspaceManager: WorkspaceManager,
+  params: { ids: string[] }
+): Promise<{ success: boolean }> {
+  await workspaceManager.permanentlyDeleteFromTrash(params.ids);
+  return { success: true };
+}
+
+export async function handleTrashEmpty(
+  workspaceManager: WorkspaceManager
+): Promise<{ success: boolean }> {
+  await workspaceManager.emptyTrash();
+  return { success: true };
+}

--- a/apps/electron/src/main/coordinator/handlers/workspace.ts
+++ b/apps/electron/src/main/coordinator/handlers/workspace.ts
@@ -1,4 +1,4 @@
-import type { FileTreeNode } from '@cushion/types';
+import type { FileTreeNode, TrashItem } from '@cushion/types';
 import type { WorkspaceManager } from '../workspace-manager';
 
 export async function handleOpenWorkspace(
@@ -59,9 +59,9 @@ export async function handleRenameFile(
 export async function handleDeleteFile(
   workspaceManager: WorkspaceManager,
   params: { path: string }
-): Promise<{ success: boolean }> {
-  await workspaceManager.deleteFile(params.path);
-  return { success: true };
+): Promise<{ success: boolean; trashItem?: TrashItem }> {
+  const trashItem = await workspaceManager.deleteFile(params.path);
+  return { success: true, trashItem };
 }
 
 export async function handleDuplicateFile(

--- a/apps/electron/src/main/coordinator/ipc-router.ts
+++ b/apps/electron/src/main/coordinator/ipc-router.ts
@@ -32,6 +32,12 @@ import {
 
 import { handleSkillInstallZip } from './handlers/skill';
 import { handleShellExec, handleLoginStart, handleLoginFinish } from './handlers/shell';
+import {
+  handleTrashRestore,
+  handleTrashList,
+  handleTrashPermanentDelete,
+  handleTrashEmpty,
+} from './handlers/trash';
 
 let workspaceManager: WorkspaceManager;
 let configManager: ConfigManager;
@@ -128,6 +134,22 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
 
   ipcMain.handle('coordinator:workspace/create-folder', async (_event, params: RPCParams<'workspace/create-folder'>) => {
     return handleCreateFolder(workspaceManager, params);
+  });
+
+  ipcMain.handle('coordinator:trash/restore', async (_event, params: RPCParams<'trash/restore'>) => {
+    return handleTrashRestore(workspaceManager, params);
+  });
+
+  ipcMain.handle('coordinator:trash/list', async () => {
+    return handleTrashList(workspaceManager);
+  });
+
+  ipcMain.handle('coordinator:trash/permanent-delete', async (_event, params: RPCParams<'trash/permanent-delete'>) => {
+    return handleTrashPermanentDelete(workspaceManager, params);
+  });
+
+  ipcMain.handle('coordinator:trash/empty', async () => {
+    return handleTrashEmpty(workspaceManager);
   });
 
   ipcMain.handle('coordinator:workspace/file-base64', async (_event, params: RPCParams<'workspace/file-base64'>) => {

--- a/apps/electron/src/main/coordinator/trash-manager.ts
+++ b/apps/electron/src/main/coordinator/trash-manager.ts
@@ -1,0 +1,156 @@
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import type { TrashItem } from '@cushion/types';
+import { writeFileAtomicWithRetry } from './atomic-write';
+
+interface TrashManifest {
+  items: TrashItem[];
+}
+
+export class TrashManager {
+  private workspacePath = '';
+  private trashDir = '';
+  private manifestPath = '';
+  private manifest: TrashManifest = { items: [] };
+
+  async init(workspacePath: string): Promise<void> {
+    this.workspacePath = workspacePath;
+    this.trashDir = path.join(workspacePath, '.cushion-trash');
+    this.manifestPath = path.join(this.trashDir, 'manifest.json');
+
+    await fs.mkdir(this.trashDir, { recursive: true });
+    await this.loadManifest();
+  }
+
+  async moveToTrash(relativePath: string, isDirectory: boolean): Promise<TrashItem> {
+    const id = crypto.randomUUID();
+    const source = path.join(this.workspacePath, relativePath);
+    const dest = path.join(this.trashDir, id);
+
+    await fs.rename(source, dest);
+
+    const item: TrashItem = {
+      id,
+      originalPath: relativePath,
+      deletedAt: new Date().toISOString(),
+      isDirectory,
+    };
+
+    this.manifest.items.push(item);
+    await this.saveManifest();
+    return item;
+  }
+
+  async restore(ids: string[]): Promise<string[]> {
+    const restoredPaths: string[] = [];
+
+    for (const id of ids) {
+      const idx = this.manifest.items.findIndex((item) => item.id === id);
+      if (idx === -1) continue;
+
+      const item = this.manifest.items[idx];
+      const trashPath = path.join(this.trashDir, id);
+
+      let targetPath = path.join(this.workspacePath, item.originalPath);
+      let finalRelativePath = item.originalPath;
+
+      // Handle name collision
+      try {
+        await fs.access(targetPath);
+        // Target exists — generate a unique name
+        finalRelativePath = this.resolveCollision(item.originalPath);
+        targetPath = path.join(this.workspacePath, finalRelativePath);
+      } catch {
+        // Target doesn't exist — good
+      }
+
+      // Ensure parent directory exists
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.rename(trashPath, targetPath);
+
+      this.manifest.items.splice(idx, 1);
+      restoredPaths.push(finalRelativePath);
+    }
+
+    await this.saveManifest();
+    return restoredPaths;
+  }
+
+  async permanentlyDelete(ids: string[]): Promise<void> {
+    for (const id of ids) {
+      const idx = this.manifest.items.findIndex((item) => item.id === id);
+      if (idx === -1) continue;
+
+      const trashPath = path.join(this.trashDir, id);
+      await fs.rm(trashPath, { recursive: true, force: true });
+      this.manifest.items.splice(idx, 1);
+    }
+
+    await this.saveManifest();
+  }
+
+  async emptyTrash(): Promise<void> {
+    for (const item of this.manifest.items) {
+      const trashPath = path.join(this.trashDir, item.id);
+      await fs.rm(trashPath, { recursive: true, force: true });
+    }
+
+    this.manifest.items = [];
+    await this.saveManifest();
+  }
+
+  listItems(): TrashItem[] {
+    return this.manifest.items;
+  }
+
+  private async saveManifest(): Promise<void> {
+    const json = JSON.stringify(this.manifest, null, 2);
+    await writeFileAtomicWithRetry(this.manifestPath, json, 'utf-8');
+  }
+
+  private async loadManifest(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.manifestPath, 'utf-8');
+      const parsed = JSON.parse(raw) as TrashManifest;
+      this.manifest = parsed;
+    } catch {
+      this.manifest = { items: [] };
+    }
+
+    // Orphan cleanup: verify files exist on disk
+    const validItems: TrashItem[] = [];
+    for (const item of this.manifest.items) {
+      try {
+        await fs.access(path.join(this.trashDir, item.id));
+        validItems.push(item);
+      } catch {
+        // File missing from disk — remove from manifest
+      }
+    }
+
+    if (validItems.length !== this.manifest.items.length) {
+      this.manifest.items = validItems;
+      await this.saveManifest();
+    }
+  }
+
+  private resolveCollision(originalPath: string): string {
+    const dir = path.dirname(originalPath);
+    const ext = path.extname(originalPath);
+    const base = path.basename(originalPath, ext);
+
+    let suffix = ' (restored)';
+    let candidate = path.join(dir, `${base}${suffix}${ext}`).replace(/\\/g, '/');
+
+    // Unlikely but handle multiple collisions
+    let counter = 2;
+    while (this.manifest.items.some((item) => item.originalPath === candidate)) {
+      suffix = ` (restored ${counter})`;
+      candidate = path.join(dir, `${base}${suffix}${ext}`).replace(/\\/g, '/');
+      counter++;
+    }
+
+    return candidate;
+  }
+}

--- a/apps/electron/src/main/coordinator/trash-manager.ts
+++ b/apps/electron/src/main/coordinator/trash-manager.ts
@@ -55,17 +55,12 @@ export class TrashManager {
       let targetPath = path.join(this.workspacePath, item.originalPath);
       let finalRelativePath = item.originalPath;
 
-      // Handle name collision
       try {
         await fs.access(targetPath);
-        // Target exists — generate a unique name
         finalRelativePath = this.resolveCollision(item.originalPath);
         targetPath = path.join(this.workspacePath, finalRelativePath);
-      } catch {
-        // Target doesn't exist — good
-      }
+      } catch {}
 
-      // Ensure parent directory exists
       await fs.mkdir(path.dirname(targetPath), { recursive: true });
       await fs.rename(trashPath, targetPath);
 
@@ -118,15 +113,12 @@ export class TrashManager {
       this.manifest = { items: [] };
     }
 
-    // Orphan cleanup: verify files exist on disk
     const validItems: TrashItem[] = [];
     for (const item of this.manifest.items) {
       try {
         await fs.access(path.join(this.trashDir, item.id));
         validItems.push(item);
-      } catch {
-        // File missing from disk — remove from manifest
-      }
+      } catch {}
     }
 
     if (validItems.length !== this.manifest.items.length) {
@@ -143,7 +135,6 @@ export class TrashManager {
     let suffix = ' (restored)';
     let candidate = path.join(dir, `${base}${suffix}${ext}`).replace(/\\/g, '/');
 
-    // Unlikely but handle multiple collisions
     let counter = 2;
     while (this.manifest.items.some((item) => item.originalPath === candidate)) {
       suffix = ` (restored ${counter})`;

--- a/apps/electron/src/main/coordinator/workspace-manager.ts
+++ b/apps/electron/src/main/coordinator/workspace-manager.ts
@@ -1,10 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
 import ignore, { type Ignore } from 'ignore';
-import type { FileTreeNode, FileChange } from '@cushion/types';
+import type { FileTreeNode, FileChange, TrashItem } from '@cushion/types';
 import { IGNORED_PATTERNS, DEFAULT_ALLOWED_EXTENSIONS, ALWAYS_VISIBLE_FILENAMES } from './constants';
 import { WorkspaceWatcher } from './workspace-watcher';
 import { writeFileAtomicWithRetry, throwSaveFileError } from './atomic-write';
+import { TrashManager } from './trash-manager';
 
 interface WorkspaceContext {
   projectPath: string;
@@ -38,6 +39,7 @@ const MIME_TYPES_BY_EXTENSION: Record<string, string> = {
 export class WorkspaceManager {
   private currentWorkspace: WorkspaceContext | null = null;
   private watcher = new WorkspaceWatcher();
+  private trashManager = new TrashManager();
   private respectGitignore = true;
   private allowedExtensions: Set<string> = new Set(
     DEFAULT_ALLOWED_EXTENSIONS.map((e) => e.toLowerCase())
@@ -169,6 +171,7 @@ export class WorkspaceManager {
       projectPath,
     };
 
+    await this.trashManager.init(projectPath);
     this.watcher.start(projectPath);
 
     return {
@@ -413,7 +416,7 @@ export class WorkspaceManager {
     }
   }
 
-  async deleteFile(relativePath: string): Promise<void> {
+  async deleteFile(relativePath: string): Promise<TrashItem> {
     if (!this.currentWorkspace) {
       throw new Error('No workspace open');
     }
@@ -422,12 +425,7 @@ export class WorkspaceManager {
 
     try {
       const stats = await fs.stat(fullPath);
-
-      if (stats.isDirectory()) {
-        await fs.rm(fullPath, { recursive: true, force: true });
-      } else {
-        await fs.unlink(fullPath);
-      }
+      return await this.trashManager.moveToTrash(relativePath, stats.isDirectory());
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         throw new Error(`File not found: ${relativePath}`);
@@ -436,6 +434,31 @@ export class WorkspaceManager {
       }
       throw error;
     }
+  }
+
+  async restoreFromTrash(ids: string[]): Promise<string[]> {
+    if (!this.currentWorkspace) {
+      throw new Error('No workspace open');
+    }
+    return this.trashManager.restore(ids);
+  }
+
+  async permanentlyDeleteFromTrash(ids: string[]): Promise<void> {
+    if (!this.currentWorkspace) {
+      throw new Error('No workspace open');
+    }
+    await this.trashManager.permanentlyDelete(ids);
+  }
+
+  async emptyTrash(): Promise<void> {
+    if (!this.currentWorkspace) {
+      throw new Error('No workspace open');
+    }
+    await this.trashManager.emptyTrash();
+  }
+
+  listTrash(): TrashItem[] {
+    return this.trashManager.listItems();
   }
 
   async duplicateFile(sourcePath: string, destPath: string): Promise<void> {

--- a/apps/frontend/components/workspace/FileBrowser.tsx
+++ b/apps/frontend/components/workspace/FileBrowser.tsx
@@ -4,8 +4,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useExplorerStore } from '@/stores/explorerStore';
 import { FileTree } from './FileTree';
 import { MoveToDialog } from './MoveToDialog';
-import { ConfirmDialog } from './ConfirmDialog';
-import { FilePlus, FolderPlus, Search, Settings, ChevronDown } from 'lucide-react';
+import { FilePlus, FolderPlus, Search, Settings, ChevronDown, Trash2 } from 'lucide-react';
 import { useMediaQuery } from 'usehooks-ts';
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
 import { LogoSpinner } from '@/components/ui/LogoSpinner';
@@ -31,6 +30,7 @@ interface FileBrowserProps {
   isCollapsed?: boolean;
   onSearch?: () => void;
   onSettings?: () => void;
+  onTrash?: () => void;
 }
 
 export interface FileBrowserHandle {
@@ -39,7 +39,7 @@ export interface FileBrowserHandle {
 }
 
 export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
-  function FileBrowser({ client, onFileOpen, onSidebarToggle, isCollapsed = false, onSearch, onSettings }, ref) {
+  function FileBrowser({ client, onFileOpen, onSidebarToggle, isCollapsed = false, onSearch, onSettings, onTrash }, ref) {
   const { metadata, currentFile, preferences, sidebarWidth: rawSidebarWidth, setSidebarWidth } = useWorkspaceStore();
   const { showToast } = useToast();
   const [rootFiles, setRootFiles] = useState<FileTreeNode[]>([]);
@@ -48,8 +48,6 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
   const [rootExpanded, setRootExpanded] = useState(true);
   const [moveDialogOpen, setMoveDialogOpen] = useState(false);
   const [moveSourcePath, setMoveSourcePath] = useState<string>('');
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [deleteTargetPaths, setDeleteTargetPaths] = useState<string[]>([]);
   const [creatingFileAtRoot, setCreatingFileAtRoot] = useState(0);
   const [creatingFolderAtRoot, setCreatingFolderAtRoot] = useState(0);
   const isMobile = useMediaQuery("(max-width: 768px)");
@@ -273,13 +271,58 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
     }
   }, [metadata, onSidebarToggle, isCollapsed]);
 
+  const handleSoftDelete = useCallback(async (paths: string[]) => {
+    if (!client) return;
+
+    try {
+      const trashItems: { id: string; path: string }[] = [];
+      const dirsToRefresh = new Set<string>();
+
+      for (const p of paths) {
+        const result = await client.deleteFile(p);
+        if (result.trashItem) {
+          trashItems.push({ id: result.trashItem.id, path: p });
+        }
+        const parentPath = p.substring(0, p.lastIndexOf('/')) || '.';
+        dirsToRefresh.add(parentPath);
+      }
+
+      for (const dir of dirsToRefresh) {
+        await loadDirectory(dir);
+      }
+      useExplorerStore.getState().clearSelection();
+
+      if (trashItems.length > 0) {
+        const fileName = trashItems[0].path.split('/').pop() || trashItems[0].path;
+        const description = trashItems.length === 1
+          ? `"${fileName}" moved to trash`
+          : `${trashItems.length} items moved to trash`;
+
+        const trashItemIds = trashItems.map((t) => t.id);
+
+        showToast({
+          description,
+          duration: 8000,
+          actions: [{
+            label: 'Undo',
+            onClick: async () => {
+              await client.restoreFromTrash(trashItemIds);
+              for (const dir of dirsToRefresh) {
+                await loadDirectory(dir);
+              }
+            },
+          }],
+        });
+      }
+    } catch (error) {
+      console.error('[FileBrowser] Failed to delete:', error);
+      setError(`Failed to delete: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }, [client, loadDirectory, showToast]);
+
   if (!metadata) {
     return null;
   }
-
-  const deleteMessage = deleteTargetPaths.length > 1
-    ? `Are you sure you want to delete ${deleteTargetPaths.length} items? This action cannot be undone.`
-    : `Are you sure you want to delete "${deleteTargetPaths[0]?.split('/').pop() || deleteTargetPaths[0]}"? This action cannot be undone.`;
 
   return (
     <>
@@ -332,6 +375,19 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
           >
             <Settings size={16} />
             <span>Settings</span>
+          </button>
+
+          <button
+            onClick={onTrash}
+            className={cn(
+              "w-full flex items-center gap-3 px-2 h-8 rounded-md",
+              "text-sm text-muted-foreground hover:text-foreground",
+              "hover:bg-muted/30",
+              "transition-colors duration-150"
+            )}
+          >
+            <Trash2 size={16} />
+            <span>Trash</span>
           </button>
 
           <button
@@ -506,12 +562,10 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
                 }
               }}
               onDelete={(path) => {
-                setDeleteTargetPaths([path]);
-                setDeleteDialogOpen(true);
+                handleSoftDelete([path]);
               }}
               onDeleteMultiple={(paths) => {
-                setDeleteTargetPaths(paths);
-                setDeleteDialogOpen(true);
+                handleSoftDelete(paths);
               }}
               onDuplicate={async (path) => {
                 if (!client) return;
@@ -564,34 +618,6 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
       }}
     />
 
-    <ConfirmDialog
-      isOpen={deleteDialogOpen}
-      onClose={() => setDeleteDialogOpen(false)}
-      onConfirm={async () => {
-        if (!client) return;
-
-        try {
-          const dirsToRefresh = new Set<string>();
-          for (const path of deleteTargetPaths) {
-            await client.deleteFile(path);
-            const parentPath = path.substring(0, path.lastIndexOf('/')) || '.';
-            dirsToRefresh.add(parentPath);
-          }
-          for (const dir of dirsToRefresh) {
-            await loadDirectory(dir);
-          }
-          useExplorerStore.getState().clearSelection();
-        } catch (error) {
-          console.error('[FileBrowser] Failed to delete:', error);
-          setError(`Failed to delete: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        }
-      }}
-      title={deleteTargetPaths.length > 1 ? `Delete ${deleteTargetPaths.length} items` : 'Delete file'}
-      message={deleteMessage}
-      confirmText="Delete"
-      cancelText="Cancel"
-      variant="danger"
-    />
     </>
   );
   }

--- a/apps/frontend/components/workspace/TrashViewerPanel.tsx
+++ b/apps/frontend/components/workspace/TrashViewerPanel.tsx
@@ -1,0 +1,193 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Trash2, RotateCcw, X, File, Folder } from 'lucide-react';
+import { ConfirmDialog } from './ConfirmDialog';
+import { cn } from '@/lib/utils';
+import type { TrashItem } from '@cushion/types';
+import type { CoordinatorClient } from '@/lib/coordinator-client';
+
+interface TrashViewerPanelProps {
+  client: CoordinatorClient;
+  onClose: () => void;
+  onFileRestored: () => void;
+}
+
+function relativeTime(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+export function TrashViewerPanel({ client, onClose, onFileRestored }: TrashViewerPanelProps) {
+  const [items, setItems] = useState<TrashItem[]>([]);
+  const [contextMenu, setContextMenu] = useState<{ item: TrashItem; x: number; y: number } | null>(null);
+  const [confirmEmpty, setConfirmEmpty] = useState(false);
+
+  const fetchItems = useCallback(async () => {
+    try {
+      const { items: trashItems } = await client.listTrash();
+      setItems(trashItems);
+    } catch (err) {
+      console.error('[TrashViewer] Failed to list trash:', err);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const handler = () => setContextMenu(null);
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [contextMenu]);
+
+  const handleRestore = async (ids: string[]) => {
+    try {
+      await client.restoreFromTrash(ids);
+      setItems((prev) => prev.filter((item) => !ids.includes(item.id)));
+      onFileRestored();
+    } catch (err) {
+      console.error('[TrashViewer] Failed to restore:', err);
+    }
+  };
+
+  const handlePermanentDelete = async (ids: string[]) => {
+    try {
+      await client.permanentlyDeleteFromTrash(ids);
+      setItems((prev) => prev.filter((item) => !ids.includes(item.id)));
+    } catch (err) {
+      console.error('[TrashViewer] Failed to permanently delete:', err);
+    }
+  };
+
+  const handleEmptyTrash = async () => {
+    try {
+      await client.emptyTrash();
+      setItems([]);
+    } catch (err) {
+      console.error('[TrashViewer] Failed to empty trash:', err);
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-surface-elevated">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+        <Trash2 size={16} className="text-accent" />
+        <span className="font-medium text-sm">Trash</span>
+        <span className="ml-1 text-xs text-foreground-muted bg-surface-tertiary px-2 py-0.5 rounded-full">
+          {items.length}
+        </span>
+        {items.length > 0 && (
+          <button
+            onClick={() => setConfirmEmpty(true)}
+            className="ml-auto text-xs text-accent-red hover:text-[var(--accent-red-hover)] transition-colors"
+          >
+            Empty Trash
+          </button>
+        )}
+        <button
+          onClick={onClose}
+          className={cn(
+            items.length === 0 && 'ml-auto',
+            "p-1.5 rounded-md text-foreground-muted hover:text-foreground hover:bg-surface-tertiary transition-colors"
+          )}
+          title="Close trash"
+          aria-label="Close trash"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto thin-scrollbar">
+        {items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-foreground-muted text-sm p-4">
+            <Trash2 size={32} className="mb-2 opacity-30" />
+            <p>Trash is empty</p>
+          </div>
+        ) : (
+          <div className="p-2">
+            {items.map((item) => (
+              <button
+                key={item.id}
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-surface-tertiary transition-colors text-left group"
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setContextMenu({ item, x: e.clientX, y: e.clientY });
+                }}
+              >
+                {item.isDirectory ? (
+                  <Folder size={14} className="text-foreground-muted flex-shrink-0" />
+                ) : (
+                  <File size={14} className="text-foreground-muted flex-shrink-0" />
+                )}
+                <span className="text-sm truncate flex-1">{item.originalPath}</span>
+                <span className="text-xs text-foreground-faint flex-shrink-0">
+                  {relativeTime(item.deletedAt)}
+                </span>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRestore([item.id]);
+                  }}
+                  className="p-1 rounded opacity-0 group-hover:opacity-100 text-foreground-muted hover:text-foreground hover:bg-surface-tertiary transition-all"
+                  title="Restore"
+                >
+                  <RotateCcw size={13} />
+                </button>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Context menu */}
+      {contextMenu && (
+        <div
+          className="fixed z-50 bg-modal-bg border border-modal-border rounded-lg shadow-lg py-1 min-w-[160px]"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button
+            className="w-full text-left px-3 py-1.5 text-sm hover:bg-surface-tertiary transition-colors"
+            onClick={() => {
+              handleRestore([contextMenu.item.id]);
+              setContextMenu(null);
+            }}
+          >
+            Restore
+          </button>
+          <button
+            className="w-full text-left px-3 py-1.5 text-sm text-accent-red hover:bg-surface-tertiary transition-colors"
+            onClick={() => {
+              handlePermanentDelete([contextMenu.item.id]);
+              setContextMenu(null);
+            }}
+          >
+            Delete permanently
+          </button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmEmpty}
+        onClose={() => setConfirmEmpty(false)}
+        onConfirm={handleEmptyTrash}
+        title="Empty Trash"
+        message={`Permanently delete ${items.length} item${items.length !== 1 ? 's' : ''}? This cannot be undone.`}
+        confirmText="Empty Trash"
+        cancelText="Cancel"
+        variant="danger"
+      />
+    </div>
+  );
+}

--- a/apps/frontend/components/workspace/TrashViewerPanel.tsx
+++ b/apps/frontend/components/workspace/TrashViewerPanel.tsx
@@ -80,7 +80,6 @@ export function TrashViewerPanel({ client, onClose, onFileRestored }: TrashViewe
 
   return (
     <div className="h-full flex flex-col bg-surface-elevated">
-      {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
         <Trash2 size={16} className="text-accent" />
         <span className="font-medium text-sm">Trash</span>
@@ -108,7 +107,6 @@ export function TrashViewerPanel({ client, onClose, onFileRestored }: TrashViewe
         </button>
       </div>
 
-      {/* Content */}
       <div className="flex-1 overflow-y-auto thin-scrollbar">
         {items.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-foreground-muted text-sm p-4">
@@ -151,7 +149,6 @@ export function TrashViewerPanel({ client, onClose, onFileRestored }: TrashViewe
         )}
       </div>
 
-      {/* Context menu */}
       {contextMenu && (
         <div
           className="fixed z-50 bg-modal-bg border border-modal-border rounded-lg shadow-lg py-1 min-w-[160px]"

--- a/apps/frontend/lib/coordinator-client.ts
+++ b/apps/frontend/lib/coordinator-client.ts
@@ -85,6 +85,22 @@ export class CoordinatorClient {
     return this.call('workspace/delete', { path });
   }
 
+  restoreFromTrash(ids: string[]) {
+    return this.call('trash/restore', { ids });
+  }
+
+  listTrash() {
+    return this.call('trash/list');
+  }
+
+  permanentlyDeleteFromTrash(ids: string[]) {
+    return this.call('trash/permanent-delete', { ids });
+  }
+
+  emptyTrash() {
+    return this.call('trash/empty');
+  }
+
   duplicateFile(path: string, newPath: string) {
     return this.call('workspace/duplicate', { path, newPath });
   }

--- a/apps/frontend/src/Home.tsx
+++ b/apps/frontend/src/Home.tsx
@@ -17,6 +17,7 @@ import { ToastProvider } from '@/components/chat/Toast';
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
 import { ModalOverlay } from '@/components/ui/ModalOverlay';
 import { SettingsPanel } from '@/components/settings/SettingsPanel';
+import { TrashViewerPanel } from '@/components/workspace/TrashViewerPanel';
 import { useLinkIndex } from '@/hooks/useLinkIndex';
 import { useFileTree } from '@/hooks/useFileTree';
 import { formatShortcutList, matchShortcut, useShortcutBindings } from '@/lib/shortcuts';
@@ -94,6 +95,7 @@ export default function Home() {
   const lastRightPanelModeRef = useRef<'chat'>('chat');
   const [showBacklinks, setShowBacklinks] = useState(false);
   const [showGraph, setShowGraph] = useState(false);
+  const [showTrash, setShowTrash] = useState(false);
   const [showQuickSwitcher, setShowQuickSwitcher] = useState(false);
   const fileBrowserRef = useRef<FileBrowserHandle>(null);
   const autoOpenAttempted = useRef(false);
@@ -136,10 +138,11 @@ export default function Home() {
       { isOpen: showWorkspaceModal && !!metadata, close: () => setShowWorkspaceModal(false) },
       { isOpen: showQuickSwitcher, close: () => setShowQuickSwitcher(false) },
       { isOpen: showSettings, close: () => setShowSettings(false) },
+      { isOpen: showTrash, close: () => setShowTrash(false) },
       { isOpen: showGraph, close: () => setShowGraph(false) },
       { isOpen: showBacklinks, close: () => setShowBacklinks(false) },
     ]);
-  }, [metadata, showBacklinks, showGraph, showQuickSwitcher, showSettings, showWorkspaceModal]);
+  }, [metadata, showBacklinks, showGraph, showQuickSwitcher, showSettings, showTrash, showWorkspaceModal]);
 
   useEffect(() => {
     let cancelled = false;
@@ -386,6 +389,7 @@ export default function Home() {
     setShowQuickSwitcher(false);
     setShowWorkspaceModal(false);
     setShowSettings(false);
+    setShowTrash(false);
   }, [focusModeEnabled]);
 
   const rightPanelMin = 280;
@@ -491,6 +495,7 @@ export default function Home() {
           onSettings={() => {
             setShowSettings(true);
           }}
+          onTrash={() => setShowTrash(true)}
         />
 
       <main className="flex-1 flex flex-col overflow-hidden min-w-0">
@@ -574,6 +579,19 @@ export default function Home() {
             currentFile={currentFile}
             onNodeClick={handleNavigateToFile}
             onClose={() => setShowGraph(false)}
+          />
+        </ModalOverlay>
+      )}
+
+      {!focusModeEnabled && showTrash && (
+        <ModalOverlay onBackdropClick={() => setShowTrash(false)}>
+          <TrashViewerPanel
+            client={client}
+            onClose={() => setShowTrash(false)}
+            onFileRestored={() => {
+              fileBrowserRef.current?.refreshFileList();
+              fetchFileTree();
+            }}
           />
         </ModalOverlay>
       )}

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -3,6 +3,13 @@ import type {
   FileChange,
 } from './index.js';
 
+export interface TrashItem {
+  id: string;
+  originalPath: string;
+  deletedAt: string; // ISO 8601
+  isDirectory: boolean;
+}
+
 export interface RPCMethodMap {
   // Workspace
   'workspace/open': {
@@ -40,7 +47,7 @@ export interface RPCMethodMap {
   };
   'workspace/delete': {
     params: { path: string };
-    result: { success: boolean };
+    result: { success: boolean; trashItem?: TrashItem };
   };
   'workspace/duplicate': {
     params: { path: string; newPath: string };
@@ -66,6 +73,24 @@ export interface RPCMethodMap {
   };
   'workspace/save-file-base64': {
     params: { filePath: string; base64: string };
+    result: { success: boolean };
+  };
+
+  // Trash
+  'trash/restore': {
+    params: { ids: string[] };
+    result: { success: boolean; restoredPaths: string[] };
+  };
+  'trash/list': {
+    params: void;
+    result: { items: TrashItem[] };
+  };
+  'trash/permanent-delete': {
+    params: { ids: string[] };
+    result: { success: boolean };
+  };
+  'trash/empty': {
+    params: void;
     result: { success: boolean };
   };
 

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -6,7 +6,7 @@ import type {
 export interface TrashItem {
   id: string;
   originalPath: string;
-  deletedAt: string; // ISO 8601
+  deletedAt: string;
   isDirectory: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Replace permanent file deletion with soft-delete to a `.cushion-trash` directory
- Add undo toast on delete with instant restore capability
- Add Trash viewer panel accessible from the sidebar for browsing, restoring, and permanently deleting trashed items
- New `TrashManager` backend with IPC routes for restore, list, permanent-delete, and empty operations

## Test plan
- [ ] Delete a file — verify it moves to trash and undo toast appears
- [ ] Click undo — verify file is restored to original location
- [ ] Open Trash panel from sidebar — verify trashed items are listed
- [ ] Restore / permanently delete items from Trash panel
- [ ] Empty trash and verify all items are removed