### PR TITLE
Add checkbox widgets and WYSIWYG decoration improvements

### DIFF
--- a/apps/frontend/lib/codemirror-wysiwyg/embed-utils.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/embed-utils.ts
@@ -37,9 +37,10 @@ export function createSourceToggle(wrapper: HTMLElement): HTMLButtonElement {
     const view = getEditorView(wrapper);
     if (!view) return;
     const pos = view.posAtDOM(wrapper);
+    const line = view.state.doc.lineAt(pos);
     view.dispatch({
       effects: embedSourceRevealEffect.of(pos),
-      selection: { anchor: pos },
+      selection: { anchor: line.from, head: line.to },
     });
   };
   return btn;

--- a/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
@@ -127,7 +127,7 @@ class HrWidget extends WidgetType {
   }
 }
 
-function isCursorAdjacentToLine(state: EditorState, from: number, to: number): boolean {
+function isCursorAdjacentToLine(state: EditorState, from: number): boolean {
   if (!hasFocus(state)) return false;
   const doc = state.doc;
   const hrLine = doc.lineAt(from).number;
@@ -604,7 +604,7 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
       }
 
       if (type === 'HorizontalRule') {
-        if (isCursorAdjacentToLine(state, from, to)) return false;
+        if (isCursorAdjacentToLine(state, from)) return false;
         decorations.push(
           Decoration.replace({
             widget: new HrWidget(),

--- a/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
@@ -8,7 +8,7 @@ import {
 } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
 import { EditorState, Range, StateField } from '@codemirror/state';
-import { isSelectRange, isSelectLine, isFocusEvent, mouseSelectEffect } from './reveal-on-cursor';
+import { isSelectRange, isSelectLine, isFocusEvent, mouseSelectEffect, mouseSelectingField, hasFocus } from './reveal-on-cursor';
 import { getListNestingDepth } from './list-utils';
 import { ImageWidget } from './widgets/image-widget';
 import { PdfWidget } from './widgets/pdf-widget';
@@ -116,6 +116,31 @@ class CodeBlockInfoWidget extends WidgetType {
   }
 
   ignoreEvent() { return true; }
+}
+
+class HrWidget extends WidgetType {
+  eq() { return true; }
+  toDOM() {
+    const span = document.createElement('span');
+    span.className = 'cm-hr-widget';
+    return span;
+  }
+}
+
+function isCursorAdjacentToLine(state: EditorState, from: number, to: number): boolean {
+  if (!hasFocus(state)) return false;
+  const doc = state.doc;
+  const hrLine = doc.lineAt(from).number;
+  return state.selection.ranges.some((r) => {
+    const headLine = doc.lineAt(r.head).number;
+    if (headLine >= hrLine - 1 && headLine <= hrLine + 1) return true;
+    if (!r.empty) {
+      const selFrom = doc.lineAt(Math.min(r.head, r.anchor)).number;
+      const selTo = doc.lineAt(Math.max(r.head, r.anchor)).number;
+      return selFrom <= hrLine + 1 && selTo >= hrLine - 1;
+    }
+    return false;
+  });
 }
 
 export const embedRevealedField = StateField.define<number | null>({
@@ -296,19 +321,6 @@ function buildMarkDecorations(view: EditorView): DecorationSet {
       }
 
       if (type === 'HorizontalRule') {
-        const line = state.doc.lineAt(from);
-        const cursorOnHr = isSelectLine(state, from, to);
-
-        decorations.push(
-          Decoration.line({
-            class: cursorOnHr ? 'cm-hr-line cm-hr-line-revealed' : 'cm-hr-line',
-          }).range(line.from),
-        );
-        decorations.push(
-          Decoration.mark({
-            class: cursorOnHr ? 'cm-hr-content cm-hr-content-revealed' : 'cm-hr-content',
-          }).range(from, to),
-        );
         return false;
       }
 
@@ -447,8 +459,6 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
       if (type === 'Table') return false;
 
       if (type === 'Image') {
-        if (isSelectRange(state, { from, to })) return false;
-
         const isRevealed = revealedPos !== null && from === revealedPos;
         const text = state.doc.sliceString(from, to);
 
@@ -471,6 +481,7 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
             heading = decodeURIComponent(href.slice(hashIdx + 1));
           }
           const embedType = classifyEmbed(href);
+          if (embedType === 'unsupported' && isSelectRange(state, { from, to })) return false;
           addEmbedDecoration(decorations, from, to, href, alt, isRevealed, width, embedType, heading);
           return false;
         }
@@ -498,6 +509,7 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
             }
           }
           const embedType = classifyEmbed(filePath);
+          if (embedType === 'unsupported' && isSelectRange(state, { from, to })) return false;
           addEmbedDecoration(decorations, from, to, filePath, wikiAlt, isRevealed, wikiWidth, embedType, heading);
         }
         return false;
@@ -592,6 +604,13 @@ function buildWidgetDecorations(state: EditorState): DecorationSet {
       }
 
       if (type === 'HorizontalRule') {
+        if (isCursorAdjacentToLine(state, from, to)) return false;
+        decorations.push(
+          Decoration.replace({
+            widget: new HrWidget(),
+            inclusive: false,
+          }).range(from, to),
+        );
         return false;
       }
 
@@ -635,7 +654,7 @@ export const widgetDecorationsField = StateField.define<DecorationSet>({
     return buildWidgetDecorations(state);
   },
   update(value, tr) {
-    if (tr.effects.some(e => e.is(embedSourceRevealEffect) || e.is(mouseSelectEffect))) {
+    if (tr.effects.some(e => e.is(embedSourceRevealEffect) || (e.is(mouseSelectEffect) && !e.value))) {
       return buildWidgetDecorations(tr.state);
     }
     const treeChanged = syntaxTree(tr.state) !== syntaxTree(tr.startState);
@@ -646,6 +665,7 @@ export const widgetDecorationsField = StateField.define<DecorationSet>({
       return value.map(tr.changes);
     }
     if (tr.selection) {
+      if (tr.state.field(mouseSelectingField, false)) return value;
       return buildWidgetDecorations(tr.state);
     }
     if (treeChanged) {
@@ -654,6 +674,20 @@ export const widgetDecorationsField = StateField.define<DecorationSet>({
     return value;
   },
   provide: (f) => EditorView.decorations.from(f),
+});
+
+export const hrClickHandler = EditorView.domEventHandlers({
+  mousedown(event, view) {
+    const target = event.target as HTMLElement;
+    const hr = target.querySelector('.cm-hr-widget') || target.closest('.cm-hr-widget');
+    if (!hr) return false;
+    const pos = view.posAtDOM(hr);
+    const line = view.state.doc.lineAt(pos);
+    event.preventDefault();
+    view.dispatch({ selection: { anchor: line.from, head: line.to } });
+    view.focus();
+    return true;
+  },
 });
 
 export const linkClickHandler = EditorView.domEventHandlers({

--- a/apps/frontend/lib/codemirror-wysiwyg/index.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/index.ts
@@ -1,6 +1,6 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { markDecorationsPlugin, widgetDecorationsField, linkClickHandler, embedRevealedField } from './hide-markup';
+import { markDecorationsPlugin, widgetDecorationsField, linkClickHandler, hrClickHandler, embedRevealedField } from './hide-markup';
 import { inlineReplacePlugin } from './inline-replace';
 import { diffTheme as aiDiffTheme } from './ai-diff';
 import { focusState, focusListener, mouseSelectingField, mouseSelectionTracker } from './reveal-on-cursor';
@@ -221,6 +221,7 @@ export function wysiwygExtension(): Extension {
     inlineReplacePlugin,
     widgetDecorationsField,
     linkClickHandler,
+    hrClickHandler,
     wikiLinkExtension(),
     combinedAutocomplete(),
     slashCommandExtension(),

--- a/apps/frontend/lib/codemirror-wysiwyg/inline-replace.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/inline-replace.ts
@@ -6,6 +6,7 @@ import { hasFocus, isFocusEvent, isMousePressed, mouseSelectEffect } from './rev
 import { wikiLinkRegex } from '../wiki-link';
 import { getListNestingDepth, computeListDisplayText } from './list-utils';
 import { ListPrefixWidget } from './widgets/list-marker-widget';
+import { CheckboxWidget } from './widgets/checkbox-widget';
 
 /** Node types handled by this plugin, mapped to their child mark node name */
 const inlineMarkTypes: Record<string, string> = {
@@ -54,7 +55,9 @@ function buildInlineReplaceDecorations(view: EditorView): DecorationSet {
         // decorations inside tables to avoid conflicting with cell boundaries.
         if (type === 'Table') return false;
 
-        // ATX Heading: hide # marks + trailing space (Zettlr pattern)
+        // ATX Heading: hide # marks + trailing space via mark decoration
+        // Uses font-size:0 mark instead of replace to avoid DOM rebuild that
+        // causes vertical shift at large heading font-sizes (H1-H3).
         if (/^ATXHeading[1-6]$/.test(type)) {
           if (!shouldRevealLine(state, node.from)) {
             const mark = node.node.getChild('HeaderMark');
@@ -66,7 +69,9 @@ function buildInlineReplaceDecorations(view: EditorView): DecorationSet {
               }
               const hideEnd = mark.to + offset;
               if (hideEnd < node.to) {
-                ranges.push(replace.range(mark.from, hideEnd));
+                ranges.push(
+                  Decoration.mark({ class: 'cm-heading-mark-hidden' }).range(mark.from, hideEnd),
+                );
               }
             }
           }
@@ -147,17 +152,35 @@ function buildInlineReplaceDecorations(view: EditorView): DecorationSet {
           const depth = getListNestingDepth(node.node);
           const depth1Based = Math.min(depth + 1, 9);
           const rawMarker = state.sliceDoc(node.from, node.to);
-          const revealed = shouldRevealLine(state, node.from);
+          // Task list in BulletList: replace entire prefix (- [ ] ) with indent guides + checkbox
+          const taskNode = parent?.getChild('Task');
+          if (taskNode && parent?.parent?.type?.name === 'BulletList') {
+            const taskMarker = taskNode.getChild('TaskMarker');
+            if (taskMarker) {
+              const markerText = state.sliceDoc(taskMarker.from, taskMarker.to);
+              const isChecked = markerText.includes('x') || markerText.includes('X');
+              const isCanceled = markerText.includes('-');
+              // Consume TaskMarker + trailing space
+              let taskEnd = taskMarker.to;
+              if (taskEnd < line.to && state.sliceDoc(taskEnd, taskEnd + 1) === ' ') taskEnd++;
 
-          // Task list in BulletList: prefix widget with empty displayText (checkbox handles the visual)
-          if (parent && (parent.getChild('Task') || parent.getChild('TaskMarker'))) {
-            const listRoot = parent.parent;
-            if (listRoot?.type?.name === 'BulletList') {
-              if (hideEnd < line.to) {
+              const revealed = shouldRevealInline(state, line.from, taskEnd);
+              if (revealed) {
                 ranges.push(
                   Decoration.replace({
-                    widget: new ListPrefixWidget(depth1Based, true, '', rawMarker, revealed),
+                    widget: new ListPrefixWidget(depth1Based, true, '', rawMarker, true),
                   }).range(line.from, hideEnd),
+                );
+              } else {
+                ranges.push(
+                  Decoration.replace({
+                    widget: new ListPrefixWidget(depth1Based, false, ''),
+                  }).range(line.from, hideEnd),
+                );
+                ranges.push(
+                  Decoration.replace({
+                    widget: new CheckboxWidget(isChecked, isCanceled, taskMarker.from, taskMarker.to),
+                  }).range(taskMarker.from, taskEnd),
                 );
               }
               return false;
@@ -165,6 +188,7 @@ function buildInlineReplaceDecorations(view: EditorView): DecorationSet {
           }
 
           // Normal case: replace from line.from to hideEnd with ListPrefixWidget
+          const revealed = shouldRevealInline(state, line.from, hideEnd);
           const displayText = computeListDisplayText(state, rawMarker, parent, depth);
           ranges.push(
             Decoration.replace({

--- a/apps/frontend/lib/codemirror-wysiwyg/inline-replace.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/inline-replace.ts
@@ -56,8 +56,6 @@ function buildInlineReplaceDecorations(view: EditorView): DecorationSet {
         if (type === 'Table') return false;
 
         // ATX Heading: hide # marks + trailing space via mark decoration
-        // Uses font-size:0 mark instead of replace to avoid DOM rebuild that
-        // causes vertical shift at large heading font-sizes (H1-H3).
         if (/^ATXHeading[1-6]$/.test(type)) {
           if (!shouldRevealLine(state, node.from)) {
             const mark = node.node.getChild('HeaderMark');
@@ -160,7 +158,6 @@ function buildInlineReplaceDecorations(view: EditorView): DecorationSet {
               const markerText = state.sliceDoc(taskMarker.from, taskMarker.to);
               const isChecked = markerText.includes('x') || markerText.includes('X');
               const isCanceled = markerText.includes('-');
-              // Consume TaskMarker + trailing space
               let taskEnd = taskMarker.to;
               if (taskEnd < line.to && state.sliceDoc(taskEnd, taskEnd + 1) === ' ') taskEnd++;
 

--- a/apps/frontend/lib/codemirror-wysiwyg/widgets/checkbox-widget.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/widgets/checkbox-widget.ts
@@ -1,0 +1,38 @@
+import { WidgetType, EditorView } from '@codemirror/view';
+
+export class CheckboxWidget extends WidgetType {
+  constructor(
+    readonly checked: boolean,
+    readonly canceled: boolean,
+    readonly markerFrom: number,
+    readonly markerTo: number,
+  ) {
+    super();
+  }
+
+  eq(other: CheckboxWidget) {
+    return this.checked === other.checked && this.canceled === other.canceled;
+  }
+
+  toDOM(view: EditorView) {
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.className = 'cm-checkbox-widget';
+    input.checked = this.checked;
+    if (this.canceled) {
+      input.indeterminate = true;
+    }
+    input.addEventListener('click', () => {
+      const newMarker = this.checked ? '[ ]' : '[x]';
+      view.dispatch({
+        changes: { from: this.markerFrom, to: this.markerTo, insert: newMarker },
+      });
+      view.contentDOM.focus();
+    });
+    return input;
+  }
+
+  ignoreEvent(event: Event) {
+    return event instanceof MouseEvent && event.type === 'mousedown';
+  }
+}

--- a/apps/frontend/lib/codemirror-wysiwyg/widgets/image-widget.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/widgets/image-widget.ts
@@ -87,9 +87,10 @@ export class ImageWidget extends WidgetType {
         const view = getEditorView(wrapper);
         if (!view) return;
         const pos = view.posAtDOM(wrapper);
+        const line = view.state.doc.lineAt(pos);
         view.dispatch({
           effects: embedSourceRevealEffect.of(pos),
-          selection: { anchor: pos },
+          selection: { anchor: line.from, head: line.to },
         });
       };
       container.appendChild(toggleBtn);

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -280,9 +280,6 @@
   color: var(--md-text-muted);
 }
 
-/* Hidden heading marks (# symbols) — uses font-size:0 instead of
-   Decoration.replace to avoid CM6 widgetBuffer elements that cause
-   vertical shift at large heading font-sizes. */
 .cm-editor.cm-markdown-wysiwyg .cm-heading-mark-hidden {
   font-size: 0;
 }

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -280,6 +280,13 @@
   color: var(--md-text-muted);
 }
 
+/* Hidden heading marks (# symbols) — uses font-size:0 instead of
+   Decoration.replace to avoid CM6 widgetBuffer elements that cause
+   vertical shift at large heading font-sizes. */
+.cm-editor.cm-markdown-wysiwyg .cm-heading-mark-hidden {
+  font-size: 0;
+}
+
 /* --- Typography - Inline formatting --- */
 
 /* Lezer-provided classes (syntax highlighting) */
@@ -672,33 +679,11 @@
 
 /* --- Horizontal Rule --- */
 
-.cm-editor.cm-markdown-wysiwyg .cm-line.cm-hr-line {
-  position: relative;
-}
-
-.cm-editor.cm-markdown-wysiwyg .cm-line.cm-hr-line::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  border-top: 1px solid var(--md-hr-color);
-  pointer-events: none;
-}
-
-.cm-editor.cm-markdown-wysiwyg .cm-hr-content,
-.cm-editor.cm-markdown-wysiwyg .cm-hr-content * {
-  color: transparent !important;
-}
-
-.cm-editor.cm-markdown-wysiwyg .cm-line.cm-hr-line-revealed::after {
-  display: none;
-}
-
-.cm-editor.cm-markdown-wysiwyg .cm-hr-content-revealed,
-.cm-editor.cm-markdown-wysiwyg .cm-hr-content-revealed * {
-  color: var(--md-text-faint) !important;
+.cm-editor.cm-markdown-wysiwyg .cm-hr-widget {
+  display: inline-block;
+  width: 100%;
+  border-top: 2px solid var(--md-hr-color);
+  vertical-align: middle;
 }
 
 /* --- Images --- */
@@ -706,6 +691,11 @@
 .cm-editor.cm-markdown-wysiwyg .cm-image-widget {
   display: block;
   padding: 2px 0;
+}
+
+/* Block widget (revealed) sits outside .cm-line — match its left padding */
+.cm-editor.cm-markdown-wysiwyg .cm-content > .cm-image-widget {
+  padding-left: 6px;
 }
 
 /* Collapse the host .cm-line that contains only a replace-widget image.


### PR DESCRIPTION
## Summary
- **Checkbox widgets**: New `CheckboxWidget` for task list items (`- [x]`, `- [-]`) with interactive toggle support
- **Horizontal rule**: Converted from mark+line decoration to a clean replace widget with adjacent-line cursor reveal
- **Heading marks**: Fixed vertical shift on H1-H3 by using `font-size:0` mark instead of `Decoration.replace` (avoids CM6 widgetBuffer elements)
- **Mouse selection optimization**: Skip widget field rebuilds during active drag to prevent flicker
- **Embed/image source reveal**: Now selects the full line instead of placing cursor at widget position

## Test plan
- [ ] Verify checkbox rendering for `- [ ]`, `- [x]`, and `- [-]` task items
- [ ] Confirm clicking checkboxes toggles state in the document
- [ ] Test horizontal rules render as styled line and reveal `---` markup when cursor is adjacent
- [ ] Verify heading `#` marks hide/reveal without vertical jumps
- [ ] Test mouse drag selection doesn't cause widget flicker
- [ ] Confirm image/embed source toggle selects full line