### PR TITLE
Open external links in system browser and fix table selection

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, nativeImage } from 'electron';
+import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
 import './pdf-export';
 import { join } from 'path';
 import windowStateKeeper from 'electron-window-state';
@@ -62,6 +62,14 @@ function createWindow() {
   });
 
   mainWindowState.manage(mainWindow);
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('https:') || url.startsWith('http:')) {
+      shell.openExternal(url);
+      return { action: 'deny' };
+    }
+    return { action: 'allow' };
+  });
 
   mainWindow.on('ready-to-show', () => {
     mainWindow?.show();

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -202,7 +202,6 @@
   border: none;
 }
 
-/* Cursor color */
 .cm-editor.cm-markdown-wysiwyg .cm-cursor {
   border-left-color: var(--md-text);
 }
@@ -217,12 +216,10 @@
   background: var(--md-selection-bg) !important;
 }
 
-/* Active line - no highlight for cleaner look */
 .cm-editor.cm-markdown-wysiwyg .cm-activeLine {
   background: transparent;
 }
 
-/* Remove active line gutter highlight too */
 .cm-editor.cm-markdown-wysiwyg .cm-activeLineGutter {
   background: transparent;
 }

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -212,7 +212,8 @@
 }
 
 .cm-editor.cm-markdown-wysiwyg .cm-line ::selection,
-.cm-editor.cm-markdown-wysiwyg .cm-line::selection {
+.cm-editor.cm-markdown-wysiwyg .cm-line::selection,
+.cm-editor.cm-markdown-wysiwyg .cm-content div.tbl-table-widget .tbl-cell-editor ::selection {
   background: var(--md-selection-bg) !important;
 }
 


### PR DESCRIPTION
## Summary
- External links (http/https) clicked in the Electron app now open in the system browser instead of spawning a new Electron window
- Table cell editor selection color now uses the same `--md-selection-bg` as the rest of the editor

## Test plan
- [ ] Click an external link in a note — should open in default browser
- [ ] Select text inside a table cell — selection highlight should match the editor's selection color