### PR TITLE
Fix asset paths breaking under file:// protocol

### DIFF
--- a/apps/frontend/components/chat/ProviderIcon.tsx
+++ b/apps/frontend/components/chat/ProviderIcon.tsx
@@ -2,7 +2,7 @@
 import type { SVGProps } from 'react';
 import type { IconName } from './provider-icons/types';
 
-const sprite = '/provider-icons/sprite.svg';
+const sprite = `${import.meta.env.BASE_URL}provider-icons/sprite.svg`;
 
 export type ProviderIconProps = Omit<SVGProps<SVGSVGElement>, 'id'> & {
   id: IconName;

--- a/apps/frontend/components/editor/ExcalidrawView.tsx
+++ b/apps/frontend/components/editor/ExcalidrawView.tsx
@@ -7,7 +7,7 @@ import type { ViewProps } from '@/lib/view-registry';
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types';
 
 if (typeof window !== 'undefined') {
-  (window as any).EXCALIDRAW_ASSET_PATH = '/excalidraw-assets/';
+  (window as any).EXCALIDRAW_ASSET_PATH = `${import.meta.env.BASE_URL}excalidraw-assets/`;
 }
 
 const DEFAULT_SCENE = {

--- a/apps/frontend/components/editor/PdfViewerNative.tsx
+++ b/apps/frontend/components/editor/PdfViewerNative.tsx
@@ -389,11 +389,12 @@ function PdfViewerInner({
   }, [filePath]);
 
   useEffect(() => {
-    const existingLink = document.querySelector('link[href="/pdfjs/pdf_viewer.css"]');
+    const cssHref = `${import.meta.env.BASE_URL}pdfjs/pdf_viewer.css`;
+    const existingLink = document.querySelector(`link[href="${cssHref}"]`);
     if (!existingLink) {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
-      link.href = '/pdfjs/pdf_viewer.css';
+      link.href = cssHref;
       document.head.appendChild(link);
     }
   }, []);
@@ -433,7 +434,7 @@ function PdfViewerInner({
           return;
         }
 
-        pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdfjs/pdf.worker.min.mjs';
+        pdfjsLib.GlobalWorkerOptions.workerSrc = `${import.meta.env.BASE_URL}pdfjs/pdf.worker.min.mjs`;
 
         if (progressiveReadChunk) {
           const requestedRangeChunkSize = progressiveRangeChunkSize ?? DEFAULT_PDF_RANGE_CHUNK_SIZE;

--- a/apps/frontend/lib/codemirror-wysiwyg/widgets/pdf-widget.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/widgets/pdf-widget.ts
@@ -53,7 +53,7 @@ async function loadPdfDocument(src: string): Promise<any> {
 
   const promise = (async () => {
     const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
-    pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdfjs/pdf.worker.min.mjs';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = `${import.meta.env.BASE_URL}pdfjs/pdf.worker.min.mjs`;
 
     let data: { data: Uint8Array } | { url: string };
     if (isRemoteSrc(src)) {

--- a/apps/frontend/public/pdfjs/pdf_viewer.css
+++ b/apps/frontend/public/pdfjs/pdf_viewer.css
@@ -14,7 +14,7 @@
  */
 
 .messageBar{
-  --closing-button-icon:url(/pdfjs/images/messageBar_closingButton.svg);
+  --closing-button-icon:url(images/messageBar_closingButton.svg);
   --message-bar-close-button-color:var(--text-primary-color);
   --message-bar-close-button-color-hover:var(--text-primary-color);
   --message-bar-close-button-border-radius:4px;
@@ -168,7 +168,7 @@
   --csstools-light-dark-toggle--3:var(--csstools-color-scheme--light) #fbfbfe;
   --text-primary-color:var(--csstools-light-dark-toggle--3, #15141a);
 
-  --message-bar-icon:url(/pdfjs/images/messageBar_info.svg);
+  --message-bar-icon:url(images/messageBar_info.svg);
   --csstools-light-dark-toggle--4:var(--csstools-color-scheme--light) #73a7f3;
   --message-bar-icon-color:var(--csstools-light-dark-toggle--4, #0060df);
   --csstools-light-dark-toggle--5:var(--csstools-color-scheme--light) #003070;
@@ -792,7 +792,7 @@
       --message-bar-fg-color:var(--csstools-light-dark-toggle--32, #15141a);
       --csstools-light-dark-toggle--33:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.08);
       --message-bar-border-color:var(--csstools-light-dark-toggle--33, rgb(0 0 0 / 0.08));
-      --message-bar-icon:url(/pdfjs/images/messageBar_warning.svg);
+      --message-bar-icon:url(images/messageBar_warning.svg);
       --csstools-light-dark-toggle--34:var(--csstools-color-scheme--light) #e49c49;
       --message-bar-icon-color:var(--csstools-light-dark-toggle--34, #cd411e);
     }
@@ -883,6 +883,9 @@
       }
 
 .textLayer{
+  --csstools-color-scheme--light:initial;
+  color-scheme:only light;
+
   position:absolute;
   text-align:initial;
   inset:0;
@@ -2061,7 +2064,7 @@
 }
 
 :root{
-  --clear-signature-button-icon:url(/pdfjs/images/editor-toolbar-delete.svg);
+  --clear-signature-button-icon:url(images/editor-toolbar-delete.svg);
   --csstools-light-dark-toggle--40:var(--csstools-color-scheme--light) #2b2a33;
   --signature-bg:var(--csstools-light-dark-toggle--40, #f9f9fb);
   --csstools-light-dark-toggle--41:var(--csstools-color-scheme--light) var(--signature-bg);
@@ -2162,7 +2165,7 @@
 
 .signatureDialog .inputWithClearButton{
     --button-dimension:24px;
-    --clear-button-icon:url(/pdfjs/images/messageBar_closingButton.svg);
+    --clear-button-icon:url(images/messageBar_closingButton.svg);
 
     width:100%;
     position:relative;
@@ -2242,7 +2245,7 @@
   --thickness-label-color:var(--primary-color);
   --thickness-slider-color:var(--primary-color);
   --thickness-border:none;
-  --draw-cursor:url(/pdfjs/images/cursor-editorInk.svg) 0 16, pointer;
+  --draw-cursor:url(images/cursor-editorInk.svg) 0 16, pointer;
 }
 
 @media (prefers-color-scheme: dark){
@@ -2925,7 +2928,7 @@
         }
 
 .editDescription.altText{
-  --alt-text-add-image:url(/pdfjs/images/editor-toolbar-edit.svg) !important;
+  --alt-text-add-image:url(images/editor-toolbar-edit.svg) !important;
 }
 
 .editDescription.altText::before{
@@ -2948,7 +2951,7 @@
 }
 
 #commentManagerDialog{
-  --comment-close-button-icon:url(/pdfjs/images/comment-closeButton.svg);
+  --comment-close-button-icon:url(images/comment-closeButton.svg);
 }
 
 #commentManagerDialog .mainContainer{
@@ -3173,9 +3176,9 @@
 
 #editorCommentsSidebar,
 .commentPopup{
-  --comment-close-button-icon:url(/pdfjs/images/comment-closeButton.svg);
-  --comment-popup-edit-button-icon:url(/pdfjs/images/comment-popup-editButton.svg);
-  --comment-popup-delete-button-icon:url(/pdfjs/images/editor-toolbar-delete.svg);
+  --comment-close-button-icon:url(images/comment-closeButton.svg);
+  --comment-popup-edit-button-icon:url(images/comment-popup-editButton.svg);
+  --comment-popup-delete-button-icon:url(images/editor-toolbar-delete.svg);
 
   --csstools-light-dark-toggle--57:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.69);
 
@@ -3341,6 +3344,7 @@
   padding-bottom:16px;
   flex-direction:column;
   align-items:flex-start;
+  overflow-y:visible;
 }
 
 #editorCommentsSidebar #editorCommentsSidebarHeader{
@@ -3834,11 +3838,11 @@
       var(--outline-around-width)
   );
   --editorFreeText-editing-cursor:text;
-  --editorInk-editing-cursor:url(/pdfjs/images/cursor-editorInk.svg) 0 16, pointer;
-  --editorHighlight-editing-cursor:url(/pdfjs/images/cursor-editorTextHighlight.svg) 24 24, text;
-  --editorFreeHighlight-editing-cursor:url(/pdfjs/images/cursor-editorFreeHighlight.svg) 1 18, pointer;
+  --editorInk-editing-cursor:url(images/cursor-editorInk.svg) 0 16, pointer;
+  --editorHighlight-editing-cursor:url(images/cursor-editorTextHighlight.svg) 24 24, text;
+  --editorFreeHighlight-editing-cursor:url(images/cursor-editorFreeHighlight.svg) 1 18, pointer;
 
-  --new-alt-text-warning-image:url(/pdfjs/images/altText_warning.svg);
+  --new-alt-text-warning-image:url(images/altText_warning.svg);
 }
 
 .textLayer.highlighting{
@@ -3870,7 +3874,7 @@
 
 @media (min-resolution: 1.1dppx){
   :root{
-    --editorFreeText-editing-cursor:url(/pdfjs/images/cursor-editorFreeText.svg) 0 16, text;
+    --editorFreeText-editing-cursor:url(images/cursor-editorFreeText.svg) 0 16, text;
   }
 }
 
@@ -3992,10 +3996,10 @@
     }
 
 :is(.annotationEditorLayer :is(.freeTextEditor,.inkEditor,.stampEditor,.highlightEditor,.signatureEditor),.textLayer) .editToolbar{
-    --editor-toolbar-delete-image:url(/pdfjs/images/editor-toolbar-delete.svg);
+    --editor-toolbar-delete-image:url(images/editor-toolbar-delete.svg);
     --csstools-light-dark-toggle--76:var(--csstools-color-scheme--light) #2b2a33;
     --editor-toolbar-bg-color:var(--csstools-light-dark-toggle--76, #f0f0f4);
-    --editor-toolbar-highlight-image:url(/pdfjs/images/toolbarButton-editorHighlight.svg);
+    --editor-toolbar-highlight-image:url(images/toolbarButton-editorHighlight.svg);
     --csstools-light-dark-toggle--77:var(--csstools-color-scheme--light) #fbfbfe;
     --editor-toolbar-fg-color:var(--csstools-light-dark-toggle--77, #2e2e56);
     --editor-toolbar-border-color:#8f8f9d;
@@ -4191,8 +4195,8 @@
         }
 
 :is(:is(:is(.annotationEditorLayer :is(.freeTextEditor,.inkEditor,.stampEditor,.highlightEditor,.signatureEditor),.textLayer) .editToolbar) .buttons) .altText{
-        --alt-text-add-image:url(/pdfjs/images/altText_add.svg);
-        --alt-text-done-image:url(/pdfjs/images/altText_done.svg);
+        --alt-text-add-image:url(images/altText_add.svg);
+        --alt-text-done-image:url(images/altText_done.svg);
 
         display:flex;
         align-items:center;
@@ -4686,8 +4690,8 @@
     }
 
 .dialog.newAltText{
-  --new-alt-text-ai-disclaimer-icon:url(/pdfjs/images/altText_disclaimer.svg);
-  --new-alt-text-spinner-icon:url(/pdfjs/images/altText_spinner.svg);
+  --new-alt-text-ai-disclaimer-icon:url(images/altText_disclaimer.svg);
+  --new-alt-text-spinner-icon:url(images/altText_spinner.svg);
   --csstools-light-dark-toggle--88:var(--csstools-color-scheme--light) #2b2a33;
   --preview-image-bg-color:var(--csstools-light-dark-toggle--88, #f0f0f4);
   --preview-image-border:none;
@@ -5008,7 +5012,7 @@
       }
 
 :is(.annotationEditorLayer .highlightEditor) .editToolbar{
-      --editor-toolbar-colorpicker-arrow-image:url(/pdfjs/images/toolbarButton-menuArrow.svg);
+      --editor-toolbar-colorpicker-arrow-image:url(images/toolbarButton-menuArrow.svg);
 
       transform-origin:center !important;
     }
@@ -5290,19 +5294,6 @@
       gap:12px;
     }
 
-:is(:is(#altTextSettingsDialog #altTextSettingsContainer) #aiModelSettings) button{
-        width:-moz-fit-content;
-        width:fit-content;
-      }
-
-.download:is(:is(#altTextSettingsDialog #altTextSettingsContainer) #aiModelSettings) #deleteModelButton{
-          display:none;
-        }
-
-:is(:is(#altTextSettingsDialog #altTextSettingsContainer) #aiModelSettings):not(.download) #downloadModelButton{
-          display:none;
-        }
-
 :is(#altTextSettingsDialog #altTextSettingsContainer) #automaticAltText,:is(#altTextSettingsDialog #altTextSettingsContainer) #altTextEditor{
       display:flex;
       flex-direction:column;
@@ -5319,8 +5310,16 @@
       gap:16px;
     }
 
+button.hasPopupMenu[aria-expanded="true"] + menu{
+    visibility:visible;
+  }
+
+button.hasPopupMenu[aria-expanded="false"] + menu{
+    visibility:hidden;
+  }
+
 .popupMenu{
-  --menuitem-checkmark-icon:none;
+  --menuitem-checkmark-icon:url(images/checkmark.svg);
   --menu-mark-icon-size:0;
   --menu-icon-size:16px;
   --menuitem-gap:5px;
@@ -5437,6 +5436,7 @@
   top:1px;
   margin:0;
   padding:5px;
+  box-sizing:border-box;
 
   background:var(--menu-bg);
   background-blend-mode:var(--menu-background-blend-mode);
@@ -5576,8 +5576,8 @@
   --treeitem-selected-color:var(--csstools-light-dark-toggle--104, rgb(0 0 0 / 0.9));
   --csstools-light-dark-toggle--105:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.25);
   --treeitem-selected-bg-color:var(--csstools-light-dark-toggle--105, rgb(0 0 0 / 0.25));
-  --treeitem-expanded-icon:none;
-  --treeitem-collapsed-icon:none;
+  --treeitem-expanded-icon:url(images/treeitem-expanded.svg);
+  --treeitem-collapsed-icon:url(images/treeitem-collapsed.svg);
 }
 
 @supports (color: light-dark(red, red)) and (color: rgb(0 0 0 / 0)){
@@ -5630,7 +5630,7 @@
 .treeView.withNesting .treeItemToggler{
 
       position:relative;
-      float:var(--inline-start);
+      float:inline-start;
       height:0;
       width:0;
       color:rgb(255 255 255 / 0.5);
@@ -5708,7 +5708,7 @@
 
 #outerContainer.viewsManagerOpen #viewsManager{
       visibility:visible;
-      inset-inline-start:1px;
+      inset-inline-start:8px;
     }
 
 #outerContainer.viewsManagerOpen #viewerContainer:not(.pdfPresentationMode){
@@ -5721,27 +5721,28 @@
   }
 
 #viewsManager{
-  --views-manager-button-icon:none;
-  --views-manager-button-arrow-icon:none;
-  --views-manager-add-file-button-icon:none;
-  --current-outline-button-icon:none;
-  --menuitem-thumbnailsView-icon:none;
-  --menuitem-outlinesView-icon:none;
-  --menuitem-attachmentsView-icon:none;
-  --menuitem-layersView-icon:none;
-  --manage-button-icon:none;
-  --close-button-icon:none;
-  --undo-label-icon:url(/pdfjs/images/altText_done.svg);
-  --pages-selected-icon:none;
-  --spinner-icon:url(/pdfjs/images/altText_spinner.svg);
+  --views-manager-button-icon:url(images/pages_viewButton.svg);
+  --views-manager-button-arrow-icon:url(images/pages_viewArrow.svg);
+  --views-manager-add-file-button-icon:url(images/toolbarButton-zoomIn.svg);
+  --current-outline-button-icon:url(images/toolbarButton-currentOutlineItem.svg);
+  --menuitem-thumbnailsView-icon:url(images/pages_viewButton.svg);
+  --menuitem-outlinesView-icon:url(images/toolbarButton-viewOutline.svg);
+  --menuitem-attachmentsView-icon:url(images/toolbarButton-viewAttachments.svg);
+  --menuitem-layersView-icon:url(images/toolbarButton-viewLayers.svg);
+  --manage-button-icon:url(images/toolbarButton-pageDown.svg);
+  --close-button-icon:url(images/pages_closeButton.svg);
+  --undo-label-icon:url(images/altText_done.svg);
+  --pages-selected-icon:url(images/pages_selected.svg);
+  --spinner-icon:url(images/altText_spinner.svg);
 
-  --csstools-light-dark-toggle--106:var(--csstools-color-scheme--light) rgb(35 34 43 / 0.92);
+  --csstools-light-dark-toggle--106:var(--csstools-color-scheme--light) rgb(66 65 77 / 0.92);
 
   --sidebar-bg-color:var(--csstools-light-dark-toggle--106, rgb(255 255 255 / 0.92));
   --sidebar-backdrop-filter:blur(7px);
   --sidebar-width:230px;
   --sidebar-min-width:min-content;
   --sidebar-max-width:50vw;
+  --sidebar-block-padding:8px;
 
   --csstools-light-dark-toggle--107:var(--csstools-color-scheme--light) #fbfbfe;
 
@@ -5779,32 +5780,50 @@
   --csstools-light-dark-toggle--118:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
   --csstools-light-dark-toggle--119:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
   --header-shadow:0 0.25px 0.75px -0.75px var(--csstools-light-dark-toggle--118, rgb(0 0 0 / 0.05)), 0 2px 6px -6px var(--csstools-light-dark-toggle--119, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--120:var(--csstools-color-scheme--light) #42414e;
+  --header-bg:var(--csstools-light-dark-toggle--120, rgb(255 255 255 / 0.92));
   --image-outline:none;
-  --image-border-width:4px;
-  --csstools-light-dark-toggle--120:var(--csstools-color-scheme--light) #3a3944;
-  --image-border-color:var(--csstools-light-dark-toggle--120, #cfcfd8);
+  --image-border-width:6px;
   --csstools-light-dark-toggle--121:var(--csstools-color-scheme--light) #3a3944;
-  --image-hover-border-color:var(--csstools-light-dark-toggle--121, #cfcfd8);
+  --image-border-color:var(--csstools-light-dark-toggle--121, #cfcfd8);
+  --image-hover-border-color:#bfbfc9;
   --image-current-border-color:var(--button-focus-outline-color);
   --image-current-focused-outline-color:var(--image-hover-border-color);
-  --csstools-light-dark-toggle--122:var(--csstools-color-scheme--light) #23222b;
+  --csstools-light-dark-toggle--122:var(--csstools-color-scheme--light) #42414d;
   --image-page-number-bg:var(--csstools-light-dark-toggle--122, #f0f0f4);
   --image-page-number-fg:var(--text-color);
-  --csstools-light-dark-toggle--123:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
-  --csstools-light-dark-toggle--124:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --image-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--123, rgb(0 0 0 / 0.05)), 0 0 0 1px var(--image-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--124, rgb(0 0 0 / 0.1));
-  --csstools-light-dark-toggle--125:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
-  --csstools-light-dark-toggle--126:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --image-hover-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--125, rgb(0 0 0 / 0.05)), 0 0 0 var(--image-border-width) var(--image-hover-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--126, rgb(0 0 0 / 0.1));
-  --csstools-light-dark-toggle--127:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --image-page-number-border-color:transparent;
+  --image-hover-page-number-bg:var(--image-page-number-bg);
+  --image-hover-page-number-fg:var(--image-page-number-fg);
+  --image-current-page-number-bg:var(--image-current-border-color);
+  --csstools-light-dark-toggle--123:var(--csstools-color-scheme--light) #15141a;
+  --image-current-page-number-fg:var(--csstools-light-dark-toggle--123, #fff);
+  --image-current-hover-page-number-bg:var(--image-current-page-number-bg);
+  --image-current-hover-page-number-fg:var(--image-current-page-number-fg);
+  --csstools-light-dark-toggle--124:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--125:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
+  --image-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--124, rgb(0 0 0 / 0.05)), 0 0 0 1px var(--image-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--125, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--126:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--127:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.1);
   --csstools-light-dark-toggle--128:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --image-current-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--127, rgb(0 0 0 / 0.05)), 0 0 0 var(--image-border-width) var(--image-current-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--128, rgb(0 0 0 / 0.1));
+  --image-hover-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--126, rgb(0 0 0 / 0.05)), 0 0 0 1px var(--csstools-light-dark-toggle--127, rgb(21 20 26 / 0.1)), 0 0 0 var(--image-border-width) var(--image-hover-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--128, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--129:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--130:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
+  --image-current-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--129, rgb(0 0 0 / 0.05)), 0 0 0 var(--image-border-width) var(--image-current-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--130, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--131:var(--csstools-color-scheme--light) rgb(0 202 219 / 0.08);
+  --image-dragging-placeholder-bg:var(--csstools-light-dark-toggle--131, rgb(0 98 250 / 0.08));
+  --multiple-dragging-bg:white;
+  --image-multiple-dragging-shadow:0 0 0 var(--image-border-width) var(--image-current-border-color), var(--image-border-width) var(--image-border-width) 0 calc(var(--image-border-width) / 2) var(--multiple-dragging-bg), var(--image-border-width) var(--image-border-width) 0 calc(3 * var(--image-border-width) / 2) var(--image-current-border-color);
+  --image-dragging-shadow:0 0 0 var(--image-border-width) var(--image-current-border-color);
+  --multiple-dragging-indicator-bg:var(--indicator-color);
+  --csstools-light-dark-toggle--132:var(--csstools-color-scheme--light) #15141a;
+  --multiple-dragging-text-color:var(--csstools-light-dark-toggle--132, #fbfbfe);
 }
 
 @supports (color: light-dark(red, red)) and (color: rgb(0 0 0 / 0)){
 #viewsManager{
 
-  --sidebar-bg-color:light-dark(rgb(255 255 255 / 0.92), rgb(35 34 43 / 0.92));
+  --sidebar-bg-color:light-dark(rgb(255 255 255 / 0.92), rgb(66 65 77 / 0.92));
 }
 }
 
@@ -5851,22 +5870,33 @@
 @supports (color: light-dark(red, red)) and (color: rgb(0 0 0 / 0)){
 #viewsManager{
   --header-shadow:0 0.25px 0.75px -0.75px light-dark(rgb(0 0 0 / 0.05), rgb(0 0 0 / 0.2)), 0 2px 6px -6px light-dark(rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.4));
+  --header-bg:light-dark(rgb(255 255 255 / 0.92), #42414e);
 }
 }
 
 @supports (color: light-dark(red, red)){
 #viewsManager{
   --image-border-color:light-dark(#cfcfd8, #3a3944);
-  --image-hover-border-color:light-dark(#cfcfd8, #3a3944);
-  --image-page-number-bg:light-dark(#f0f0f4, #23222b);
+  --image-page-number-bg:light-dark(#f0f0f4, #42414d);
+  --image-current-page-number-fg:light-dark(#fff, #15141a);
 }
 }
 
 @supports (color: light-dark(red, red)) and (color: rgb(0 0 0 / 0)){
 #viewsManager{
   --image-shadow:0 0.375px 1.5px 0 light-dark(rgb(0 0 0 / 0.05), rgb(0 0 0 / 0.2)), 0 0 0 1px var(--image-border-color), 0 3px 12px 0 light-dark(rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.4));
-  --image-hover-shadow:0 0.375px 1.5px 0 light-dark(rgb(0 0 0 / 0.05), rgb(0 0 0 / 0.2)), 0 0 0 var(--image-border-width) var(--image-hover-border-color), 0 3px 12px 0 light-dark(rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.4));
+  --image-hover-shadow:0 0.375px 1.5px 0 light-dark(rgb(0 0 0 / 0.05), rgb(0 0 0 / 0.2)), 0 0 0 1px light-dark(rgb(21 20 26 / 0.1), rgb(251 251 254 / 0.1)), 0 0 0 var(--image-border-width) var(--image-hover-border-color), 0 3px 12px 0 light-dark(rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.4));
   --image-current-shadow:0 0.375px 1.5px 0 light-dark(rgb(0 0 0 / 0.05), rgb(0 0 0 / 0.2)), 0 0 0 var(--image-border-width) var(--image-current-border-color), 0 3px 12px 0 light-dark(rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.4));
+  --image-dragging-placeholder-bg:light-dark(
+    rgb(0 98 250 / 0.08),
+    rgb(0 202 219 / 0.08)
+  );
+}
+}
+
+@supports (color: light-dark(red, red)){
+#viewsManager{
+  --multiple-dragging-text-color:light-dark(#fbfbfe, #15141a);
 }
 }
 
@@ -5874,7 +5904,7 @@
 
 #viewsManager *{
 
-  --csstools-light-dark-toggle--106:var(--csstools-color-scheme--light) rgb(35 34 43 / 0.92);
+  --csstools-light-dark-toggle--106:var(--csstools-color-scheme--light) rgb(66 65 77 / 0.92);
 
   --sidebar-bg-color:var(--csstools-light-dark-toggle--106, rgb(255 255 255 / 0.92));
 
@@ -5904,21 +5934,28 @@
   --csstools-light-dark-toggle--118:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
   --csstools-light-dark-toggle--119:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
   --header-shadow:0 0.25px 0.75px -0.75px var(--csstools-light-dark-toggle--118, rgb(0 0 0 / 0.05)), 0 2px 6px -6px var(--csstools-light-dark-toggle--119, rgb(0 0 0 / 0.1));
-  --csstools-light-dark-toggle--120:var(--csstools-color-scheme--light) #3a3944;
-  --image-border-color:var(--csstools-light-dark-toggle--120, #cfcfd8);
+  --csstools-light-dark-toggle--120:var(--csstools-color-scheme--light) #42414e;
+  --header-bg:var(--csstools-light-dark-toggle--120, rgb(255 255 255 / 0.92));
   --csstools-light-dark-toggle--121:var(--csstools-color-scheme--light) #3a3944;
-  --image-hover-border-color:var(--csstools-light-dark-toggle--121, #cfcfd8);
-  --csstools-light-dark-toggle--122:var(--csstools-color-scheme--light) #23222b;
+  --image-border-color:var(--csstools-light-dark-toggle--121, #cfcfd8);
+  --csstools-light-dark-toggle--122:var(--csstools-color-scheme--light) #42414d;
   --image-page-number-bg:var(--csstools-light-dark-toggle--122, #f0f0f4);
-  --csstools-light-dark-toggle--123:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
-  --csstools-light-dark-toggle--124:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --image-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--123, rgb(0 0 0 / 0.05)), 0 0 0 1px var(--image-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--124, rgb(0 0 0 / 0.1));
-  --csstools-light-dark-toggle--125:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
-  --csstools-light-dark-toggle--126:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --image-hover-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--125, rgb(0 0 0 / 0.05)), 0 0 0 var(--image-border-width) var(--image-hover-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--126, rgb(0 0 0 / 0.1));
-  --csstools-light-dark-toggle--127:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--123:var(--csstools-color-scheme--light) #15141a;
+  --image-current-page-number-fg:var(--csstools-light-dark-toggle--123, #fff);
+  --csstools-light-dark-toggle--124:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--125:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
+  --image-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--124, rgb(0 0 0 / 0.05)), 0 0 0 1px var(--image-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--125, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--126:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--127:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.1);
   --csstools-light-dark-toggle--128:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --image-current-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--127, rgb(0 0 0 / 0.05)), 0 0 0 var(--image-border-width) var(--image-current-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--128, rgb(0 0 0 / 0.1));
+  --image-hover-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--126, rgb(0 0 0 / 0.05)), 0 0 0 1px var(--csstools-light-dark-toggle--127, rgb(21 20 26 / 0.1)), 0 0 0 var(--image-border-width) var(--image-hover-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--128, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--129:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--130:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
+  --image-current-shadow:0 0.375px 1.5px 0 var(--csstools-light-dark-toggle--129, rgb(0 0 0 / 0.05)), 0 0 0 var(--image-border-width) var(--image-current-border-color), 0 3px 12px 0 var(--csstools-light-dark-toggle--130, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--131:var(--csstools-color-scheme--light) rgb(0 202 219 / 0.08);
+  --image-dragging-placeholder-bg:var(--csstools-light-dark-toggle--131, rgb(0 98 250 / 0.08));
+  --csstools-light-dark-toggle--132:var(--csstools-color-scheme--light) #15141a;
+  --multiple-dragging-text-color:var(--csstools-light-dark-toggle--132, #fbfbfe);
   }
 }
 
@@ -5945,14 +5982,24 @@
     --status-warning-bg:none;
     --indicator-warning-color:CanvasText;
     --header-shadow:none;
-    --image-shadow:0 0 0 1px CanvasText;
-    --image-outline:1px solid CanvasText;
-    --image-border-color:CanvasText;
+    --image-shadow:none;
+    --image-outline:1px solid ButtonText;
+    --image-focus-outline-color:CanvasText;
     --image-hover-border-color:SelectedItem;
-    --image-current-border-color:ButtonBorder;
+    --image-hover-page-number-bg:SelectedItemText;
+    --image-hover-page-number-fg:SelectedItem;
+    --image-current-page-number-bg:ButtonText;
+    --image-current-page-number-fg:ButtonFace;
+    --image-current-border-color:ButtonText;
     --image-current-focused-outline-color:var(--image-hover-border-color);
+    --image-current-hover-page-number-bg:SelectedItem;
+    --image-current-hover-page-number-fg:SelectedItemText;
     --image-page-number-bg:ButtonFace;
-    --image-page-number-fg:CanvasText;
+    --image-page-number-fg:ButtonText;
+    --image-page-number-border-color:var(--image-page-number-fg);
+    --multiple-dragging-bg:Canvas;
+    --multiple-dragging-indicator-bg:ButtonBorder;
+    --multiple-dragging-text-color:Canvas;
 }
   }
 
@@ -5962,9 +6009,9 @@
   padding-bottom:16px;
   flex-direction:column;
   align-items:flex-start;
+  inset-block-start:calc(100% + var(--sidebar-block-padding));
   height:calc(
-    var(--viewer-container-height) - var(--toolbar-height) -
-      var(--doorhanger-height)
+    var(--viewer-container-height) - 2 * var(--sidebar-block-padding)
   );
   position:absolute;
 
@@ -5977,7 +6024,7 @@
 }
 
 #viewsManager .sidebarResizer{
-    inset-inline-start:100%;
+    inset-inline-start:calc(100% + 4px);
   }
 
 #viewsManager .viewsManagerButton{
@@ -6034,14 +6081,17 @@
     width:100%;
     box-shadow:var(--header-shadow);
     flex:0 0 auto;
+    background-color:var(--header-bg);
   }
 
 :is(#viewsManager #viewsManagerHeader) .viewsManagerLabel{
-      flex:1 0 0;
+      flex:0;
       color:var(--text-color);
       text-align:center;
       height:-moz-fit-content;
       height:fit-content;
+      width:-moz-fit-content;
+      width:fit-content;
       -webkit-user-select:none;
          -moz-user-select:none;
               user-select:none;
@@ -6087,14 +6137,6 @@
             background-color:var(--button-fg);
           }
 
-:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button)::before):hover{
-              background-color:var(--button-hover-fg) !important;
-            }
-
-:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button)::before):active{
-              background-color:var(--button-active-fg) !important;
-            }
-
 :is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button)::after{
             content:"";
             display:inline-block;
@@ -6110,11 +6152,11 @@
             background-color:var(--button-fg);
           }
 
-:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button)::after):hover{
+:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button):hover::before,:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button):hover::after{
               background-color:var(--button-hover-fg) !important;
             }
 
-:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button)::after):active{
+:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button):active::before,:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerSelector) > button):active::after{
               background-color:var(--button-active-fg) !important;
             }
 
@@ -6144,6 +6186,8 @@
             }
 
 :is(:is(#viewsManager #viewsManagerHeader) #viewsManagerTitle) #viewsManagerAddFileButton{
+        visibility:hidden;
+
         background:var(--button-no-bg);
         width:32px;
         height:32px;
@@ -6225,6 +6269,7 @@
 
 :is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector{
           height:32px;
+          min-width:115px;
           width:auto;
           display:block;
         }
@@ -6253,16 +6298,19 @@
               background-color:var(--button-fg);
             }
 
-:is(:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector) #viewsManagerStatusActionButton)::after):hover{
-                background-color:var(--button-hover-fg) !important;
-              }
+:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector) #viewsManagerStatusActionButton):hover::after{
+              background-color:var(--button-hover-fg) !important;
+            }
 
-:is(:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector) #viewsManagerStatusActionButton)::after):active{
-                background-color:var(--button-active-fg) !important;
-              }
+:is(:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector) #viewsManagerStatusActionButton):active::after{
+              background-color:var(--button-active-fg) !important;
+            }
 
-:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector)  > .contextMenu{
-            min-width:115px;
+:is(:is(:is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusAction) #actionSelector)  > .popupMenu{
+            width:100%;
+            min-width:-moz-fit-content;
+            min-width:fit-content;
+            z-index:1;
           }
 
 :is(:is(#viewsManager #viewsManagerHeader) #viewsManagerStatus) #viewsManagerStatusUndo{
@@ -6354,6 +6402,10 @@
     overflow:auto;
   }
 
+:is(#viewsManager #viewsManagerContent):has(#thumbnailsView.isDragging){
+      overflow-x:hidden;
+    }
+
 :is(#viewsManager #viewsManagerContent) #thumbnailsView{
       --thumbnail-width:126px;
 
@@ -6362,86 +6414,312 @@
       align-items:center;
       justify-content:space-evenly;
       padding:20px 32px;
-      gap:16px;
+      gap:44px;
       width:100%;
       box-sizing:border-box;
+      position:relative;
     }
 
+.isDragging:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView){
+        cursor:grabbing;
+      }
+
+:is(.isDragging:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > .thumbnailImageContainer:hover{
+            cursor:grabbing;
+          }
+
+:is(:is(.isDragging:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer:hover):not([aria-current="page"]){
+              box-shadow:var(--image-shadow);
+            }
+
+:is(.isDragging:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > input{
+            pointer-events:none;
+          }
+
+.isDragging:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView)  > .dragMarker{
+          position:absolute;
+          top:0;
+          left:0;
+          border:2px solid var(--indicator-color);
+          contain:strict;
+        }
+
+.pasteMode:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView)  > .thumbnail{
+          flex-direction:column;
+        }
+
+:is(.pasteMode:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > input{
+            display:none;
+          }
+
+:is(.pasteMode:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > .thumbnailPasteButton{
+            display:flex;
+            justify-content:center;
+            align-items:center;
+            border-radius:16px;
+            min-height:24px;
+            padding:4px 16px;
+
+            font:menu;
+            font-size:13px;
+            font-style:normal;
+            font-weight:400;
+            line-height:normal;
+          }
+
+:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView):not(.pasteMode) > .thumbnail > .thumbnailPasteButton{
+        display:none;
+      }
+
 :is(:is(#viewsManager #viewsManagerContent) #thumbnailsView)  > .thumbnail{
+        --input-dim:16px;
+        --gap-between-input-and-thumbnail:16px;
+
         display:inline-flex;
-        justify-content:center;
+        justify-content:flex-end;
         align-items:center;
-        gap:16px;
-        width:auto;
+        flex-direction:row-reverse;
+        gap:var(--gap-between-input-and-thumbnail);
+        width:190px;
         height:auto;
         position:relative;
         scroll-margin-top:20px;
       }
 
-:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > input{
-          display:none;
+:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) .thumbnailPasteButton{
+          padding:8px 0;
+          text-align:center;
         }
 
-:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)::after{
+:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail):not(.isDragging) > .thumbnailImageContainer::after{
           content:attr(page-number);
           border-radius:8px;
+          border:1px solid var(--image-page-number-border-color);
           background-color:var(--image-page-number-bg);
           color:var(--image-page-number-fg);
           position:absolute;
           bottom:5px;
-          right:calc(var(--thumbnail-width) / 2);
+          inset-inline-end:50%;
           min-width:32px;
           height:16px;
           text-align:center;
-          translate:50%;
+          box-sizing:content-box;
+          translate:calc(var(--dir-factor) * 50%);
 
           font:menu;
-          font-size:13px;
+          font-size:12px;
           font-style:normal;
           font-weight:400;
           line-height:normal;
+
           pointer-events:none;
+          -webkit-user-select:none;
+             -moz-user-select:none;
+                  user-select:none;
         }
 
-:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > .thumbnailImage{
+:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail):has([aria-current="page"]):not(.isDragging) > .thumbnailImageContainer::after{
+          background-color:var(--image-current-page-number-bg);
+          color:var(--image-current-page-number-fg);
+          outline:1px solid var(--image-current-border-color);
+        }
+
+.isDragging:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > input{
+          visibility:hidden;
+        }
+
+:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > input{
+          margin:0;
+          width:var(--input-dim);
+          height:var(--input-dim);
+          accent-color:var(--indicator-color);
+        }
+
+:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail)  > .thumbnailImageContainer{
+          --thumbnail-dragging-scale:1.4;
+
           width:var(--thumbnail-width);
           border:none;
           border-radius:8px;
           box-shadow:var(--image-shadow);
           box-sizing:content-box;
           outline:var(--image-outline);
+          -webkit-user-select:none;
+             -moz-user-select:none;
+                  user-select:none;
+          position:relative;
         }
 
-.missingThumbnailImage:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImage){
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer) img{
+            width:100%;
+            height:100%;
+            border:none;
+            border-radius:8px;
+            outline:none;
+            -webkit-user-select:none;
+               -moz-user-select:none;
+                    user-select:none;
+            pointer-events:none;
+          }
+
+.missingThumbnailImage:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
             content-visibility:hidden;
           }
 
-:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImage):hover{
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):hover{
             cursor:pointer;
             box-shadow:var(--image-hover-shadow);
           }
 
-:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImage):focus-visible:not([aria-current="page"]){
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):hover::after{
+              background-color:var(--image-hover-page-number-bg);
+              color:var(--image-hover-page-number-fg);
+            }
+
+@media screen and (forced-colors: active){
+
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):hover{
+              box-shadow:none;
+              outline:var(--image-border-width) var(--image-hover-border-color) solid;
+          }
+            }
+
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible:not([aria-current="page"]){
               box-shadow:var(--image-hover-shadow);
               outline:none;
             }
 
-[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImage):focus-visible{
+@media screen and (forced-colors: active){
+
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible:not([aria-current="page"]){
+                box-shadow:none;
+                outline:var(--image-border-width) var(--image-focus-outline-color) solid;
+            }
+              }
+
+[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible{
               outline:var(--image-border-width) solid var(--image-current-focused-outline-color);
               outline-offset:var(--image-border-width);
             }
 
-[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImage){
+@media screen and (forced-colors: active){
+
+[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible{
+                box-shadow:none;
+                outline:var(--image-border-width) var(--image-current-border-color) solid;
+                outline-offset:0;
+            }
+
+                [aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible  > img{
+                  outline:var(--image-border-width) var(--image-focus-outline-color) solid;
+                  outline-offset:var(--image-border-width);
+                }
+              }
+
+@media screen and (forced-colors: active){
+
+:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible{
+              box-shadow:none;
+              outline:var(--image-border-width) var(--image-current-border-color) solid;
+          }
+
+              :is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):focus-visible:hover > img{
+                outline:var(--image-border-width) var(--image-hover-border-color) solid;
+                outline-offset:var(--image-border-width);
+              }
+            }
+
+[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
             box-shadow:var(--image-current-shadow);
           }
 
+[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):hover::after{
+              background-color:var(--image-current-hover-page-number-bg);
+              color:var(--image-current-hover-page-number-fg);
+            }
+
+@media screen and (forced-colors: active){
+
+[aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
+              box-shadow:none;
+              outline:var(--image-border-width) var(--image-current-border-color) solid;
+          }
+
+              [aria-current="page"]:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer):hover > img{
+                outline:var(--image-border-width) var(--image-hover-border-color) solid;
+                outline-offset:var(--image-border-width);
+              }
+            }
+
+.placeholder:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
+            background-color:var(--image-dragging-placeholder-bg);
+            box-shadow:none !important;
+          }
+
+.draggingThumbnail:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
+            position:absolute;
+            left:0;
+            top:0;
+            z-index:1;
+            transform-origin:0 0 0;
+            scale:calc(1 / var(--thumbnail-dragging-scale));
+            pointer-events:none;
+            box-shadow:var(--image-dragging-shadow);
+          }
+
+.draggingThumbnail.multiple:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
+              box-shadow:var(--image-multiple-dragging-shadow);
+            }
+
+@media screen and (forced-colors: active){
+
+.draggingThumbnail.multiple:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer){
+                forced-color-adjust:none;
+                box-shadow:var(--image-multiple-dragging-shadow);
+            }
+              }
+
+.draggingThumbnail.multiple:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer)  > .thumbnailImageContainer{
+                position:absolute;
+                top:0;
+                left:0;
+
+                width:var(--thumbnail-width);
+                border:none;
+                border-radius:8px;
+                box-sizing:content-box;
+                outline:none;
+                -webkit-user-select:none;
+                   -moz-user-select:none;
+                        user-select:none;
+              }
+
+.draggingThumbnail.multiple:is(:is(:is(:is(#viewsManager #viewsManagerContent) #thumbnailsView) > .thumbnail) > .thumbnailImageContainer)::after{
+                content:attr(data-multiple-count);
+                border-radius:calc(8px * var(--thumbnail-dragging-scale));
+                background-color:var(--multiple-dragging-indicator-bg);
+                color:var(--multiple-dragging-text-color);
+                position:absolute;
+                inset-block-end:calc(4px * var(--thumbnail-dragging-scale));
+                inset-inline-start:calc(4px * var(--thumbnail-dragging-scale));
+                min-width:calc(32px * var(--thumbnail-dragging-scale));
+                height:calc(16px * var(--thumbnail-dragging-scale));
+                text-align:center;
+                font:menu;
+                font-size:calc(13px * var(--thumbnail-dragging-scale));
+                font-style:normal;
+                font-weight:400;
+                line-height:normal;
+                contain:strict;
+              }
+
 :is(#viewsManager #viewsManagerContent) #attachmentsView{
-      --csstools-light-dark-toggle--129:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.8);
-      --attachment-color:var(--csstools-light-dark-toggle--129, rgb(0 0 0 / 0.8));
-      --csstools-light-dark-toggle--130:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.15);
-      --attachment-bg-color:var(--csstools-light-dark-toggle--130, rgb(0 0 0 / 0.15));
-      --csstools-light-dark-toggle--131:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.9);
-      --attachment-hover-color:var(--csstools-light-dark-toggle--131, rgb(0 0 0 / 0.9));
+      --csstools-light-dark-toggle--133:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.8);
+      --attachment-color:var(--csstools-light-dark-toggle--133, rgb(0 0 0 / 0.8));
+      --csstools-light-dark-toggle--134:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.15);
+      --attachment-bg-color:var(--csstools-light-dark-toggle--134, rgb(0 0 0 / 0.15));
+      --csstools-light-dark-toggle--135:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.9);
+      --attachment-hover-color:var(--csstools-light-dark-toggle--135, rgb(0 0 0 / 0.9));
     }
 
 @supports (color: light-dark(red, red)) and (color: rgb(0 0 0 / 0)){
@@ -6461,12 +6739,12 @@
 @supports not (color: light-dark(tan, tan)){
 
 :is(:is(#viewsManager #viewsManagerContent) #attachmentsView) *{
-      --csstools-light-dark-toggle--129:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.8);
-      --attachment-color:var(--csstools-light-dark-toggle--129, rgb(0 0 0 / 0.8));
-      --csstools-light-dark-toggle--130:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.15);
-      --attachment-bg-color:var(--csstools-light-dark-toggle--130, rgb(0 0 0 / 0.15));
-      --csstools-light-dark-toggle--131:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.9);
-      --attachment-hover-color:var(--csstools-light-dark-toggle--131, rgb(0 0 0 / 0.9));
+      --csstools-light-dark-toggle--133:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.8);
+      --attachment-color:var(--csstools-light-dark-toggle--133, rgb(0 0 0 / 0.8));
+      --csstools-light-dark-toggle--134:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.15);
+      --attachment-bg-color:var(--csstools-light-dark-toggle--134, rgb(0 0 0 / 0.15));
+      --csstools-light-dark-toggle--135:var(--csstools-color-scheme--light) rgb(255 255 255 / 0.9);
+      --attachment-hover-color:var(--csstools-light-dark-toggle--135, rgb(0 0 0 / 0.9));
   }
 }
 
