### PR TITLE
Add dictation enable toggle and OpenCode server

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -12,11 +12,12 @@
   "dependencies": {
     "@cushion/types": "workspace:*",
     "chokidar": "^5.0.0",
-    "ignore": "^7.0.5",
-    "pdf-lib": "^1.17.1",
     "ffmpeg-static": "^5.2.0",
-    "ws": "^8.18.0",
-    "write-file-atomic": "^7.0.0"
+    "ignore": "^7.0.5",
+    "opencode-ai": "1.3.0",
+    "pdf-lib": "^1.17.1",
+    "write-file-atomic": "^7.0.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/ws": "^8.5.14",

--- a/apps/electron/src/main/coordinator/dictation-config.ts
+++ b/apps/electron/src/main/coordinator/dictation-config.ts
@@ -6,6 +6,7 @@ import type { DictationConfig, DictationModelName } from '@cushion/types';
 const CONFIG_FILE = 'dictation.json';
 
 const DEFAULT_CONFIG: DictationConfig = {
+  enabled: false,
   selectedModel: 'parakeet-v3',
   hotkey: 'Control+W',
   postProcessing: {
@@ -46,6 +47,7 @@ function migrateConfig(raw: Record<string, unknown>): DictationConfig {
     return {
       ...DEFAULT_CONFIG,
       ...raw,
+      enabled: typeof raw.enabled === 'boolean' ? raw.enabled : true,
       selectedModel: raw.selectedModel as DictationModelName,
       postProcessing: { ...DEFAULT_CONFIG.postProcessing, ...(raw.postProcessing as object) },
     };
@@ -64,6 +66,7 @@ function migrateConfig(raw: Record<string, unknown>): DictationConfig {
   }
 
   return {
+    enabled: true,
     selectedModel,
     hotkey: (raw.hotkey as string) || DEFAULT_CONFIG.hotkey,
     postProcessing: { ...DEFAULT_CONFIG.postProcessing, ...(raw.postProcessing as object) },

--- a/apps/electron/src/main/coordinator/dictation-config.ts
+++ b/apps/electron/src/main/coordinator/dictation-config.ts
@@ -27,7 +27,6 @@ const DEFAULT_CONFIG: DictationConfig = {
   accelerator: 'cpu',
 };
 
-/** Map old whisper model name to unified DictationModelName */
 function migrateWhisperModel(name: string): DictationModelName {
   switch (name) {
     case 'tiny': return 'whisper-small';
@@ -40,7 +39,6 @@ function migrateWhisperModel(name: string): DictationModelName {
   }
 }
 
-/** Detect old config format and migrate to unified */
 function migrateConfig(raw: Record<string, unknown>): DictationConfig {
   // Already migrated — no legacy selectedEngine field present
   if (raw.selectedModel && typeof raw.selectedModel === 'string' && !raw.selectedEngine) {
@@ -95,7 +93,6 @@ export class DictationConfigManager {
     const parsed = JSON.parse(raw);
     this.cache = migrateConfig(parsed);
 
-    // Write back migrated config if it was in old format
     if (parsed.selectedEngine !== undefined) {
       await this.write(this.cache);
     }

--- a/apps/electron/src/main/coordinator/handlers/dictation.ts
+++ b/apps/electron/src/main/coordinator/handlers/dictation.ts
@@ -88,9 +88,15 @@ export async function handleDictationConfigRead(dictationConfig: DictationConfig
 
 export async function handleDictationConfigWrite(
   dictationConfig: DictationConfigManager,
+  hotkeyManager: HotkeyManager,
   params: { config: DictationConfig },
 ) {
   await dictationConfig.write(params.config);
+  if (params.config.enabled && params.config.hotkey) {
+    hotkeyManager.register(params.config.hotkey);
+  } else {
+    hotkeyManager.unregister();
+  }
   return { success: true };
 }
 

--- a/apps/electron/src/main/coordinator/ipc-router.ts
+++ b/apps/electron/src/main/coordinator/ipc-router.ts
@@ -284,7 +284,7 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
     return handleLoginFinish();
   });
 
-  // --- Unified dictation handlers ---
+  // Dictation handlers
   ipcMain.handle('coordinator:dictation/list-models', async () => {
     return handleDictationListModels(sherpaModelManager);
   });

--- a/apps/electron/src/main/coordinator/ipc-router.ts
+++ b/apps/electron/src/main/coordinator/ipc-router.ts
@@ -107,6 +107,7 @@ async function loadFileFilter() {
 
 async function warmStartDictationServer() {
   const config = await dictationConfigManager.read();
+  if (!config.enabled) return;
   const model = config.selectedModel;
   const accelerator = config.accelerator || 'cpu';
   if (!sherpaModelManager.isModelDownloaded(model)) return;
@@ -140,7 +141,7 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
   hotkeyManager = new HotkeyManager(notifyRenderer);
   try {
     const config = await dictationConfigManager.read();
-    if (config.hotkey) hotkeyManager.register(config.hotkey);
+    if (config.enabled && config.hotkey) hotkeyManager.register(config.hotkey);
   } catch {}
 
   sherpaModelManager = new SherpaModelManager(notifyRenderer);
@@ -333,7 +334,7 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
   });
 
   ipcMain.handle('coordinator:dictation/dictation-config-write', async (_event, params: RPCParams<'dictation/dictation-config-write'>) => {
-    return handleDictationConfigWrite(dictationConfigManager, params);
+    return handleDictationConfigWrite(dictationConfigManager, hotkeyManager, params);
   });
 
   ipcMain.handle('coordinator:dictation/dictionary-add', async (_event, params: RPCParams<'dictation/dictionary-add'>) => {

--- a/apps/electron/src/main/coordinator/opencode-server.ts
+++ b/apps/electron/src/main/coordinator/opencode-server.ts
@@ -1,0 +1,48 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import net from 'node:net';
+import path from 'node:path';
+
+const OPENCODE_PORT = 14_097;
+const CORS_ORIGIN = 'http://localhost:3000';
+
+let serverProcess: ChildProcess | null = null;
+
+function isPortListening(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.once('connect', () => { socket.destroy(); resolve(true); });
+    socket.once('error', () => resolve(false));
+    socket.connect(port, '127.0.0.1');
+  });
+}
+
+function getOpenCodeBin(): string {
+  const binDir = path.join(__dirname, '../../node_modules/.bin');
+  return path.join(binDir, process.platform === 'win32' ? 'opencode.exe' : 'opencode');
+}
+
+export async function startOpenCodeServer(): Promise<void> {
+  if (await isPortListening(OPENCODE_PORT)) {
+    console.log(`[OpenCode] Already listening on port ${OPENCODE_PORT}, reusing existing server.`);
+    return;
+  }
+
+  console.log(`[OpenCode] Starting server on port ${OPENCODE_PORT}...`);
+
+  serverProcess = spawn(getOpenCodeBin(), ['serve', '--port', String(OPENCODE_PORT), '--cors', CORS_ORIGIN], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  serverProcess.stdout?.on('data', (d: Buffer) => console.log(`[OpenCode] ${d.toString().trimEnd()}`));
+  serverProcess.stderr?.on('data', (d: Buffer) => console.error(`[OpenCode] ${d.toString().trimEnd()}`));
+  serverProcess.on('error', (err) => { console.error('[OpenCode] Failed to start:', err.message); serverProcess = null; });
+  serverProcess.on('close', (code) => { console.log(`[OpenCode] Server exited with code ${code}`); serverProcess = null; });
+}
+
+export function stopOpenCodeServer(): void {
+  if (!serverProcess) return;
+  console.log('[OpenCode] Stopping server...');
+  serverProcess.kill();
+  serverProcess = null;
+}

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3,6 +3,7 @@ import './pdf-export';
 import { join } from 'path';
 import windowStateKeeper from 'electron-window-state';
 import { initCoordinator, stopCoordinator } from './coordinator/ipc-router';
+import { startOpenCodeServer, stopOpenCodeServer } from './coordinator/opencode-server';
 
 const iconExt = process.platform === 'win32' ? 'icon.ico' : 'icon.png';
 const iconPath = app.isPackaged
@@ -156,6 +157,7 @@ app.whenReady().then(async () => {
   }
 
   createWindow();
+  await startOpenCodeServer();
   await initCoordinator(mainWindow!);
 
   app.on('activate', () => {
@@ -173,4 +175,5 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   stopCoordinator();
+  stopOpenCodeServer();
 });

--- a/apps/frontend/components/settings/DictationSettings.tsx
+++ b/apps/frontend/components/settings/DictationSettings.tsx
@@ -8,6 +8,8 @@ import { cn } from '@/lib/utils';
 
 export function DictationSettings() {
   const loadSettings = useDictationStore((s) => s.loadSettings);
+  const enabled = useDictationStore((s) => s.enabled);
+  const setEnabled = useDictationStore((s) => s.setEnabled);
   const serverStatus = useDictationStore((s) => s.serverStatus);
   const selectedModel = useDictationStore((s) => s.selectedModel);
   const models = useDictationStore((s) => s.models);
@@ -35,23 +37,32 @@ export function DictationSettings() {
 
   return (
     <div className="p-6 overflow-y-auto thin-scrollbar space-y-6">
-      <div className="flex items-center gap-2">
-        <h2 className="text-base font-semibold">Dictation</h2>
-        <span
-          className={cn(
-            'inline-block h-2 w-2 rounded-full',
-            serverStatus === 'running'
-              ? 'bg-accent-green'
-              : serverStatus === 'starting'
-                ? 'bg-accent animate-pulse'
-                : serverStatus === 'error'
-                  ? 'bg-accent-red'
-                  : 'bg-foreground-faint',
-          )}
-          title={`Server: ${serverStatus}`}
+      <div className="flex items-center gap-3">
+        <ToggleRow
+          label="Enable Whisper"
+          description="Start the transcription server and register the global hotkey"
+          checked={enabled}
+          onChange={() => setEnabled(!enabled)}
+          className="flex-1"
         />
+        {enabled && (
+          <span
+            className={cn(
+              'inline-block h-2 w-2 rounded-full shrink-0',
+              serverStatus === 'running'
+                ? 'bg-accent-green'
+                : serverStatus === 'starting'
+                  ? 'bg-accent animate-pulse'
+                  : serverStatus === 'error'
+                    ? 'bg-accent-red'
+                    : 'bg-foreground-faint',
+            )}
+            title={`Server: ${serverStatus}`}
+          />
+        )}
       </div>
 
+      {!enabled ? null : <>
       <div>
         <h3 className="text-xs uppercase tracking-wide text-foreground-faint mb-3">Model</h3>
         <div className="flex items-center justify-between">
@@ -109,6 +120,7 @@ export function DictationSettings() {
 
       <DictationPostProcessing />
       <DictationDictionary />
+      </>}
     </div>
   );
 }

--- a/apps/frontend/stores/dictationStore.ts
+++ b/apps/frontend/stores/dictationStore.ts
@@ -42,10 +42,12 @@ interface DictationState {
   gpuAvailable: boolean;
   gpuName: string | null;
   gpuBinaryDownloaded: boolean;
+  enabled: boolean;
   gpuBinaryDownloading: boolean;
   gpuBinaryDownloadProgress: GpuDownloadProgress | null;
   setClient: (client: CoordinatorClient) => void;
   loadSettings: () => Promise<void>;
+  setEnabled: (enabled: boolean) => Promise<void>;
   refreshModels: () => Promise<void>;
   downloadModel: (model: DictationModelName) => Promise<void>;
   cancelDownload: () => Promise<void>;
@@ -117,6 +119,7 @@ export const useDictationStore = create<DictationState>()(
     postProcessing: { enabled: false, provider: 'openai', apiKey: '', model: 'gpt-4o-mini', fillerRemoval: true, stutterCollapse: true, includeNoteContext: true, autoLearnCorrections: true, skipShortTranscriptions: true, shortTextThreshold: 3 } as DictationConfig['postProcessing'],
     dictionary: [],
     hotkey: 'Control+W',
+    enabled: false,
     accelerator: 'cpu',
     gpuAvailable: false,
     gpuName: null,
@@ -229,6 +232,7 @@ export const useDictationStore = create<DictationState>()(
 
       dictationConfig = config;
       set({
+        enabled: config.enabled ?? false,
         models: modelsResult.models,
         selectedModel: config.selectedModel,
         postProcessing: config.postProcessing,
@@ -240,6 +244,20 @@ export const useDictationStore = create<DictationState>()(
         gpuBinaryDownloaded: gpuBinaryResult.available,
         settingsLoaded: true,
       });
+    },
+
+    setEnabled: async (enabled) => {
+      const client = coordinatorClient;
+      if (!client || !dictationConfig) return;
+      dictationConfig = { ...dictationConfig, enabled };
+      await client.call('dictation/dictation-config-write', { config: dictationConfig });
+      set({ enabled });
+
+      if (enabled) {
+        await client.call('dictation/start-server', { model: dictationConfig.selectedModel });
+      } else {
+        await client.call('dictation/stop-server');
+      }
     },
 
     refreshModels: async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,8 @@
         "chokidar": "^5.0.0",
         "ffmpeg-static": "^5.2.0",
         "ignore": "^7.0.5",
+        "opencode-ai": "1.3.0",
+        "opencode-windows-x64-baseline": "1.3.0",
         "pdf-lib": "^1.17.1",
         "write-file-atomic": "^7.0.0",
         "ws": "^8.18.0",
@@ -1477,6 +1479,32 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open-color": ["open-color@1.9.1", "", {}, "sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw=="],
+
+    "opencode-ai": ["opencode-ai@1.3.0", "", { "optionalDependencies": { "opencode-darwin-arm64": "1.3.0", "opencode-darwin-x64": "1.3.0", "opencode-darwin-x64-baseline": "1.3.0", "opencode-linux-arm64": "1.3.0", "opencode-linux-arm64-musl": "1.3.0", "opencode-linux-x64": "1.3.0", "opencode-linux-x64-baseline": "1.3.0", "opencode-linux-x64-baseline-musl": "1.3.0", "opencode-linux-x64-musl": "1.3.0", "opencode-windows-arm64": "1.3.0", "opencode-windows-x64": "1.3.0", "opencode-windows-x64-baseline": "1.3.0" }, "bin": { "opencode": "bin/opencode" } }, "sha512-il/dC3B55m5mZV2u72emfPqkZBTzrlZwqGI4Ds5Ld6kt2LTUzBZtKB8sOfy7Bmw2qIel0hLZdoKc8wxLjaXQDw=="],
+
+    "opencode-darwin-arm64": ["opencode-darwin-arm64@1.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OB+yl/BZkjQhnjjFc+KT57iqhPlXNq3E0oIcHHlGiG63L2LTY3zfi9OhzaoemL+or2CWnpCITUe91yTAddiSEQ=="],
+
+    "opencode-darwin-x64": ["opencode-darwin-x64@1.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-jivDUpmhzkT7WZp7pXVSb9fdnEVuhKBsnve/9fIkI/UFHxomiZ2NIaNRbHxG26PYT9a1IR4D5QvXBq623g2Mnw=="],
+
+    "opencode-darwin-x64-baseline": ["opencode-darwin-x64-baseline@1.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Th5yiWOSDeEcjnKWhR8b267Uf8r+jwLFhv30JK4x07Zdmu3Jjjr6TdMvjLgEOv3PWmHf/1yYz22Xachb+QST0A=="],
+
+    "opencode-linux-arm64": ["opencode-linux-arm64@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-rWEEKo4oqgJ/zk670ywg6uhEPwbUIQCwYCeh+xJ3IlgPltQNiIjqUbzbRqAmEfI1Uj9DCdbZ2TUtHayRv8umKw=="],
+
+    "opencode-linux-arm64-musl": ["opencode-linux-arm64-musl@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EmXBHyRSzWCnD/KDpaSi8ldgjOa+1t5c5tRASyL/lnbinsrZekxub3lI+oxRvKJXESKdgq9EP4gkp6t2fqGsFw=="],
+
+    "opencode-linux-x64": ["opencode-linux-x64@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-U9aS0wl0uBDxXncqSYhYBDDQP2ZwiTiuJSLM6MgtFJTbUXuTZZCKmQ8p7C5/+Nxpl4sY5xK+ZaCJcS3k3WGN3g=="],
+
+    "opencode-linux-x64-baseline": ["opencode-linux-x64-baseline@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-STZtcgGgeRlaFCmkk+mNm+01d02JCzCPvP9kWwNpRF6FBGTcFZ97MxEoGvk+7mEqMueImVQZOR21NiYN6anQhw=="],
+
+    "opencode-linux-x64-baseline-musl": ["opencode-linux-x64-baseline-musl@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sb7LyPlf+5/t4pQ3whcHPVlb7R7SRY0Bgjgy55amEs3xRuKnC3BfSoj8CAoY50M/yVAbOj0haoxu4LFixljwNw=="],
+
+    "opencode-linux-x64-musl": ["opencode-linux-x64-musl@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Jc/EbYgqmT2J2WLPm7EQWBYfSqetWTrI4Ipc4KFrSB/LbM/7lfXkjpemjQaYNlDTVkvPXaUPFJUpisH64xZ+4g=="],
+
+    "opencode-windows-arm64": ["opencode-windows-arm64@1.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-3iWo9lOctaWQ+8QHRKszINPTLjLtb0ztzedlvdY5HAiot9MUK/G5MHeskutxQ7sMvTACiAp02ey+Ml/f/jyf7Q=="],
+
+    "opencode-windows-x64": ["opencode-windows-x64@1.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-iFd/6GwfM3jlI2tOb3f12m5ddDY8Ug2HiUU1xmxWJvDnbDBdftlHrzD5twlbIHnKoGvohepX8iWk+A/UN2cXKQ=="],
+
+    "opencode-windows-x64-baseline": ["opencode-windows-x64-baseline@1.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pYuY+9LqPLB/GrlZQr67Cl8RlV6vcay4fW8L3TjabwJOinFMDX9OpNo+DkdKJW7YtPtHD78cXaNDEV8tv9Nx2A=="],
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -51,6 +51,7 @@ export interface DictationServerInfo {
 }
 
 export interface DictationConfig {
+  enabled: boolean;
   selectedModel: DictationModelName;
   hotkey: string;
   postProcessing: {


### PR DESCRIPTION
## Summary
- Add `enabled` flag to dictation config — whisper server and global hotkey only activate when toggled on
- Add toggle UI in DictationSettings with conditional rendering of all sub-settings
- Integrate `opencode-ai` as a background server managed by Electron's main process

## Test plan
- [ ] Toggle dictation off → verify hotkey is unregistered and server doesn't start
- [ ] Toggle dictation on → verify server starts and hotkey registers
- [ ] Restart app with dictation disabled → verify no warm-start or hotkey registration
- [ ] Verify OpenCode server starts on app launch and stops on quit