### PR TITLE
Fix table cell caret color

### DIFF
--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -216,6 +216,11 @@
   background: var(--md-selection-bg) !important;
 }
 
+.cm-editor.cm-markdown-wysiwyg .cm-content div.tbl-table-widget .tbl-cell-editor .cm-line,
+.cm-editor.cm-markdown-wysiwyg .cm-content div.tbl-table-widget .tbl-cell-editor .cm-content {
+  caret-color: var(--md-text) !important;
+}
+
 .cm-editor.cm-markdown-wysiwyg .cm-activeLine {
   background: transparent;
 }


### PR DESCRIPTION
## Summary
- Set table cell editor caret color to `var(--md-text)` so it's visible across all themes instead of defaulting to black/white.

## Test plan
- [ ] Open a table in the editor
- [ ] Verify the caret is visible in both light and dark themes