@@ -6502,13 +6780,13 @@
           }
 
 .sidebar{
-  --csstools-light-dark-toggle--132:var(--csstools-color-scheme--light) #23222b;
-  --sidebar-bg-color:var(--csstools-light-dark-toggle--132, #fff);
-  --csstools-light-dark-toggle--133:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.1);
-  --sidebar-border-color:var(--csstools-light-dark-toggle--133, rgb(21 20 26 / 0.1));
-  --csstools-light-dark-toggle--134:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
-  --csstools-light-dark-toggle--135:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --sidebar-box-shadow:0 0.25px 0.75px var(--csstools-light-dark-toggle--134, rgb(0 0 0 / 0.05)), 0 2px 6px 0 var(--csstools-light-dark-toggle--135, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--136:var(--csstools-color-scheme--light) #23222b;
+  --sidebar-bg-color:var(--csstools-light-dark-toggle--136, #fff);
+  --csstools-light-dark-toggle--137:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.1);
+  --sidebar-border-color:var(--csstools-light-dark-toggle--137, rgb(21 20 26 / 0.1));
+  --csstools-light-dark-toggle--138:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--139:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
+  --sidebar-box-shadow:0 0.25px 0.75px var(--csstools-light-dark-toggle--138, rgb(0 0 0 / 0.05)), 0 2px 6px 0 var(--csstools-light-dark-toggle--139, rgb(0 0 0 / 0.1));
   --sidebar-backdrop-filter:none;
   --sidebar-border-radius:8px;
   --sidebar-padding:5px;
@@ -6516,8 +6794,9 @@
   --sidebar-max-width:632px;
   --sidebar-width:239px;
   --resizer-width:4px;
-  --csstools-light-dark-toggle--136:var(--csstools-color-scheme--light) #00cadb;
-  --resizer-hover-bg-color:var(--csstools-light-dark-toggle--136, #0062fa);
+  --resizer-shift:calc(0px - var(--resizer-width) - 2px);
+  --csstools-light-dark-toggle--140:var(--csstools-color-scheme--light) #00cadb;
+  --resizer-hover-bg-color:var(--csstools-light-dark-toggle--140, #0062fa);
 }
 
 @supports (color: light-dark(red, red)){
@@ -6545,15 +6824,15 @@
 @supports not (color: light-dark(tan, tan)){
 
 .sidebar *{
-  --csstools-light-dark-toggle--132:var(--csstools-color-scheme--light) #23222b;
-  --sidebar-bg-color:var(--csstools-light-dark-toggle--132, #fff);
-  --csstools-light-dark-toggle--133:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.1);
-  --sidebar-border-color:var(--csstools-light-dark-toggle--133, rgb(21 20 26 / 0.1));
-  --csstools-light-dark-toggle--134:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
-  --csstools-light-dark-toggle--135:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
-  --sidebar-box-shadow:0 0.25px 0.75px var(--csstools-light-dark-toggle--134, rgb(0 0 0 / 0.05)), 0 2px 6px 0 var(--csstools-light-dark-toggle--135, rgb(0 0 0 / 0.1));
-  --csstools-light-dark-toggle--136:var(--csstools-color-scheme--light) #00cadb;
-  --resizer-hover-bg-color:var(--csstools-light-dark-toggle--136, #0062fa);
+  --csstools-light-dark-toggle--136:var(--csstools-color-scheme--light) #23222b;
+  --sidebar-bg-color:var(--csstools-light-dark-toggle--136, #fff);
+  --csstools-light-dark-toggle--137:var(--csstools-color-scheme--light) rgb(251 251 254 / 0.1);
+  --sidebar-border-color:var(--csstools-light-dark-toggle--137, rgb(21 20 26 / 0.1));
+  --csstools-light-dark-toggle--138:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.2);
+  --csstools-light-dark-toggle--139:var(--csstools-color-scheme--light) rgb(0 0 0 / 0.4);
+  --sidebar-box-shadow:0 0.25px 0.75px var(--csstools-light-dark-toggle--138, rgb(0 0 0 / 0.05)), 0 2px 6px 0 var(--csstools-light-dark-toggle--139, rgb(0 0 0 / 0.1));
+  --csstools-light-dark-toggle--140:var(--csstools-color-scheme--light) #00cadb;
+  --resizer-hover-bg-color:var(--csstools-light-dark-toggle--140, #0062fa);
   }
 }
 
@@ -6580,6 +6859,8 @@
   max-width:var(--sidebar-max-width);
   -webkit-backdrop-filter:var(--sidebar-backdrop-filter);
           backdrop-filter:var(--sidebar-backdrop-filter);
+  box-sizing:border-box;
+  position:relative;
 }
 
 .sidebar .sidebarResizer{
@@ -6588,9 +6869,9 @@
     forced-color-adjust:none;
     cursor:ew-resize;
     position:absolute;
-    inset-block:calc(var(--sidebar-padding) + var(--sidebar-border-radius));
-    inset-inline-start:calc(0px - var(--resizer-width) / 2);
-    transition:background-color 0.5s ease-in-out;
+    inset-block:0;
+    inset-inline-start:var(--resizer-shift);
+    transition:background-color 0.5s ease-in-out, border-color 0.5s ease-in-out;
     box-sizing:border-box;
     border:1px solid transparent;
     border-block-width:0;
@@ -6599,6 +6880,7 @@
 
 :is(.sidebar .sidebarResizer):hover{
       background-color:var(--resizer-hover-bg-color);
+      border-color:white;
     }
 
 :is(.sidebar .sidebarResizer):focus-visible{
@@ -6631,8 +6913,8 @@
   --page-border:9px solid transparent;
   --spreadHorizontalWrapped-margin-LR:-3.5px;
   --loading-icon-delay:400ms;
-  --csstools-light-dark-toggle--137:var(--csstools-color-scheme--light) #0df;
-  --focus-ring-color:var(--csstools-light-dark-toggle--137, #0060df);
+  --csstools-light-dark-toggle--141:var(--csstools-color-scheme--light) #0df;
+  --focus-ring-color:var(--csstools-light-dark-toggle--141, #0060df);
   --focus-ring-outline:2px solid var(--focus-ring-color);
 }
 
@@ -6645,8 +6927,8 @@
 @supports not (color: light-dark(tan, tan)){
 
 :root *{
-  --csstools-light-dark-toggle--137:var(--csstools-color-scheme--light) #0df;
-  --focus-ring-color:var(--csstools-light-dark-toggle--137, #0060df);
+  --csstools-light-dark-toggle--141:var(--csstools-color-scheme--light) #0df;
+  --focus-ring-color:var(--csstools-light-dark-toggle--141, #0060df);
   }
 }
 
@@ -6816,7 +7098,7 @@
   content:"";
   width:100%;
   height:100%;
-  background:url(/pdfjs/images/loading-icon.gif) center no-repeat;
+  background:url(images/loading-icon.gif) center no-repeat;
   display:none;
   transition-property:display;
   transition-delay:var(--loading-icon-delay);

--- a/scripts/sync-pdfjs-assets.mjs
+++ b/scripts/sync-pdfjs-assets.mjs
@@ -1,0 +1,77 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+const sourceRoot = join(repoRoot, 'apps', 'frontend', 'node_modules', 'pdfjs-dist', 'legacy', 'web');
+const sourceCssPath = join(sourceRoot, 'pdf_viewer.css');
+const sourceImagesDir = join(sourceRoot, 'images');
+
+const targetRoot = join(repoRoot, 'apps', 'frontend', 'public', 'pdfjs');
+const targetCssPath = join(targetRoot, 'pdf_viewer.css');
+const targetImagesDir = join(targetRoot, 'images');
+
+if (!existsSync(sourceCssPath)) {
+  throw new Error(`Cannot sync PDF.js assets: missing source CSS at ${sourceCssPath}`);
+}
+
+if (!existsSync(sourceImagesDir)) {
+  throw new Error(`Cannot sync PDF.js assets: missing source images directory at ${sourceImagesDir}`);
+}
+
+const sourceCss = readFileSync(sourceCssPath, 'utf8');
+const referencedImages = new Set();
+const missingSourceImages = new Set();
+
+const rewrittenCss = sourceCss.replace(
+  /url\(\s*(['"]?)images\/([^'")]+)\1\s*\)/g,
+  (_fullMatch, _quote, fileName) => {
+    const imageRelativePath = `images/${fileName}`;
+    referencedImages.add(imageRelativePath);
+
+    const sourceImagePath = join(sourceRoot, imageRelativePath);
+    if (!existsSync(sourceImagePath)) {
+      missingSourceImages.add(imageRelativePath);
+      return 'none';
+    }
+
+    return `url(${imageRelativePath})`;
+  },
+);
+
+mkdirSync(targetRoot, { recursive: true });
+writeFileSync(targetCssPath, rewrittenCss, 'utf8');
+
+rmSync(targetImagesDir, { recursive: true, force: true });
+mkdirSync(targetImagesDir, { recursive: true });
+
+const sourceImageFiles = readdirSync(sourceImagesDir)
+  .filter((entry) => !entry.startsWith('.'))
+  .sort();
+
+for (const fileName of sourceImageFiles) {
+  copyFileSync(join(sourceImagesDir, fileName), join(targetImagesDir, fileName));
+}
+
+// Copy the worker script
+const sourceWorkerPath = join(repoRoot, 'apps', 'frontend', 'node_modules', 'pdfjs-dist', 'legacy', 'build', 'pdf.worker.min.mjs');
+const targetWorkerPath = join(targetRoot, 'pdf.worker.min.mjs');
+if (existsSync(sourceWorkerPath)) {
+  copyFileSync(sourceWorkerPath, targetWorkerPath);
+  console.log(`Synced PDF.js worker: ${targetWorkerPath}`);
+} else {
+  console.warn(`Warning: PDF.js worker not found at ${sourceWorkerPath}`);
+}
+
+console.log(`Synced PDF.js CSS: ${targetCssPath}`);
+console.log(`Synced PDF.js image files: ${sourceImageFiles.length}`);
+console.log(`Rewritten CSS image references: ${referencedImages.size}`);
+
+if (missingSourceImages.size > 0) {
+  const missing = [...missingSourceImages].sort();
+  console.warn(
+    `Replaced ${missing.length} unresolved PDF.js CSS image references with \"none\" (missing in pdfjs-dist):`,
+  );
+  for (const assetPath of missing) {
+    console.warn(`- ${assetPath}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Root-relative paths (`/pdfjs/...`, `/excalidraw-assets/...`, `/provider-icons/...`) resolve to the filesystem root (`C:/`) instead of the app directory when Electron loads the renderer via `file://` protocol in production
- Use `import.meta.env.BASE_URL` prefix for all runtime asset paths in JS (PDF worker, PDF viewer CSS, Excalidraw assets, provider icon sprite)
- Changed `pdf_viewer.css` image references from absolute (`/pdfjs/images/...`) to relative (`images/...`) since the CSS lives inside `pdfjs/`

## Test plan
- [ ] Open a PDF in the packaged Electron app — verify it renders without worker errors
- [ ] Verify Excalidraw drawings load correctly (fonts, icons)
- [ ] Verify provider icons render in chat sidebar
- [ ] Verify PDF annotation toolbar delete button icon shows
- [ ] Confirm dev mode (`bun run dev:electron`) still works