### PR TITLE
Remove browser support, make Cushion fully Electron-based

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -142,60 +142,6 @@ app.on('second-instance', (_event, commandLine) => {
   if (openPath) focusAndOpenWorkspace(openPath);
 });
 
-const OAUTH_CALLBACK_ORIGIN = 'http://127.0.0.1:19876';
-const OAUTH_CALLBACK_PATH = '/mcp/oauth/callback';
-
-ipcMain.handle('oauth:openWindow', (_event, authUrl: string): Promise<string | null> => {
-  return new Promise((resolve) => {
-    const oauthWin = new BrowserWindow({
-      width: 600,
-      height: 700,
-      parent: mainWindow ?? undefined,
-      modal: false,
-      webPreferences: { nodeIntegration: false, contextIsolation: true },
-    });
-
-    let resolved = false;
-    const finish = (code: string | null) => {
-      if (resolved) return;
-      resolved = true;
-      resolve(code);
-      setImmediate(() => { if (!oauthWin.isDestroyed()) oauthWin.close(); });
-    };
-
-    const isCallbackUrl = (url: string) =>
-      url.startsWith(`${OAUTH_CALLBACK_ORIGIN}${OAUTH_CALLBACK_PATH}`);
-
-    oauthWin.webContents.on('will-redirect', (e, url) => {
-      if (isCallbackUrl(url)) {
-        e.preventDefault();
-        finish(new URL(url).searchParams.get('code'));
-      }
-    });
-
-    oauthWin.webContents.on('will-navigate', (e, url) => {
-      if (isCallbackUrl(url)) {
-        e.preventDefault();
-        finish(new URL(url).searchParams.get('code'));
-      }
-    });
-
-    oauthWin.on('closed', () => finish(null));
-
-    try {
-      const parsed = new URL(authUrl);
-      if (!['https:', 'http:'].includes(parsed.protocol)) {
-        finish(null);
-        return;
-      }
-    } catch {
-      finish(null);
-      return;
-    }
-    oauthWin.loadURL(authUrl);
-  });
-});
-
 app.whenReady().then(async () => {
   const cliPath = extractPathArg(process.argv.slice(1));
   if (cliPath) {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -32,7 +32,4 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   exportPdf: (data: { html: string; title: string; options: unknown }) =>
     ipcRenderer.invoke('export:pdf', data),
-
-  openOAuthWindow: (authUrl: string) =>
-    ipcRenderer.invoke('oauth:openWindow', authUrl) as Promise<string | null>,
 });

--- a/apps/frontend/components/chat/McpsPanel.tsx
+++ b/apps/frontend/components/chat/McpsPanel.tsx
@@ -102,33 +102,8 @@ export function McpsPanel() {
     authAbortRef.current = abort;
 
     try {
-      if (window.electronAPI?.openOAuthWindow) {
-        // Electron: 2-step flow — start() gets the URL, BrowserWindow intercepts the redirect
-        const startResult = await ctx.client.mcp.auth.start({ name, directory: ctx.directory });
-        if (abort.signal.aborted) return;
-
-        const authUrl = startResult?.data?.authorizationUrl;
-        if (!authUrl) {
-          showToast({ variant: 'success', title: 'Already authenticated', description: `${name} is connected`, duration: 4000 });
-          await fetchMcps();
-          return;
-        }
-
-        const code = await window.electronAPI.openOAuthWindow(authUrl);
-        if (abort.signal.aborted) return;
-
-        if (!code) {
-          showToast({ variant: 'error', title: 'Auth cancelled', description: 'OAuth window was closed', duration: 4000 });
-          return;
-        }
-
-        await ctx.client.mcp.auth.callback({ name, directory: ctx.directory, code });
-        if (abort.signal.aborted) return;
-      } else {
-        // Browser: use the blocking authenticate() call (opens browser server-side)
-        await ctx.client.mcp.auth.authenticate({ name, directory: ctx.directory });
-        if (abort.signal.aborted) return;
-      }
+      await ctx.client.mcp.auth.authenticate({ name, directory: ctx.directory });
+      if (abort.signal.aborted) return;
 
       showToast({ variant: 'success', title: 'Authenticated', description: `${name} is now connected`, duration: 4000 });
       await fetchMcps();

--- a/apps/frontend/components/editor/EditorTabRow.tsx
+++ b/apps/frontend/components/editor/EditorTabRow.tsx
@@ -142,21 +142,21 @@ export function EditorTabRow({
       {needsCustomWindowControls && (
         <div className="flex items-center flex-shrink-0 ml-auto" style={noDragStyle}>
           <button
-            onClick={() => window.electronAPI?.windowMinimize()}
+            onClick={() => window.electronAPI.windowMinimize()}
             className="h-10 w-12 flex items-center justify-center text-muted-foreground hover:bg-muted/30 transition-colors"
             aria-label="Minimize"
           >
             <Minus size={16} strokeWidth={1.5} />
           </button>
           <button
-            onClick={() => window.electronAPI?.windowMaximize()}
+            onClick={() => window.electronAPI.windowMaximize()}
             className="h-10 w-12 flex items-center justify-center text-muted-foreground hover:bg-muted/30 transition-colors"
             aria-label="Maximize"
           >
             <Square size={14} strokeWidth={1.5} />
           </button>
           <button
-            onClick={() => window.electronAPI?.windowClose()}
+            onClick={() => window.electronAPI.windowClose()}
             className="h-10 w-12 flex items-center justify-center text-muted-foreground hover:text-white hover:bg-red-500 transition-colors"
             aria-label="Close"
           >

--- a/apps/frontend/components/editor/editor-path.ts
+++ b/apps/frontend/components/editor/editor-path.ts
@@ -1,6 +1,5 @@
-export const isElectron = !!window.electronAPI;
-export const isLinux = window.electronAPI?.platform === 'linux';
-export const hasCustomTitlebar = isElectron && !isLinux;
+export const isLinux = window.electronAPI.platform === 'linux';
+export const hasCustomTitlebar = !isLinux;
 export const needsCustomWindowControls = false;
 export const noDragStyle = hasCustomTitlebar ? { WebkitAppRegion: 'no-drag' } as React.CSSProperties : undefined;
 

--- a/apps/frontend/components/workspace/FileBrowser.tsx
+++ b/apps/frontend/components/workspace/FileBrowser.tsx
@@ -227,7 +227,7 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
 
   const handleExternalDrop = useCallback(async (files: FileList, targetDir: string) => {
     if (!client) return;
-    if (!window.electronAPI) return; // Electron-only
+
 
     const allowedExts = new Set(preferences.allowedExtensions.map((e: string) => e.toLowerCase()));
     const dirsToRefresh = new Set<string>();

--- a/apps/frontend/lib/coordinator-client.ts
+++ b/apps/frontend/lib/coordinator-client.ts
@@ -12,7 +12,7 @@ export class CoordinatorClient {
   private _cleanups: Array<() => void> = [];
 
   connect(): Promise<void> {
-    const api = window.electronAPI!;
+    const api = window.electronAPI;
 
     this._cleanups.push(
       api.onCoordinatorNotification('workspace/filesChanged', (data: { changes: FileChange[] }) => {
@@ -50,7 +50,7 @@ export class CoordinatorClient {
     method: M,
     ...args: RPCParams<M> extends void ? [] : [RPCParams<M>]
   ): Promise<RPCResult<M>> {
-    return window.electronAPI!.coordinatorInvoke(method, args[0] ?? {});
+    return window.electronAPI.coordinatorInvoke(method, args[0] ?? {});
   }
 
   openWorkspace(projectPath: string) {

--- a/apps/frontend/lib/pdf-export.ts
+++ b/apps/frontend/lib/pdf-export.ts
@@ -49,7 +49,7 @@ export async function exportToPdf(
   options: PdfExportOptions,
 ): Promise<void> {
   const html = buildPdfHtml(markdown, title, options);
-  await window.electronAPI!.exportPdf({ html, title, options });
+  await window.electronAPI.exportPdf({ html, title, options });
 }
 
 function slugify(text: string): string {

--- a/apps/frontend/src/Home.tsx
+++ b/apps/frontend/src/Home.tsx
@@ -74,7 +74,7 @@ function applyAppearanceToDOM(resolvedTheme: 'light' | 'dark', accentColor: stri
     html.style.removeProperty('--accent-l');
   }
 
-  window.electronAPI?.updateTitleBarTheme(TITLEBAR_OVERLAY_COLORS[resolvedTheme]);
+  window.electronAPI.updateTitleBarTheme(TITLEBAR_OVERLAY_COLORS[resolvedTheme]);
 }
 
 function ToastBridge() {
@@ -453,7 +453,6 @@ export default function Home() {
   }, [client, openFile, fetchFileTree]);
 
   useEffect(() => {
-    if (!window.electronAPI?.onOpenWorkspace) return;
     window.electronAPI.onOpenWorkspace((path) => {
       openWorkspace(path).catch((err) => {
         console.error('[Home] Failed to open workspace from OS:', err);
@@ -462,7 +461,6 @@ export default function Home() {
   }, [openWorkspace]);
 
   useEffect(() => {
-    if (!window.electronAPI?.onCloseCurrentTabShortcut) return;
     return window.electronAPI.onCloseCurrentTabShortcut(() => {
       const closeTabBindings = appShortcuts['app.tab.close'] ?? [];
       const hasModWBinding = closeTabBindings.some(

--- a/apps/frontend/src/electron.d.ts
+++ b/apps/frontend/src/electron.d.ts
@@ -9,7 +9,6 @@ export interface ElectronAPI {
   notifyWorkspaceOpened: (path: string) => Promise<void>;
   onOpenWorkspace: (callback: (path: string) => void) => void;
   onCloseCurrentTabShortcut: (callback: () => void) => () => void;
-  openOAuthWindow: (authUrl: string) => Promise<string | null>;
   exportPdf: (data: {
     html: string;
     title: string;
@@ -19,6 +18,6 @@ export interface ElectronAPI {
 
 declare global {
   interface Window {
-    electronAPI?: ElectronAPI;
+    electronAPI: ElectronAPI;
   }
 }

--- a/apps/frontend/stores/dictationStore.ts
+++ b/apps/frontend/stores/dictationStore.ts
@@ -131,7 +131,7 @@ export const useDictationStore = create<DictationState>()(
       coordinatorClient = client;
 
       if (serverStatusCleanup) serverStatusCleanup();
-      serverStatusCleanup = window.electronAPI!.onCoordinatorNotification(
+      serverStatusCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/server-status-changed',
         (data: DictationServerInfo) => {
           set({ serverStatus: data.status });
@@ -139,7 +139,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (downloadProgressCleanup) downloadProgressCleanup();
-      downloadProgressCleanup = window.electronAPI!.onCoordinatorNotification(
+      downloadProgressCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/download-progress',
         (data: DownloadProgress) => {
           set({ downloadProgress: data });
@@ -147,7 +147,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (downloadCompleteCleanup) downloadCompleteCleanup();
-      downloadCompleteCleanup = window.electronAPI!.onCoordinatorNotification(
+      downloadCompleteCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/download-complete',
         () => {
           set({ downloadProgress: null });
@@ -156,7 +156,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (downloadErrorCleanup) downloadErrorCleanup();
-      downloadErrorCleanup = window.electronAPI!.onCoordinatorNotification(
+      downloadErrorCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/download-error',
         () => {
           set({ downloadProgress: null });
@@ -164,7 +164,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (hotkeyPressedCleanup) hotkeyPressedCleanup();
-      hotkeyPressedCleanup = window.electronAPI!.onCoordinatorNotification(
+      hotkeyPressedCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/hotkey-pressed',
         () => {
           get().toggleRecording();
@@ -172,7 +172,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (hotkeyFailedCleanup) hotkeyFailedCleanup();
-      hotkeyFailedCleanup = window.electronAPI!.onCoordinatorNotification(
+      hotkeyFailedCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/hotkey-registration-failed',
         (data: { hotkey: string; error: string }) => {
           showGlobalToast({ description: `Hotkey registration failed: ${data.error}`, variant: 'error' });
@@ -180,7 +180,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (gpuDownloadProgressCleanup) gpuDownloadProgressCleanup();
-      gpuDownloadProgressCleanup = window.electronAPI!.onCoordinatorNotification(
+      gpuDownloadProgressCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/gpu-binary-download-progress',
         (data: GpuDownloadProgress) => {
           set({ gpuBinaryDownloadProgress: data });
@@ -188,7 +188,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (gpuDownloadCompleteCleanup) gpuDownloadCompleteCleanup();
-      gpuDownloadCompleteCleanup = window.electronAPI!.onCoordinatorNotification(
+      gpuDownloadCompleteCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/gpu-binary-download-complete',
         () => {
           set({ gpuBinaryDownloading: false, gpuBinaryDownloaded: true, gpuBinaryDownloadProgress: null });
@@ -196,7 +196,7 @@ export const useDictationStore = create<DictationState>()(
       );
 
       if (gpuDownloadErrorCleanup) gpuDownloadErrorCleanup();
-      gpuDownloadErrorCleanup = window.electronAPI!.onCoordinatorNotification(
+      gpuDownloadErrorCleanup = window.electronAPI.onCoordinatorNotification(
         'dictation/gpu-binary-download-error',
         (data: { error: string }) => {
           set({ gpuBinaryDownloading: false, gpuBinaryDownloadProgress: null });

--- a/apps/frontend/stores/workspaceStore.ts
+++ b/apps/frontend/stores/workspaceStore.ts
@@ -184,7 +184,7 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
 
             get().addRecentProject();
 
-            window.electronAPI?.notifyWorkspaceOpened?.(projectPath);
+            window.electronAPI.notifyWorkspaceOpened(projectPath);
           } catch (error) {
             const errorMessage =
               error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Summary
- Makes `window.electronAPI` required (no longer optional) across the frontend
- Removes all browser fallback guards (`?.`, `!`, `isElectron` checks) from 12 files
- Replaces MCP OAuth BrowserWindow flow with OpenCode's `authenticate()` — opens the user's default browser instead of an in-app window
- Removes `openOAuthWindow` IPC bridge, preload method, and 53-line BrowserWindow handler

## Test plan
- [ ] Type check passes (no new errors)
- [ ] MCP OAuth tested and working with `authenticate()`
- [ ] Verify window controls (minimize/maximize/close) still work
- [ ] Verify external file drop in file browser
- [ ] Verify titlebar theme updates on theme switch
- [ ] Verify workspace open from OS (e.g. double-click .md file)
- [ ] Test on Linux to confirm OAuth opens default browser via xdg-open