### PR TITLE
Redesign dictation overlay and improve post-processing

### DIFF
--- a/apps/electron/src/main/coordinator/dictation-config.ts
+++ b/apps/electron/src/main/coordinator/dictation-config.ts
@@ -72,7 +72,6 @@ function migrateConfig(raw: Record<string, unknown>): DictationConfig {
 
 export class DictationConfigManager {
   private configPath: string;
-  private cache: DictationConfig | null = null;
   private writeQueue: Promise<void> = Promise.resolve();
 
   constructor() {
@@ -90,17 +89,16 @@ export class DictationConfigManager {
   async read(): Promise<DictationConfig> {
     const raw = await fs.readFile(this.configPath, 'utf-8');
     const parsed = JSON.parse(raw);
-    this.cache = migrateConfig(parsed);
+    const config = migrateConfig(parsed);
 
     if (parsed.selectedEngine !== undefined) {
-      await this.write(this.cache);
+      await this.write(config);
     }
 
-    return this.cache;
+    return config;
   }
 
   async write(config: DictationConfig): Promise<void> {
-    this.cache = config;
     const task = this.writeQueue.then(() =>
       fs.writeFile(this.configPath, JSON.stringify(config, null, 2), 'utf-8'),
     );

--- a/apps/electron/src/main/coordinator/dictation-config.ts
+++ b/apps/electron/src/main/coordinator/dictation-config.ts
@@ -75,6 +75,7 @@ function migrateConfig(raw: Record<string, unknown>): DictationConfig {
 export class DictationConfigManager {
   private configPath: string;
   private cache: DictationConfig | null = null;
+  private writeQueue: Promise<void> = Promise.resolve();
 
   constructor() {
     this.configPath = path.join(app.getPath('userData'), CONFIG_FILE);
@@ -102,7 +103,11 @@ export class DictationConfigManager {
 
   async write(config: DictationConfig): Promise<void> {
     this.cache = config;
-    await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), 'utf-8');
+    const task = this.writeQueue.then(() =>
+      fs.writeFile(this.configPath, JSON.stringify(config, null, 2), 'utf-8'),
+    );
+    this.writeQueue = task.catch(() => {});
+    await task;
   }
 
   async getDictionary(): Promise<string[]> {

--- a/apps/electron/src/main/coordinator/dictation-config.ts
+++ b/apps/electron/src/main/coordinator/dictation-config.ts
@@ -40,7 +40,6 @@ function migrateWhisperModel(name: string): DictationModelName {
 }
 
 function migrateConfig(raw: Record<string, unknown>): DictationConfig {
-  // Already migrated — no legacy selectedEngine field present
   if (raw.selectedModel && typeof raw.selectedModel === 'string' && !raw.selectedEngine) {
     return {
       ...DEFAULT_CONFIG,
@@ -51,7 +50,6 @@ function migrateConfig(raw: Record<string, unknown>): DictationConfig {
     };
   }
 
-  // Legacy format: selectedEngine + selectedModel (WhisperModelName) + selectedSherpaModel
   const engine = raw.selectedEngine as string | undefined;
   const whisperModel = raw.selectedModel as string | undefined;
   const sherpaModel = raw.selectedSherpaModel as string | undefined;

--- a/apps/electron/src/main/coordinator/post-processor.ts
+++ b/apps/electron/src/main/coordinator/post-processor.ts
@@ -1,6 +1,3 @@
-import http from 'http';
-import https from 'https';
-import { URL } from 'url';
 import type { DictationConfigManager } from './dictation-config';
 import { applyFuzzyCorrection } from './fuzzy-correct';
 import { applyTextCleanup } from './text-cleanup';
@@ -74,20 +71,21 @@ interface LLMRequest {
   thinking?: boolean;
 }
 
-function callLLM(req: LLMRequest): Promise<string> {
+async function callLLM(req: LLMRequest): Promise<string> {
   const messages = [
     { role: 'system', content: req.systemPrompt },
     { role: 'user', content: req.userText },
   ];
 
-  let url: URL;
+  let url: string;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   let body: string;
   let extractContent: (json: Record<string, unknown>) => string | undefined;
 
   if (req.provider === 'ollama') {
-    url = new URL(req.baseUrl || 'http://localhost:11434');
-    url.pathname = '/api/chat';
+    const base = new URL(req.baseUrl || 'http://localhost:11434');
+    base.pathname = '/api/chat';
+    url = base.toString();
     body = JSON.stringify({
       model: req.model,
       messages,
@@ -97,7 +95,7 @@ function callLLM(req: LLMRequest): Promise<string> {
     extractContent = (json) =>
       (json.message as { content?: string })?.content?.trim();
   } else {
-    url = new URL(req.baseUrl || 'https://api.openai.com/v1/chat/completions');
+    url = req.baseUrl || 'https://api.openai.com/v1/chat/completions';
     if (req.apiKey) headers['Authorization'] = `Bearer ${req.apiKey}`;
     body = JSON.stringify({
       model: req.model,
@@ -108,42 +106,21 @@ function callLLM(req: LLMRequest): Promise<string> {
       ((json.choices as { message?: { content?: string } }[])?.[0])?.message?.content?.trim();
   }
 
-  return new Promise((resolve, reject) => {
-    const transport = url.protocol === 'https:' ? https : http;
-    const httpReq = transport.request(
-      url,
-      { method: 'POST', headers: { ...headers, 'Content-Length': Buffer.byteLength(body) } },
-      (res) => {
-        let data = '';
-        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
-        res.on('end', () => {
-          try {
-            const json = JSON.parse(data);
-            if (json.error) {
-              reject(new Error(typeof json.error === 'string' ? json.error : json.error.message || 'LLM API error'));
-              return;
-            }
-            const content = extractContent(json);
-            if (!content) {
-              reject(new Error('Empty response from LLM'));
-              return;
-            }
-            resolve(content);
-          } catch (err) {
-            reject(err);
-          }
-        });
-      },
-    );
-
-    const timeoutMs = req.thinking ? 90_000 : 45_000;
-    httpReq.setTimeout(timeoutMs, () => {
-      httpReq.destroy(new Error('LLM request timed out'));
-    });
-    httpReq.on('error', reject);
-    httpReq.write(body);
-    httpReq.end();
+  const timeoutMs = req.thinking ? 90_000 : 45_000;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
   });
+
+  const json = await res.json();
+  if (json.error) {
+    throw new Error(typeof json.error === 'string' ? json.error : json.error.message || 'LLM API error');
+  }
+  const content = extractContent(json);
+  if (!content) throw new Error('Empty response from LLM');
+  return content;
 }
 
 export class PostProcessor {
@@ -151,11 +128,9 @@ export class PostProcessor {
 
   async process(rawText: string, language?: string, noteContext?: string): Promise<{ text: string; wasProcessed: boolean }> {
     const trimmed = rawText.trim();
-    console.log('[PostProcessor] RAW →', trimmed);
     if (!trimmed) return { text: '', wasProcessed: false };
 
     if (isHallucination(trimmed)) {
-      console.log('[PostProcessor] hallucination caught, discarded');
       return { text: '', wasProcessed: true };
     }
 
@@ -167,7 +142,6 @@ export class PostProcessor {
     if (config.postProcessing.fuzzyCorrection && config.dictionary.length > 0) {
       const fuzzyResult = applyFuzzyCorrection(text, config.dictionary);
       if (fuzzyResult !== text) {
-        console.log('[PostProcessor] POST FUZZY →', fuzzyResult);
         text = fuzzyResult;
         wasProcessed = true;
       }
@@ -177,7 +151,6 @@ export class PostProcessor {
     if (fillerRemoval || stutterCollapse) {
       text = applyTextCleanup(text, { fillerRemoval, stutterCollapse, language });
       if (text !== trimmed) {
-        console.log('[PostProcessor] CLEANED UP →', text);
         wasProcessed = true;
       }
       if (!text) return { text: '', wasProcessed: true };
@@ -186,7 +159,6 @@ export class PostProcessor {
     if (config.postProcessing.skipShortTranscriptions) {
       const wordCount = countWords(text);
       if (wordCount <= config.postProcessing.shortTextThreshold) {
-        console.log(`[PostProcessor] short text (${wordCount} words), skipping LLM`);
         return { text, wasProcessed };
       }
     }
@@ -210,10 +182,9 @@ export class PostProcessor {
         apiKey: config.postProcessing.apiKey,
         thinking: config.postProcessing.thinking,
       });
-      console.log('[PostProcessor] POST AI →', cleaned);
       return { text: cleaned, wasProcessed: true };
     } catch (err) {
-      console.error('[PostProcessor] LLM call failed, falling back to cleaned text:', err);
+      if (err instanceof Error && err.name === 'TimeoutError') throw err;
       return { text, wasProcessed };
     }
   }

--- a/apps/electron/src/main/coordinator/post-processor.ts
+++ b/apps/electron/src/main/coordinator/post-processor.ts
@@ -47,9 +47,10 @@ function isHallucination(text: string): boolean {
   );
 }
 
+const wordSegmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
+
 function countWords(text: string): number {
-  const segmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
-  return [...segmenter.segment(text)].filter(s => s.isWordLike).length;
+  return [...wordSegmenter.segment(text)].filter(s => s.isWordLike).length;
 }
 
 function buildPrompt(dictionary: string[], noteContext?: string): string {

--- a/apps/electron/src/main/coordinator/post-processor.ts
+++ b/apps/electron/src/main/coordinator/post-processor.ts
@@ -15,7 +15,7 @@ RULES:
 - Preserve the speaker's voice, tone, vocabulary, and intent
 - Preserve technical terms, proper nouns, names, and jargon exactly as spoken
 
-Self-corrections ("wait no", "I meant", "scratch that"): use only the corrected version. "Actually" used for emphasis is NOT a correction.
+Self-corrections ("wait no", "I meant", "scratch that", and equivalents in any language): remove the mistake entirely and keep ONLY the corrected version. "Actually" used for emphasis is NOT a correction.
 Spoken punctuation ("period", "comma", "new line"): convert to symbols. Use context to distinguish commands from literal mentions.
 Numbers & dates: standard written forms (January 15, 2026 / $300 / 5:30 PM). Small conversational numbers can stay as words.
 Broken phrases: reconstruct the speaker's likely intent from context. Never output a polished sentence that says nothing coherent.
@@ -63,56 +63,55 @@ function buildPrompt(dictionary: string[], noteContext?: string): string {
   return prompt;
 }
 
-interface ResolvedEndpoint {
-  url: URL;
-  headers: Record<string, string>;
+interface LLMRequest {
+  provider: 'openai' | 'ollama';
+  model: string;
+  systemPrompt: string;
+  userText: string;
+  baseUrl?: string;
+  apiKey?: string;
+  thinking?: boolean;
 }
 
-function resolveEndpoint(
-  provider: 'openai' | 'ollama',
-  baseUrl?: string,
-  apiKey?: string,
-): ResolvedEndpoint {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+function callLLM(req: LLMRequest): Promise<string> {
+  const messages = [
+    { role: 'system', content: req.systemPrompt },
+    { role: 'user', content: req.userText },
+  ];
+
   let url: URL;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  let body: string;
+  let extractContent: (json: Record<string, unknown>) => string | undefined;
 
-  switch (provider) {
-    case 'openai':
-      url = new URL('https://api.openai.com/v1/chat/completions');
-      if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
-      break;
-    case 'ollama':
-      url = new URL(baseUrl || 'http://localhost:11434');
-      url.pathname = '/v1/chat/completions';
-      break;
-  }
-
-  return { url, headers };
-}
-
-function callLLM(
-  endpoint: ResolvedEndpoint,
-  model: string,
-  systemPrompt: string,
-  userText: string,
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const body = JSON.stringify({
-      model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userText },
-      ],
+  if (req.provider === 'ollama') {
+    url = new URL(req.baseUrl || 'http://localhost:11434');
+    url.pathname = '/api/chat';
+    body = JSON.stringify({
+      model: req.model,
+      messages,
+      stream: false,
+      think: req.thinking ?? false,
+    });
+    extractContent = (json) =>
+      (json.message as { content?: string })?.content?.trim();
+  } else {
+    url = new URL(req.baseUrl || 'https://api.openai.com/v1/chat/completions');
+    if (req.apiKey) headers['Authorization'] = `Bearer ${req.apiKey}`;
+    body = JSON.stringify({
+      model: req.model,
+      messages,
       temperature: 0.3,
     });
+    extractContent = (json) =>
+      ((json.choices as { message?: { content?: string } }[])?.[0])?.message?.content?.trim();
+  }
 
-    const transport = endpoint.url.protocol === 'https:' ? https : http;
-    const req = transport.request(
-      endpoint.url,
-      {
-        method: 'POST',
-        headers: { ...endpoint.headers, 'Content-Length': Buffer.byteLength(body) },
-      },
+  return new Promise((resolve, reject) => {
+    const transport = url.protocol === 'https:' ? https : http;
+    const httpReq = transport.request(
+      url,
+      { method: 'POST', headers: { ...headers, 'Content-Length': Buffer.byteLength(body) } },
       (res) => {
         let data = '';
         res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
@@ -120,10 +119,10 @@ function callLLM(
           try {
             const json = JSON.parse(data);
             if (json.error) {
-              reject(new Error(json.error.message || 'LLM API error'));
+              reject(new Error(typeof json.error === 'string' ? json.error : json.error.message || 'LLM API error'));
               return;
             }
-            const content = json.choices?.[0]?.message?.content?.trim();
+            const content = extractContent(json);
             if (!content) {
               reject(new Error('Empty response from LLM'));
               return;
@@ -136,12 +135,13 @@ function callLLM(
       },
     );
 
-    req.on('error', reject);
-    req.setTimeout(30000, () => {
-      req.destroy(new Error('LLM request timed out'));
+    const timeoutMs = req.thinking ? 90_000 : 45_000;
+    httpReq.setTimeout(timeoutMs, () => {
+      httpReq.destroy(new Error('LLM request timed out'));
     });
-    req.write(body);
-    req.end();
+    httpReq.on('error', reject);
+    httpReq.write(body);
+    httpReq.end();
   });
 }
 
@@ -200,8 +200,15 @@ export class PostProcessor {
 
     try {
       const { provider } = config.postProcessing;
-      const endpoint = resolveEndpoint(provider, config.postProcessing.baseUrl, config.postProcessing.apiKey);
-      const cleaned = await callLLM(endpoint, config.postProcessing.model, systemPrompt, text);
+      const cleaned = await callLLM({
+        provider,
+        model: config.postProcessing.model,
+        systemPrompt,
+        userText: text,
+        baseUrl: config.postProcessing.baseUrl,
+        apiKey: config.postProcessing.apiKey,
+        thinking: config.postProcessing.thinking,
+      });
       console.log('[PostProcessor] POST AI →', cleaned);
       return { text: cleaned, wasProcessed: true };
     } catch (err) {

--- a/apps/frontend/components/chat/Toast.tsx
+++ b/apps/frontend/components/chat/Toast.tsx
@@ -118,26 +118,24 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: string)
   return (
     <div
       className={cn(
-        "pointer-events-auto relative w-96 max-w-sm rounded-lg border shadow-lg p-4 transition-all duration-300",
+        "pointer-events-auto relative w-80 rounded-lg border shadow-lg px-4 py-3 transition-all duration-300",
         getVariantStyles(),
         isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
       )}
     >
-      {!toast.persistent && (
-        <button
-          onClick={() => onDismiss(toast.id)}
-          className="absolute top-2 right-2 size-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-10)] transition-colors"
-        >
-          <X className="size-3.5" />
-        </button>
-      )}
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="absolute top-2 right-2 size-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-10)] transition-colors"
+      >
+        <X className="size-3.5" />
+      </button>
       <div className="flex gap-3 pr-5">
         {icon && <div className="shrink-0 mt-0.5">{icon}</div>}
         <div className="flex-1 min-w-0">
           {toast.title && (
             <p className="text-sm font-medium text-foreground">{toast.title}</p>
           )}
-          <p className="text-sm text-muted-foreground">{toast.description}</p>
+          <p className="text-sm text-muted-foreground whitespace-pre-line">{toast.description}</p>
           {toast.actions && toast.actions.length > 0 && (
             <div className="mt-2 flex gap-2">
               {toast.actions.map((action, index) => (

--- a/apps/frontend/components/editor/EditorPanel.tsx
+++ b/apps/frontend/components/editor/EditorPanel.tsx
@@ -466,7 +466,6 @@ export function EditorPanel({
             openFile(resolvedPath, '');
             return;
           }
-          // Skip server fetch if the file is already open
           if (useWorkspaceStore.getState().openFiles.has(resolvedPath)) {
             openFile(resolvedPath, '');
             return;

--- a/apps/frontend/components/editor/EditorPanel.tsx
+++ b/apps/frontend/components/editor/EditorPanel.tsx
@@ -538,13 +538,13 @@ export function EditorPanel({
         />
       )}
 
+      <div className="relative flex-1 min-h-0 min-w-0">
       <div
-        className="relative flex-1 min-h-0 min-w-0 overflow-auto rounded-tl-lg thin-scrollbar"
+        className="absolute inset-0 overflow-auto rounded-tl-lg thin-scrollbar"
         ref={editorContainerRef}
         data-editor-scroll-container
         style={{ background: 'var(--md-bg, var(--background))' }}
       >
-        <RecordingOverlay />
         {Array.from(openFiles.entries()).map(([fp]) => {
           const isActive = fp === currentFile;
           const resolved = getViewForFile(fp);
@@ -620,6 +620,8 @@ export function EditorPanel({
             )}
           </div>
         )}
+      </div>
+      <RecordingOverlay />
       </div>
 
       <ExportOptionsDialog

--- a/apps/frontend/components/editor/RecordingOverlay.tsx
+++ b/apps/frontend/components/editor/RecordingOverlay.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Square } from 'lucide-react';
-import { useDictationStore } from '@/stores/dictationStore';
-import { getAnalyserNode } from '@/stores/dictationStore';
+import { useDictationStore, getAnalyserNode } from '@/stores/dictationStore';
 
 const BAR_COUNT = 9;
 const NOISE_GATE = 0.22;
@@ -18,9 +17,9 @@ export function RecordingOverlay() {
   const loadingPhaseRef = useRef(0);
   const smoothedRef = useRef<number[]>(new Array(BAR_COUNT).fill(0));
 
-  const setBarsRef = useCallback((i: number) => (el: HTMLDivElement | null) => {
+  const setBarsRef = (i: number) => (el: HTMLDivElement | null) => {
     barsRef.current[i] = el;
-  }, []);
+  };
 
   // Timer
   useEffect(() => {
@@ -48,10 +47,8 @@ export function RecordingOverlay() {
             const gated = raw < NOISE_GATE ? 0 : (raw - NOISE_GATE) / (1 - NOISE_GATE);
             const shaped = Math.min(1, Math.pow(gated * GAIN, CURVE));
 
-            // Temporal smoothing (like Handy: prev * 0.7 + new * 0.3)
             smoothedRef.current[i] = smoothedRef.current[i] * SMOOTHING + shaped * (1 - SMOOTHING);
 
-            // Spatial smoothing across neighbors
             let val = smoothedRef.current[i];
             if (i > 0 && i < BAR_COUNT - 1) {
               val = val * 0.7 + smoothedRef.current[i - 1] * 0.15 + smoothedRef.current[i + 1] * 0.15;
@@ -85,7 +82,7 @@ export function RecordingOverlay() {
       };
       loadingPhaseRef.current = 0;
       rafRef.current = requestAnimationFrame(animate);
-      return () => cancelAnimationFrame(animate);
+      return () => cancelAnimationFrame(rafRef.current);
     }
   }, [status]);
 
@@ -105,7 +102,6 @@ export function RecordingOverlay() {
     <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-overlay flex items-center gap-2.5 pl-3 pr-2 py-1.5 rounded-full bg-[var(--color-base-100)] animate-in fade-in duration-300"
       style={{ minWidth: 160 }}
     >
-      {/* Bars */}
       <div className="flex items-end justify-center gap-[3px] h-5 shrink-0">
         {Array.from({ length: BAR_COUNT }, (_, i) => (
           <div
@@ -124,12 +120,10 @@ export function RecordingOverlay() {
         ))}
       </div>
 
-      {/* Label or timer */}
       <span className="text-[11px] font-mono tabular-nums select-none" style={{ color: 'var(--color-base-50)' }}>
         {label || `${minutes}:${seconds}`}
       </span>
 
-      {/* Stop button — only during recording */}
       {status === 'recording' && (
         <button
           onMouseDown={(e) => e.preventDefault()}

--- a/apps/frontend/components/editor/RecordingOverlay.tsx
+++ b/apps/frontend/components/editor/RecordingOverlay.tsx
@@ -1,10 +1,28 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Square } from 'lucide-react';
 import { useDictationStore } from '@/stores/dictationStore';
+import { getAnalyserNode } from '@/stores/dictationStore';
+
+const BAR_COUNT = 9;
+const NOISE_GATE = 0.22;
+const SMOOTHING = 0.82;
+const GAIN = 1.4;
+const CURVE = 0.7;
 
 export function RecordingOverlay() {
   const status = useDictationStore((s) => s.status);
+  const stopRecording = useDictationStore((s) => s.stopRecording);
   const [elapsed, setElapsed] = useState(0);
+  const barsRef = useRef<(HTMLDivElement | null)[]>([]);
+  const rafRef = useRef<number>(0);
+  const loadingPhaseRef = useRef(0);
+  const smoothedRef = useRef<number[]>(new Array(BAR_COUNT).fill(0));
 
+  const setBarsRef = useCallback((i: number) => (el: HTMLDivElement | null) => {
+    barsRef.current[i] = el;
+  }, []);
+
+  // Timer
   useEffect(() => {
     if (status !== 'recording') {
       setElapsed(0);
@@ -14,15 +32,115 @@ export function RecordingOverlay() {
     return () => clearInterval(id);
   }, [status]);
 
-  if (status !== 'recording') return null;
+  // Waveform animation
+  useEffect(() => {
+    if (status === 'recording') {
+      const dataArray = new Uint8Array(32);
+      smoothedRef.current.fill(0);
+
+      const animate = () => {
+        const analyser = getAnalyserNode();
+        if (analyser) {
+          analyser.getByteFrequencyData(dataArray);
+
+          for (let i = 0; i < BAR_COUNT; i++) {
+            const raw = dataArray[i + 3] / 255;
+            const gated = raw < NOISE_GATE ? 0 : (raw - NOISE_GATE) / (1 - NOISE_GATE);
+            const shaped = Math.min(1, Math.pow(gated * GAIN, CURVE));
+
+            // Temporal smoothing (like Handy: prev * 0.7 + new * 0.3)
+            smoothedRef.current[i] = smoothedRef.current[i] * SMOOTHING + shaped * (1 - SMOOTHING);
+
+            // Spatial smoothing across neighbors
+            let val = smoothedRef.current[i];
+            if (i > 0 && i < BAR_COUNT - 1) {
+              val = val * 0.7 + smoothedRef.current[i - 1] * 0.15 + smoothedRef.current[i + 1] * 0.15;
+            }
+
+            const bar = barsRef.current[i];
+            if (!bar) continue;
+            const h = Math.min(20, 2 + val * 18);
+            bar.style.height = `${h}px`;
+            bar.style.opacity = `${val < 0.01 ? 0.15 : Math.max(0.3, val)}`;
+          }
+        }
+        rafRef.current = requestAnimationFrame(animate);
+      };
+      rafRef.current = requestAnimationFrame(animate);
+      return () => cancelAnimationFrame(rafRef.current);
+    }
+
+    if (status === 'transcribing' || status === 'post-processing') {
+      const animate = () => {
+        loadingPhaseRef.current += 0.06;
+        for (let i = 0; i < BAR_COUNT; i++) {
+          const bar = barsRef.current[i];
+          if (!bar) continue;
+          const wave = Math.sin(loadingPhaseRef.current + i * 0.7) * 0.5 + 0.5;
+          const h = 3 + wave * 14;
+          bar.style.height = `${h}px`;
+          bar.style.opacity = `${0.3 + wave * 0.5}`;
+        }
+        rafRef.current = requestAnimationFrame(animate);
+      };
+      loadingPhaseRef.current = 0;
+      rafRef.current = requestAnimationFrame(animate);
+      return () => cancelAnimationFrame(animate);
+    }
+  }, [status]);
+
+  const isActive = status === 'recording' || status === 'transcribing' || status === 'post-processing';
+  if (!isActive) return null;
 
   const minutes = String(Math.floor(elapsed / 60)).padStart(2, '0');
   const seconds = String(elapsed % 60).padStart(2, '0');
 
+  const label = status === 'transcribing'
+    ? 'Transcribing'
+    : status === 'post-processing'
+      ? 'Processing'
+      : null;
+
   return (
-    <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-[var(--accent-red-12)] text-[var(--accent-red)] text-xs font-mono pointer-events-none">
-      <span className="size-2 rounded-full bg-current animate-pulse" />
-      {minutes}:{seconds}
+    <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-overlay flex items-center gap-2.5 pl-3 pr-2 py-1.5 rounded-full bg-[var(--color-base-100)] animate-in fade-in duration-300"
+      style={{ minWidth: 160 }}
+    >
+      {/* Bars */}
+      <div className="flex items-end justify-center gap-[3px] h-5 shrink-0">
+        {Array.from({ length: BAR_COUNT }, (_, i) => (
+          <div
+            key={i}
+            ref={setBarsRef(i)}
+            className="w-[5px] rounded-sm"
+            style={{
+              height: '2px',
+              opacity: 0.15,
+              background: 'var(--color-base-00)',
+              transition: status !== 'recording'
+                ? 'height 80ms ease-out, opacity 80ms ease-out'
+                : undefined,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Label or timer */}
+      <span className="text-[11px] font-mono tabular-nums select-none" style={{ color: 'var(--color-base-50)' }}>
+        {label || `${minutes}:${seconds}`}
+      </span>
+
+      {/* Stop button — only during recording */}
+      {status === 'recording' && (
+        <button
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={stopRecording}
+          className="size-6 flex items-center justify-center rounded-full transition-colors duration-100 hover:bg-[var(--color-base-70)] active:scale-95"
+          style={{ color: 'var(--color-base-50)' }}
+          title="Stop dictation"
+        >
+          <Square size={10} fill="currentColor" />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/frontend/components/settings/DictationPostProcessing.tsx
+++ b/apps/frontend/components/settings/DictationPostProcessing.tsx
@@ -17,7 +17,6 @@ export function DictationPostProcessing() {
   const [apiKey, setApiKey] = useState(storePostProcessing.apiKey || '');
   const [baseUrl, setBaseUrl] = useState(storePostProcessing.baseUrl || '');
   const [model, setModel] = useState(storePostProcessing.model);
-  const [showKey, setShowKey] = useState(false);
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const [fillerRemoval, setFillerRemoval] = useState(storePostProcessing.fillerRemoval ?? true);
   const [stutterCollapse, setStutterCollapse] = useState(storePostProcessing.stutterCollapse ?? true);
@@ -188,7 +187,6 @@ export function DictationPostProcessing() {
           apiKey={apiKey}
           baseUrl={baseUrl}
           model={model}
-          showKey={showKey}
           thinking={thinking}
           onProviderChange={handleProviderChange}
           onApiKeyChange={setApiKey}
@@ -197,7 +195,6 @@ export function DictationPostProcessing() {
           onBaseUrlBlur={handleBaseUrlBlur}
           onModelChange={(m: string) => { setModel(m); updatePostProcessing({ model: m }); }}
           onThinkingChange={(v: boolean) => { setThinking(v); updatePostProcessing({ thinking: v }); }}
-          onToggleShowKey={() => setShowKey(!showKey)}
           onClose={() => setModelDialogOpen(false)}
         />
       )}
@@ -210,7 +207,6 @@ interface ProcessingModelDialogProps {
   apiKey: string;
   baseUrl: string;
   model: string;
-  showKey: boolean;
   thinking: boolean;
   onProviderChange: (provider: 'openai' | 'ollama') => void;
   onApiKeyChange: (value: string) => void;
@@ -219,7 +215,6 @@ interface ProcessingModelDialogProps {
   onBaseUrlBlur: () => void;
   onModelChange: (value: string) => void;
   onThinkingChange: (value: boolean) => void;
-  onToggleShowKey: () => void;
   onClose: () => void;
 }
 
@@ -237,7 +232,6 @@ function ProcessingModelDialog({
   apiKey,
   baseUrl,
   model,
-  showKey,
   thinking,
   onProviderChange,
   onApiKeyChange,
@@ -246,10 +240,10 @@ function ProcessingModelDialog({
   onBaseUrlBlur,
   onModelChange,
   onThinkingChange,
-  onToggleShowKey,
   onClose,
 }: ProcessingModelDialogProps) {
   const [tab, setTab] = useState<Tab>('local');
+  const [showKey, setShowKey] = useState(false);
   const [customModel, setCustomModel] = useState('');
   const [localModels, setLocalModels] = useState<LocalOllamaModel[]>([]);
   const [pulling, setPulling] = useState<PullState | null>(null);
@@ -363,7 +357,6 @@ function ProcessingModelDialog({
           Choose an LLM to clean up transcribed text.
         </p>
 
-        {/* ── Tabs + thinking toggle ── */}
         <div className="flex items-center px-5 mb-4">
           <div className="flex gap-1">
             {([['local', 'Local'], ['cloud', 'Cloud']] as const).map(([key, label]) => (
@@ -409,7 +402,6 @@ function ProcessingModelDialog({
           )}
         </div>
 
-        {/* ── Local tab ── */}
         {tab === 'local' && (
           <div className="px-5 pb-5 space-y-5 max-h-[55vh] overflow-y-auto thin-scrollbar">
             {OLLAMA_MODEL_CATEGORIES.map((cat) => {
@@ -466,18 +458,14 @@ function ProcessingModelDialog({
                             : 'border-[var(--border)] hover:border-[var(--border-subtle)] hover:bg-[var(--overlay-10)]',
                         )}
                       >
-                        <div className="flex gap-3">
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <span className="font-medium text-sm text-foreground">{baseName}</span>
-                              {isSelected && (
-                                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
-                                  <Check size={10} />
-                                  Active
-                                </span>
-                              )}
-                            </div>
-                          </div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm text-foreground">{baseName}</span>
+                          {isSelected && (
+                            <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+                              <Check size={10} />
+                              Active
+                            </span>
+                          )}
                         </div>
                         <div className="flex items-center mt-1.5 text-[11px] text-foreground-faint">
                           {m.parameterSize && <span>{m.parameterSize}</span>}
@@ -491,7 +479,6 @@ function ProcessingModelDialog({
               </div>
             )}
 
-            {/* ── Custom model ── */}
             <div>
               <div className="text-[11px] font-medium text-foreground-faint uppercase tracking-wider mb-2">Custom</div>
               <div
@@ -528,7 +515,6 @@ function ProcessingModelDialog({
           </div>
         )}
 
-        {/* ── Cloud tab ── */}
         {tab === 'cloud' && (
           <div className="px-5 pb-5 space-y-4">
             <div>
@@ -544,7 +530,7 @@ function ProcessingModelDialog({
                 />
                 <button
                   type="button"
-                  onClick={onToggleShowKey}
+                  onClick={() => setShowKey(!showKey)}
                   className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-foreground-muted hover:text-foreground transition-colors"
                   aria-label={showKey ? 'Hide API key' : 'Show API key'}
                 >
@@ -625,29 +611,25 @@ function OllamaModelCard({
         isPulling && 'opacity-100 border-[var(--border)]',
       )}
     >
-      <div className="flex gap-3">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-sm text-foreground">{model.label}</span>
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-sm text-foreground">{model.label}</span>
 
-            {isSelected && isPulled && (
-              <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
-                <Check size={10} />
-                Active
-              </span>
-            )}
+        {isSelected && isPulled && (
+          <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+            <Check size={10} />
+            Active
+          </span>
+        )}
 
-            {model.isRecommended && (
-              <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
-                <Star size={10} />
-                Recommended
-              </span>
-            )}
-          </div>
-
-          <p className="text-xs text-foreground-muted mt-0.5">{model.description}</p>
-        </div>
+        {model.isRecommended && (
+          <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+            <Star size={10} />
+            Recommended
+          </span>
+        )}
       </div>
+
+      <p className="text-xs text-foreground-muted mt-0.5">{model.description}</p>
 
       <div className="flex items-center mt-2 text-[11px] text-foreground-faint">
         <span>{model.parameterSize}</span>

--- a/apps/frontend/components/settings/DictationPostProcessing.tsx
+++ b/apps/frontend/components/settings/DictationPostProcessing.tsx
@@ -1,22 +1,12 @@
-import { useEffect, useState } from 'react';
-import { Eye, EyeOff, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Eye, EyeOff, X, Check, Star, Download } from 'lucide-react';
 import { useDictationStore } from '@/stores/dictationStore';
 import { cn } from '@/lib/utils';
 import { ToggleRow } from './FilesSettings';
-
-const PROVIDERS = [
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'ollama', label: 'Ollama' },
-] as const;
-
-const MODEL_PLACEHOLDERS: Record<string, string> = {
-  openai: 'gpt-4o-mini',
-  ollama: 'llama3.2',
-};
-
-const BASE_URL_PLACEHOLDERS: Record<string, string> = {
-  ollama: 'http://localhost:11434',
-};
+import { OLLAMA_MODELS, OLLAMA_MODEL_CATEGORIES } from './ollama-models';
+import { fetchLocalOllamaModels, pullOllamaModel } from '@/lib/ollama-api';
+import type { LocalOllamaModel } from '@/lib/ollama-api';
+import type { OllamaModelInfo, OllamaModelCategory } from '@cushion/types';
 
 export function DictationPostProcessing() {
   const updatePostProcessing = useDictationStore((s) => s.updatePostProcessing);
@@ -37,6 +27,7 @@ export function DictationPostProcessing() {
   const [dictionaryInPrompt, setDictionaryInPrompt] = useState(storePostProcessing.dictionaryInPrompt ?? true);
   const [skipShort, setSkipShort] = useState(storePostProcessing.skipShortTranscriptions ?? true);
   const [shortThreshold, setShortThreshold] = useState(storePostProcessing.shortTextThreshold ?? 3);
+  const [thinking, setThinking] = useState(storePostProcessing.thinking ?? false);
 
   useEffect(() => {
     setEnabled(storePostProcessing.enabled);
@@ -52,13 +43,8 @@ export function DictationPostProcessing() {
     setDictionaryInPrompt(storePostProcessing.dictionaryInPrompt ?? true);
     setSkipShort(storePostProcessing.skipShortTranscriptions ?? true);
     setShortThreshold(storePostProcessing.shortTextThreshold ?? 3);
+    setThinking(storePostProcessing.thinking ?? false);
   }, [storePostProcessing]);
-
-  const handleToggle = () => {
-    const next = !enabled;
-    setEnabled(next);
-    updatePostProcessing({ enabled: next });
-  };
 
   const handleProviderChange = (next: 'openai' | 'ollama') => {
     setProvider(next);
@@ -79,10 +65,6 @@ export function DictationPostProcessing() {
 
   const handleBaseUrlBlur = () => {
     updatePostProcessing({ baseUrl: baseUrl || undefined });
-  };
-
-  const handleModelBlur = () => {
-    updatePostProcessing({ model });
   };
 
   const handleThresholdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -129,27 +111,41 @@ export function DictationPostProcessing() {
         checked={enabled}
         onChange={() => { const next = !enabled; setEnabled(next); updatePostProcessing({ enabled: next }); }}
       />
-      <ToggleRow
-        label="Skip short phrases"
-        description="Skip AI enhancement for very short phrases"
-        checked={skipShort}
-        disabled={!enabled}
-        onChange={() => { const next = !skipShort; setSkipShort(next); updatePostProcessing({ skipShortTranscriptions: next }); }}
-      />
-
-      {enabled && skipShort && (
-        <div className="flex items-center gap-3 py-2 pl-4">
-          <div className="text-sm text-foreground-muted">Word threshold</div>
-          <input
-            type="number"
-            min={1}
-            max={15}
-            value={shortThreshold}
-            onChange={handleThresholdChange}
-            className="w-16 px-2 py-1 text-sm text-center rounded-md bg-surface border border-border text-foreground focus:outline-none focus:border-[var(--accent-primary)]"
-          />
+      <label className={cn('flex items-center justify-between gap-4 py-2', !enabled && 'opacity-40 pointer-events-none')}>
+        <div>
+          <div className="text-sm font-medium">Skip short phrases</div>
+          <div className="text-xs text-foreground-muted flex items-center gap-2">
+            <span>Skip AI enhancement for very short phrases</span>
+            {skipShort && (
+              <span className="inline-flex items-center gap-1">
+                <span className="text-foreground-faint">Threshold</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={15}
+                  value={shortThreshold}
+                  onChange={handleThresholdChange}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-10 px-1 py-0 text-xs text-center rounded bg-surface border border-border text-foreground focus:outline-none focus:border-[var(--accent-primary)]"
+                />
+              </span>
+            )}
+          </div>
         </div>
-      )}
+        <button
+          type="button"
+          role="switch"
+          aria-checked={skipShort}
+          disabled={!enabled}
+          onClick={() => { const next = !skipShort; setSkipShort(next); updatePostProcessing({ skipShortTranscriptions: next }); }}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors',
+            skipShort ? 'bg-[var(--accent-primary)]' : 'bg-[var(--border-subtle)]',
+          )}
+        >
+          <span className={`pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-background transition-transform ${skipShort ? 'translate-x-4' : 'translate-x-0.5'}`} />
+        </button>
+      </label>
 
       <ToggleRow
         label="Include note context"
@@ -170,7 +166,7 @@ export function DictationPostProcessing() {
         <div>
           <div className="text-sm font-medium">Processing Model</div>
           <div className="text-xs text-foreground-muted">
-            {model || MODEL_PLACEHOLDERS[provider]} — {PROVIDERS.find((p) => p.value === provider)?.label}
+            {model || 'gpt-4o-mini'} — {provider === 'ollama' ? 'Local (Ollama)' : 'Cloud (OpenAI)'}
           </div>
         </div>
         <button
@@ -188,19 +184,19 @@ export function DictationPostProcessing() {
 
       {modelDialogOpen && (
         <ProcessingModelDialog
-          enabled={enabled}
           provider={provider}
           apiKey={apiKey}
           baseUrl={baseUrl}
           model={model}
           showKey={showKey}
+          thinking={thinking}
           onProviderChange={handleProviderChange}
           onApiKeyChange={setApiKey}
           onApiKeyBlur={handleApiKeyBlur}
           onBaseUrlChange={setBaseUrl}
           onBaseUrlBlur={handleBaseUrlBlur}
-          onModelChange={setModel}
-          onModelBlur={handleModelBlur}
+          onModelChange={(m: string) => { setModel(m); updatePostProcessing({ model: m }); }}
+          onThinkingChange={(v: boolean) => { setThinking(v); updatePostProcessing({ thinking: v }); }}
           onToggleShowKey={() => setShowKey(!showKey)}
           onClose={() => setModelDialogOpen(false)}
         />
@@ -210,40 +206,76 @@ export function DictationPostProcessing() {
 }
 
 interface ProcessingModelDialogProps {
-  enabled: boolean;
   provider: string;
   apiKey: string;
   baseUrl: string;
   model: string;
   showKey: boolean;
+  thinking: boolean;
   onProviderChange: (provider: 'openai' | 'ollama') => void;
   onApiKeyChange: (value: string) => void;
   onApiKeyBlur: () => void;
   onBaseUrlChange: (value: string) => void;
   onBaseUrlBlur: () => void;
   onModelChange: (value: string) => void;
-  onModelBlur: () => void;
+  onThinkingChange: (value: boolean) => void;
   onToggleShowKey: () => void;
   onClose: () => void;
 }
 
+type Tab = 'local' | 'cloud';
+
+interface PullState {
+  model: string;
+  percent: number;
+  status: string;
+  error?: string;
+}
+
 function ProcessingModelDialog({
-  enabled,
   provider,
   apiKey,
   baseUrl,
   model,
   showKey,
+  thinking,
   onProviderChange,
   onApiKeyChange,
   onApiKeyBlur,
   onBaseUrlChange,
   onBaseUrlBlur,
   onModelChange,
-  onModelBlur,
+  onThinkingChange,
   onToggleShowKey,
   onClose,
 }: ProcessingModelDialogProps) {
+  const [tab, setTab] = useState<Tab>('local');
+  const [customModel, setCustomModel] = useState('');
+  const [localModels, setLocalModels] = useState<LocalOllamaModel[]>([]);
+  const [pulling, setPulling] = useState<PullState | null>(null);
+  const cancelRef = useRef<(() => void) | null>(null);
+
+  const pulledNames = new Set(localModels.map((m) => m.name));
+  for (const m of localModels) {
+    pulledNames.add(m.name.replace(/:latest$/, ''));
+  }
+
+  const curatedIds = new Set(OLLAMA_MODELS.map((m) => m.id));
+  const extraModels = localModels.filter((m) => {
+    const base = m.name.replace(/:latest$/, '');
+    return !curatedIds.has(m.name) && !curatedIds.has(base);
+  });
+
+  const isCustom = provider === 'ollama' && !OLLAMA_MODELS.some((m) => m.id === model) && !extraModels.some((m) => m.name === model || m.name.replace(/:latest$/, '') === model);
+
+  useEffect(() => {
+    if (isCustom && model) setCustomModel(model);
+  }, []);
+
+  useEffect(() => {
+    fetchLocalOllamaModels().then(setLocalModels);
+  }, []);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -252,16 +284,72 @@ function ProcessingModelDialog({
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
+  const handlePull = (modelId: string) => {
+    setPulling({ model: modelId, percent: 0, status: 'pulling manifest' });
+    const { cancel, done } = pullOllamaModel(modelId, (p) => {
+      if (p.error) {
+        setPulling({ model: modelId, percent: 0, status: 'error', error: p.error });
+      } else {
+        setPulling({ model: modelId, percent: p.percent, status: p.status });
+      }
+    });
+    cancelRef.current = cancel;
+    done.then((ok) => {
+      cancelRef.current = null;
+      if (ok) {
+        setPulling(null);
+        fetchLocalOllamaModels().then(setLocalModels);
+        handleSelectLocal(modelId);
+      } else {
+        setPulling((prev) => prev?.error ? prev : null);
+      }
+    });
+  };
+
+  const handleCancelPull = () => {
+    cancelRef.current?.();
+    setPulling(null);
+    cancelRef.current = null;
+  };
+
+  const handleSelectLocal = (modelId: string) => {
+    onProviderChange('ollama');
+    onModelChange(modelId);
+    setCustomModel('');
+  };
+
+  const handleSelectCustom = () => {
+    onProviderChange('ollama');
+    const value = customModel.trim() || model;
+    onModelChange(value);
+  };
+
+  const handleCustomBlur = () => {
+    if (customModel.trim()) {
+      onProviderChange('ollama');
+      onModelChange(customModel.trim());
+    }
+  };
+
+  const handleSelectCloud = (cloudModel: string) => {
+    onProviderChange('openai');
+    onModelChange(cloudModel);
+  };
+
+  const grouped = new Map<OllamaModelCategory, OllamaModelInfo[]>();
+  for (const cat of OLLAMA_MODEL_CATEGORIES) grouped.set(cat, []);
+  for (const m of OLLAMA_MODELS) grouped.get(m.category)?.push(m);
+
   return (
     <div
-      className="fixed inset-0 z-confirm flex items-start justify-center pt-[15%] bg-[var(--overlay-50)]"
+      className="fixed inset-0 z-confirm flex items-start justify-center pt-[10%] bg-[var(--overlay-50)]"
       onClick={onClose}
     >
       <div
-        className="bg-modal-bg rounded-lg w-[460px] max-w-[90%] flex flex-col shadow-lg animate-slide-in border border-modal-border"
+        className="bg-modal-bg rounded-lg w-[520px] max-w-[90%] flex flex-col shadow-lg animate-slide-in border border-modal-border"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-5 pt-5 pb-3">
+        <div className="flex items-center justify-between px-5 pt-5 pb-2">
           <h3 className="text-base font-semibold text-foreground">Processing Model</h3>
           <button
             className="p-1 rounded cursor-pointer flex items-center justify-center text-foreground-muted hover:bg-[var(--overlay-10)] hover:text-foreground transition-all"
@@ -271,47 +359,178 @@ function ProcessingModelDialog({
           </button>
         </div>
 
-        <p className="text-xs text-foreground-muted px-5 mb-4">
-          Configure the LLM provider and model used to clean up transcribed text.
+        <p className="text-xs text-foreground-muted px-5 mb-3">
+          Choose an LLM to clean up transcribed text.
         </p>
 
-        <div className="px-5 pb-5 space-y-4">
-          <div>
-            <div className="text-sm font-medium mb-2">Provider</div>
-            <div className="flex gap-1">
-              {PROVIDERS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => onProviderChange(opt.value)}
+        {/* ── Tabs + thinking toggle ── */}
+        <div className="flex items-center px-5 mb-4">
+          <div className="flex gap-1">
+            {([['local', 'Local'], ['cloud', 'Cloud']] as const).map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setTab(key)}
+                className={cn(
+                  'px-3 py-1.5 text-xs rounded-md border transition-colors',
+                  tab === key
+                    ? 'border-[var(--accent-primary)] bg-[var(--accent-primary-12)] text-foreground'
+                    : 'border-border text-foreground-muted hover:text-foreground hover:bg-[var(--overlay-10)]',
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {provider === 'ollama' && OLLAMA_MODELS.find((m) => m.id === model)?.supportsThinking && (
+            <div className="ml-auto flex flex-col items-end gap-0.5">
+              <button
+                type="button"
+                onClick={() => onThinkingChange(!thinking)}
+                className="flex items-center gap-1.5 text-xs text-foreground-muted hover:text-foreground transition-colors"
+              >
+                <span>Thinking</span>
+                <span
                   className={cn(
-                    'px-3 py-1.5 text-xs rounded-md border transition-colors',
-                    provider === opt.value
-                      ? 'border-[var(--accent-primary)] bg-[var(--accent-primary-12)] text-foreground'
-                      : 'border-border text-foreground-muted hover:text-foreground hover:bg-[var(--overlay-10)]',
+                    'relative inline-flex h-4 w-7 items-center rounded-full transition-colors',
+                    thinking ? 'bg-[var(--accent-primary)]' : 'bg-[var(--border-subtle)]',
                   )}
                 >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {provider !== 'openai' && (
-            <div>
-              <label className="block text-sm font-medium mb-1">Base URL</label>
-              <input
-                type="text"
-                value={baseUrl}
-                onChange={(e) => onBaseUrlChange(e.target.value)}
-                onBlur={onBaseUrlBlur}
-                placeholder={BASE_URL_PLACEHOLDERS[provider]}
-                className="w-full px-3 py-2 text-sm rounded-md bg-surface border border-border text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-[var(--accent-primary)]"
-              />
+                  <span
+                    className={cn(
+                      'inline-block h-3 w-3 rounded-full bg-white transition-transform',
+                      thinking ? 'translate-x-[13px]' : 'translate-x-[2px]',
+                    )}
+                  />
+                </span>
+              </button>
+              <span className="text-[10px] text-foreground-faint">Much slower, needs a good GPU</span>
             </div>
           )}
+        </div>
 
-          {provider !== 'ollama' && (
+        {/* ── Local tab ── */}
+        {tab === 'local' && (
+          <div className="px-5 pb-5 space-y-5 max-h-[55vh] overflow-y-auto thin-scrollbar">
+            {OLLAMA_MODEL_CATEGORIES.map((cat) => {
+              const catModels = grouped.get(cat);
+              if (!catModels || catModels.length === 0) return null;
+              return (
+                <div key={cat}>
+                  <div className="text-[11px] font-medium text-foreground-faint uppercase tracking-wider mb-2">{cat}</div>
+                  <div className="space-y-1.5">
+                    {catModels.map((m) => {
+                      const isSelected = provider === 'ollama' && model === m.id;
+                      const isPulled = pulledNames.has(m.id);
+                      const isPulling = pulling?.model === m.id;
+                      return (
+                        <OllamaModelCard
+                          key={m.id}
+                          model={m}
+                          isSelected={isSelected}
+                          isPulled={isPulled}
+                          isPulling={isPulling}
+                          pullPercent={isPulling ? pulling.percent : 0}
+                          pullStatus={isPulling ? pulling.status : ''}
+                          pullError={isPulling ? pulling.error : undefined}
+                          onSelect={() => handleSelectLocal(m.id)}
+                          onPull={() => handlePull(m.id)}
+                          onCancelPull={handleCancelPull}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* ── Extra local models (not in curated list) ── */}
+            {extraModels.length > 0 && (
+              <div>
+                <div className="text-[11px] font-medium text-foreground-faint uppercase tracking-wider mb-2">Installed</div>
+                <div className="space-y-1.5">
+                  {extraModels.map((m) => {
+                    const baseName = m.name.replace(/:latest$/, '');
+                    const isSelected = provider === 'ollama' && (model === m.name || model === baseName);
+                    const sizeLabel = m.sizeMb >= 1000
+                      ? `${(m.sizeMb / 1000).toFixed(1)} GB`
+                      : `${m.sizeMb} MB`;
+                    return (
+                      <div
+                        key={m.name}
+                        onClick={() => handleSelectLocal(baseName)}
+                        className={cn(
+                          'relative rounded-md border px-3.5 py-2.5 transition-all group cursor-pointer',
+                          isSelected
+                            ? 'border-[var(--accent-primary)] bg-[var(--accent-primary-12)]'
+                            : 'border-[var(--border)] hover:border-[var(--border-subtle)] hover:bg-[var(--overlay-10)]',
+                        )}
+                      >
+                        <div className="flex gap-3">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-sm text-foreground">{baseName}</span>
+                              {isSelected && (
+                                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+                                  <Check size={10} />
+                                  Active
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="flex items-center mt-1.5 text-[11px] text-foreground-faint">
+                          {m.parameterSize && <span>{m.parameterSize}</span>}
+                          <span className="flex-1" />
+                          <span>{sizeLabel}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* ── Custom model ── */}
+            <div>
+              <div className="text-[11px] font-medium text-foreground-faint uppercase tracking-wider mb-2">Custom</div>
+              <div
+                onClick={handleSelectCustom}
+                className={cn(
+                  'rounded-md border px-3.5 py-2.5 transition-all cursor-pointer',
+                  isCustom && provider === 'ollama'
+                    ? 'border-[var(--accent-primary)] bg-[var(--accent-primary-12)]'
+                    : 'border-border hover:border-[var(--border-subtle)] hover:bg-[var(--overlay-10)]',
+                )}
+              >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span className="font-medium text-sm text-foreground">Custom Model</span>
+                  {isCustom && provider === 'ollama' && (
+                    <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+                      <Check size={10} />
+                      Active
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-foreground-muted mb-2">Enter any Ollama model name</p>
+                <input
+                  type="text"
+                  value={customModel}
+                  onChange={(e) => setCustomModel(e.target.value)}
+                  onBlur={handleCustomBlur}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleCustomBlur(); }}
+                  placeholder="e.g. mistral:7b"
+                  className="w-full px-3 py-1.5 text-sm rounded-md bg-surface border border-border text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-[var(--accent-primary)]"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ── Cloud tab ── */}
+        {tab === 'cloud' && (
+          <div className="px-5 pb-5 space-y-4">
             <div>
               <label className="block text-sm font-medium mb-1">API Key</label>
               <div className="relative">
@@ -333,21 +552,154 @@ function ProcessingModelDialog({
                 </button>
               </div>
             </div>
-          )}
 
-          <div>
-            <label className="block text-sm font-medium mb-1">Model</label>
-            <input
-              type="text"
-              value={model}
-              onChange={(e) => onModelChange(e.target.value)}
-              onBlur={onModelBlur}
-              placeholder={MODEL_PLACEHOLDERS[provider]}
-              className="w-full px-3 py-2 text-sm rounded-md bg-surface border border-border text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-[var(--accent-primary)]"
-            />
+            <div>
+              <label className="block text-sm font-medium mb-1">Model</label>
+              <input
+                type="text"
+                value={provider === 'openai' ? model : ''}
+                onChange={(e) => handleSelectCloud(e.target.value)}
+                placeholder="gpt-4o-mini"
+                className="w-full px-3 py-2 text-sm rounded-md bg-surface border border-border text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-[var(--accent-primary)]"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Base URL</label>
+              <input
+                type="text"
+                value={baseUrl}
+                onChange={(e) => onBaseUrlChange(e.target.value)}
+                onBlur={onBaseUrlBlur}
+                placeholder="https://api.openai.com/v1/chat/completions"
+                className="w-full px-3 py-2 text-sm rounded-md bg-surface border border-border text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-[var(--accent-primary)]"
+              />
+              <p className="text-[11px] text-foreground-faint mt-1">Leave empty for default OpenAI endpoint</p>
+            </div>
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Ollama model card ── */
+
+function OllamaModelCard({
+  model,
+  isSelected,
+  isPulled,
+  isPulling,
+  pullPercent,
+  pullStatus,
+  pullError,
+  onSelect,
+  onPull,
+  onCancelPull,
+}: {
+  model: OllamaModelInfo;
+  isSelected: boolean;
+  isPulled: boolean;
+  isPulling: boolean;
+  pullPercent: number;
+  pullStatus: string;
+  pullError?: string;
+  onSelect: () => void;
+  onPull: () => void;
+  onCancelPull: () => void;
+}) {
+  const sizeLabel = model.sizeMb >= 1000
+    ? `${(model.sizeMb / 1000).toFixed(1)} GB`
+    : `${model.sizeMb} MB`;
+
+  return (
+    <div
+      onClick={() => isPulled && onSelect()}
+      className={cn(
+        'relative rounded-md border px-3.5 py-2.5 transition-all group',
+        isSelected && isPulled
+          ? 'border-[var(--accent-primary)] bg-[var(--accent-primary-12)]'
+          : isPulled
+            ? 'border-[var(--border)] hover:border-[var(--border-subtle)] hover:bg-[var(--overlay-10)] cursor-pointer'
+            : 'border-[var(--border)] opacity-60',
+        isPulling && 'opacity-100 border-[var(--border)]',
+      )}
+    >
+      <div className="flex gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm text-foreground">{model.label}</span>
+
+            {isSelected && isPulled && (
+              <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+                <Check size={10} />
+                Active
+              </span>
+            )}
+
+            {model.isRecommended && (
+              <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+                <Star size={10} />
+                Recommended
+              </span>
+            )}
+          </div>
+
+          <p className="text-xs text-foreground-muted mt-0.5">{model.description}</p>
         </div>
       </div>
+
+      <div className="flex items-center mt-2 text-[11px] text-foreground-faint">
+        <span>{model.parameterSize}</span>
+        <span className="flex-1" />
+
+        {isPulling ? (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onCancelPull(); }}
+            className="inline-flex items-center gap-1 text-foreground-muted hover:text-foreground transition-colors"
+            aria-label="Cancel download"
+          >
+            <X size={12} />
+            Cancel
+          </button>
+        ) : isPulled ? (
+          <span className="inline-flex items-center gap-1 text-foreground-faint">
+            <Check size={11} />
+            Installed
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onPull(); }}
+            className="inline-flex items-center gap-1 text-foreground-muted hover:text-foreground transition-colors cursor-pointer"
+            aria-label={`Download ${model.label}`}
+          >
+            <Download size={11} />
+            {sizeLabel}
+          </button>
+        )}
+      </div>
+
+      {isPulling && !pullError && (
+        <div className="mt-2">
+          <div className="h-1 rounded-full bg-[var(--border-subtle)] overflow-hidden">
+            <div
+              className="h-full bg-[var(--accent-primary)] transition-all duration-300"
+              style={{ width: `${pullPercent}%` }}
+            />
+          </div>
+          <div className="flex items-center gap-2 mt-0.5">
+            <span className="text-[10px] text-foreground-faint">
+              {pullPercent > 0 ? `${pullPercent}%` : pullStatus || 'Starting...'}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {pullError && (
+        <p className="mt-1.5 text-[11px] text-[var(--error)]">{pullError.trim()}</p>
+      )}
     </div>
   );
 }

--- a/apps/frontend/components/settings/DictationPostProcessing.tsx
+++ b/apps/frontend/components/settings/DictationPostProcessing.tsx
@@ -10,43 +10,18 @@ import type { OllamaModelInfo, OllamaModelCategory } from '@cushion/types';
 
 export function DictationPostProcessing() {
   const updatePostProcessing = useDictationStore((s) => s.updatePostProcessing);
-  const storePostProcessing = useDictationStore((s) => s.postProcessing);
+  const pp = useDictationStore((s) => s.postProcessing);
 
-  const [enabled, setEnabled] = useState(storePostProcessing.enabled);
-  const [provider, setProvider] = useState(storePostProcessing.provider);
-  const [apiKey, setApiKey] = useState(storePostProcessing.apiKey || '');
-  const [baseUrl, setBaseUrl] = useState(storePostProcessing.baseUrl || '');
-  const [model, setModel] = useState(storePostProcessing.model);
+  const [apiKey, setApiKey] = useState(pp.apiKey || '');
+  const [baseUrl, setBaseUrl] = useState(pp.baseUrl || '');
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
-  const [fillerRemoval, setFillerRemoval] = useState(storePostProcessing.fillerRemoval ?? true);
-  const [stutterCollapse, setStutterCollapse] = useState(storePostProcessing.stutterCollapse ?? true);
-  const [includeNoteContext, setIncludeNoteContext] = useState(storePostProcessing.includeNoteContext ?? true);
-  const [autoLearnCorrections, setAutoLearnCorrections] = useState(storePostProcessing.autoLearnCorrections ?? true);
-  const [fuzzyCorrection, setFuzzyCorrection] = useState(storePostProcessing.fuzzyCorrection ?? true);
-  const [dictionaryInPrompt, setDictionaryInPrompt] = useState(storePostProcessing.dictionaryInPrompt ?? true);
-  const [skipShort, setSkipShort] = useState(storePostProcessing.skipShortTranscriptions ?? true);
-  const [shortThreshold, setShortThreshold] = useState(storePostProcessing.shortTextThreshold ?? 3);
-  const [thinking, setThinking] = useState(storePostProcessing.thinking ?? false);
 
   useEffect(() => {
-    setEnabled(storePostProcessing.enabled);
-    setProvider(storePostProcessing.provider);
-    setApiKey(storePostProcessing.apiKey || '');
-    setBaseUrl(storePostProcessing.baseUrl || '');
-    setModel(storePostProcessing.model);
-    setFillerRemoval(storePostProcessing.fillerRemoval ?? true);
-    setStutterCollapse(storePostProcessing.stutterCollapse ?? true);
-    setIncludeNoteContext(storePostProcessing.includeNoteContext ?? true);
-    setAutoLearnCorrections(storePostProcessing.autoLearnCorrections ?? true);
-    setFuzzyCorrection(storePostProcessing.fuzzyCorrection ?? true);
-    setDictionaryInPrompt(storePostProcessing.dictionaryInPrompt ?? true);
-    setSkipShort(storePostProcessing.skipShortTranscriptions ?? true);
-    setShortThreshold(storePostProcessing.shortTextThreshold ?? 3);
-    setThinking(storePostProcessing.thinking ?? false);
-  }, [storePostProcessing]);
+    setApiKey(pp.apiKey || '');
+    setBaseUrl(pp.baseUrl || '');
+  }, [pp]);
 
   const handleProviderChange = (next: 'openai' | 'ollama') => {
-    setProvider(next);
     const updates: Record<string, unknown> = { provider: next };
     if (next === 'ollama') {
       setBaseUrl('http://localhost:11434');
@@ -68,7 +43,6 @@ export function DictationPostProcessing() {
 
   const handleThresholdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = Math.max(1, Math.min(15, Number(e.target.value) || 1));
-    setShortThreshold(val);
     updatePostProcessing({ shortTextThreshold: val });
   };
 
@@ -79,20 +53,20 @@ export function DictationPostProcessing() {
       <ToggleRow
         label="Remove filler words"
         description="Remove uh, um, hmm and similar filler sounds"
-        checked={fillerRemoval}
-        onChange={() => { const next = !fillerRemoval; setFillerRemoval(next); updatePostProcessing({ fillerRemoval: next }); }}
+        checked={pp.fillerRemoval}
+        onChange={() => updatePostProcessing({ fillerRemoval: !pp.fillerRemoval })}
       />
       <ToggleRow
         label="Collapse stutters"
         description="Collapse repeated words (e.g. no no no → no)"
-        checked={stutterCollapse}
-        onChange={() => { const next = !stutterCollapse; setStutterCollapse(next); updatePostProcessing({ stutterCollapse: next }); }}
+        checked={pp.stutterCollapse}
+        onChange={() => updatePostProcessing({ stutterCollapse: !pp.stutterCollapse })}
       />
       <ToggleRow
         label="Auto-learn corrections"
         description="Learn new words when you edit dictated text"
-        checked={autoLearnCorrections}
-        onChange={() => { const next = !autoLearnCorrections; setAutoLearnCorrections(next); updatePostProcessing({ autoLearnCorrections: next }); }}
+        checked={pp.autoLearnCorrections}
+        onChange={() => updatePostProcessing({ autoLearnCorrections: !pp.autoLearnCorrections })}
       />
 
       <h3 className="text-xs uppercase tracking-wide text-foreground-faint mb-3 mt-6">Post-Processing</h3>
@@ -100,29 +74,29 @@ export function DictationPostProcessing() {
       <ToggleRow
         label="Fuzzy correction"
         description="Auto-correct words using your dictionary"
-        checked={fuzzyCorrection}
-        onChange={() => { const next = !fuzzyCorrection; setFuzzyCorrection(next); updatePostProcessing({ fuzzyCorrection: next }); }}
+        checked={pp.fuzzyCorrection}
+        onChange={() => updatePostProcessing({ fuzzyCorrection: !pp.fuzzyCorrection })}
       />
 
       <ToggleRow
         label="AI post-processing"
         description="Clean up transcribed text with an LLM"
-        checked={enabled}
-        onChange={() => { const next = !enabled; setEnabled(next); updatePostProcessing({ enabled: next }); }}
+        checked={pp.enabled}
+        onChange={() => updatePostProcessing({ enabled: !pp.enabled })}
       />
-      <label className={cn('flex items-center justify-between gap-4 py-2', !enabled && 'opacity-40 pointer-events-none')}>
+      <label className={cn('flex items-center justify-between gap-4 py-2', !pp.enabled && 'opacity-40 pointer-events-none')}>
         <div>
           <div className="text-sm font-medium">Skip short phrases</div>
           <div className="text-xs text-foreground-muted flex items-center gap-2">
             <span>Skip AI enhancement for very short phrases</span>
-            {skipShort && (
+            {pp.skipShortTranscriptions && (
               <span className="inline-flex items-center gap-1">
                 <span className="text-foreground-faint">Threshold</span>
                 <input
                   type="number"
                   min={1}
                   max={15}
-                  value={shortThreshold}
+                  value={pp.shortTextThreshold}
                   onChange={handleThresholdChange}
                   onClick={(e) => e.stopPropagation()}
                   className="w-10 px-1 py-0 text-xs text-center rounded bg-surface border border-border text-foreground focus:outline-none focus:border-[var(--accent-primary)]"
@@ -134,47 +108,47 @@ export function DictationPostProcessing() {
         <button
           type="button"
           role="switch"
-          aria-checked={skipShort}
-          disabled={!enabled}
-          onClick={() => { const next = !skipShort; setSkipShort(next); updatePostProcessing({ skipShortTranscriptions: next }); }}
+          aria-checked={pp.skipShortTranscriptions}
+          disabled={!pp.enabled}
+          onClick={() => updatePostProcessing({ skipShortTranscriptions: !pp.skipShortTranscriptions })}
           className={cn(
             'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors',
-            skipShort ? 'bg-[var(--accent-primary)]' : 'bg-[var(--border-subtle)]',
+            pp.skipShortTranscriptions ? 'bg-[var(--accent-primary)]' : 'bg-[var(--border-subtle)]',
           )}
         >
-          <span className={`pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-background transition-transform ${skipShort ? 'translate-x-4' : 'translate-x-0.5'}`} />
+          <span className={`pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-background transition-transform ${pp.skipShortTranscriptions ? 'translate-x-4' : 'translate-x-0.5'}`} />
         </button>
       </label>
 
       <ToggleRow
         label="Include note context"
         description="Send surrounding text to match tone and style"
-        checked={includeNoteContext}
-        disabled={!enabled}
-        onChange={() => { const next = !includeNoteContext; setIncludeNoteContext(next); updatePostProcessing({ includeNoteContext: next }); }}
+        checked={pp.includeNoteContext ?? true}
+        disabled={!pp.enabled}
+        onChange={() => updatePostProcessing({ includeNoteContext: !(pp.includeNoteContext ?? true) })}
       />
       <ToggleRow
         label="Use dictionary with AI"
         description="Include custom dictionary in the AI prompt"
-        checked={dictionaryInPrompt}
-        disabled={!enabled}
-        onChange={() => { const next = !dictionaryInPrompt; setDictionaryInPrompt(next); updatePostProcessing({ dictionaryInPrompt: next }); }}
+        checked={pp.dictionaryInPrompt}
+        disabled={!pp.enabled}
+        onChange={() => updatePostProcessing({ dictionaryInPrompt: !pp.dictionaryInPrompt })}
       />
 
-      <div className={cn("flex items-center justify-between mt-3", !enabled && "opacity-40")}>
+      <div className={cn("flex items-center justify-between mt-3", !pp.enabled && "opacity-40")}>
         <div>
           <div className="text-sm font-medium">Processing Model</div>
           <div className="text-xs text-foreground-muted">
-            {model || 'gpt-4o-mini'} — {provider === 'ollama' ? 'Local (Ollama)' : 'Cloud (OpenAI)'}
+            {pp.model || 'gpt-4o-mini'} — {pp.provider === 'ollama' ? 'Local (Ollama)' : 'Cloud (OpenAI)'}
           </div>
         </div>
         <button
           type="button"
-          disabled={!enabled}
+          disabled={!pp.enabled}
           onClick={() => setModelDialogOpen(true)}
           className={cn(
             'text-xs text-foreground-muted hover:text-foreground transition-colors px-3 py-1.5 rounded-md border border-border hover:bg-background-secondary',
-            !enabled && 'opacity-40 cursor-not-allowed',
+            !pp.enabled && 'opacity-40 cursor-not-allowed',
           )}
         >
           Manage
@@ -183,18 +157,18 @@ export function DictationPostProcessing() {
 
       {modelDialogOpen && (
         <ProcessingModelDialog
-          provider={provider}
+          provider={pp.provider}
           apiKey={apiKey}
           baseUrl={baseUrl}
-          model={model}
-          thinking={thinking}
+          model={pp.model}
+          thinking={pp.thinking ?? false}
           onProviderChange={handleProviderChange}
           onApiKeyChange={setApiKey}
           onApiKeyBlur={handleApiKeyBlur}
           onBaseUrlChange={setBaseUrl}
           onBaseUrlBlur={handleBaseUrlBlur}
-          onModelChange={(m: string) => { setModel(m); updatePostProcessing({ model: m }); }}
-          onThinkingChange={(v: boolean) => { setThinking(v); updatePostProcessing({ thinking: v }); }}
+          onModelChange={(m: string) => updatePostProcessing({ model: m })}
+          onThinkingChange={(v: boolean) => updatePostProcessing({ thinking: v })}
           onClose={() => setModelDialogOpen(false)}
         />
       )}

--- a/apps/frontend/components/settings/ollama-models.ts
+++ b/apps/frontend/components/settings/ollama-models.ts
@@ -1,0 +1,81 @@
+import type { OllamaModelInfo, OllamaModelCategory } from '@cushion/types';
+
+export const OLLAMA_MODEL_CATEGORIES: OllamaModelCategory[] = ['Gemma', 'Qwen', 'NVIDIA'];
+
+export const OLLAMA_MODELS: OllamaModelInfo[] = [
+  // Qwen 3.5
+  {
+    id: 'qwen3.5:0.8b',
+    label: 'Qwen 3.5 0.8B',
+    category: 'Qwen',
+    parameterSize: '0.8B',
+    sizeMb: 1000,
+    description: 'Small but capable Qwen3.5 model',
+    supportsThinking: true,
+  },
+  {
+    id: 'qwen3.5:2b',
+    label: 'Qwen 3.5 2B',
+    category: 'Qwen',
+    parameterSize: '2B',
+    sizeMb: 2700,
+    description: 'Small Qwen3.5 for quick tasks',
+    supportsThinking: true,
+  },
+  {
+    id: 'qwen3.5:4b',
+    label: 'Qwen 3.5 4B',
+    category: 'Qwen',
+    parameterSize: '4B',
+    sizeMb: 3400,
+    description: 'Balanced Qwen3.5 for general use',
+    supportsThinking: true,
+  },
+  {
+    id: 'qwen3.5:9b',
+    label: 'Qwen 3.5 9B',
+    category: 'Qwen',
+    parameterSize: '9B',
+    sizeMb: 6600,
+    description: 'Powerful hybrid model',
+    supportsThinking: true,
+  },
+
+  // Gemma 3
+  {
+    id: 'gemma3:1b',
+    label: 'Gemma 3 1B',
+    category: 'Gemma',
+    parameterSize: '1B',
+    sizeMb: 815,
+    description: 'Ultra-fast Google model, best for short dictation cleanup',
+  },
+  {
+    id: 'gemma3:4b',
+    label: 'Gemma 3 4B',
+    category: 'Gemma',
+    parameterSize: '4B',
+    sizeMb: 3300,
+    description: "Google's open-weight model, great balance of speed and quality",
+    isRecommended: true,
+  },
+  {
+    id: 'gemma3:12b',
+    label: 'Gemma 3 12B',
+    category: 'Gemma',
+    parameterSize: '12B',
+    sizeMb: 8100,
+    description: "Google's mid-range model, strong reasoning",
+  },
+
+  // NVIDIA
+  {
+    id: 'nemotron-3-nano:4b',
+    label: 'Nemotron 3 Nano 4B',
+    category: 'NVIDIA',
+    parameterSize: '4B',
+    sizeMb: 2800,
+    description: 'Efficient, open, and intelligent agentic model',
+    supportsThinking: true,
+  },
+];

--- a/apps/frontend/lib/ollama-api.ts
+++ b/apps/frontend/lib/ollama-api.ts
@@ -55,7 +55,6 @@ export function pullOllamaModel(
       let buffer = '';
       let lastStatus = '';
       let success = false;
-      let lineCount = 0;
 
       while (true) {
         const { done: streamDone, value } = await reader.read();
@@ -67,7 +66,6 @@ export function pullOllamaModel(
 
         for (const line of lines) {
           if (!line.trim()) continue;
-          lineCount++;
           try {
             const json = JSON.parse(line);
             if (json.error) {
@@ -80,7 +78,7 @@ export function pullOllamaModel(
             const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
             onProgress({ status: lastStatus, total, completed, percent });
             if (lastStatus === 'success') success = true;
-          } catch { /* skip malformed lines */ }
+          } catch {}
         }
       }
 

--- a/apps/frontend/lib/ollama-api.ts
+++ b/apps/frontend/lib/ollama-api.ts
@@ -1,0 +1,95 @@
+const OLLAMA_BASE = 'http://localhost:11434';
+
+export interface LocalOllamaModel {
+  name: string;
+  sizeMb: number;
+  parameterSize: string;
+}
+
+export async function fetchLocalOllamaModels(baseUrl = OLLAMA_BASE): Promise<LocalOllamaModel[]> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    const models: LocalOllamaModel[] = [];
+    for (const m of data.models ?? []) {
+      models.push({
+        name: m.name as string,
+        sizeMb: Math.round((m.size as number) / (1024 * 1024)),
+        parameterSize: (m.details?.parameter_size as string) ?? '',
+      });
+    }
+    return models;
+  } catch {
+    return [];
+  }
+}
+
+export interface PullProgress {
+  status: string;
+  error?: string;
+  total?: number;
+  completed?: number;
+  percent: number;
+}
+
+export function pullOllamaModel(
+  modelId: string,
+  onProgress: (p: PullProgress) => void,
+  baseUrl = OLLAMA_BASE,
+): { cancel: () => void; done: Promise<boolean> } {
+  const controller = new AbortController();
+
+  const done = (async () => {
+    try {
+      const res = await fetch(`${baseUrl}/api/pull`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: modelId, stream: true }),
+        signal: controller.signal,
+      });
+      if (!res.ok || !res.body) return false;
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let lastStatus = '';
+      let success = false;
+      let lineCount = 0;
+
+      while (true) {
+        const { done: streamDone, value } = await reader.read();
+        if (streamDone) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          lineCount++;
+          try {
+            const json = JSON.parse(line);
+            if (json.error) {
+              onProgress({ status: 'error', error: json.error, percent: 0 });
+              return false;
+            }
+            lastStatus = json.status ?? '';
+            const total = json.total ?? 0;
+            const completed = json.completed ?? 0;
+            const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+            onProgress({ status: lastStatus, total, completed, percent });
+            if (lastStatus === 'success') success = true;
+          } catch { /* skip malformed lines */ }
+        }
+      }
+
+      return success || lastStatus.includes('up to date');
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return false;
+      return false;
+    }
+  })();
+
+  return { cancel: () => controller.abort(), done };
+}

--- a/apps/frontend/lib/ollama-api.ts
+++ b/apps/frontend/lib/ollama-api.ts
@@ -83,8 +83,7 @@ export function pullOllamaModel(
       }
 
       return success || lastStatus.includes('up to date');
-    } catch (err) {
-      if ((err as Error).name === 'AbortError') return false;
+    } catch {
       return false;
     }
   })();

--- a/apps/frontend/stores/dictationStore.ts
+++ b/apps/frontend/stores/dictationStore.ts
@@ -68,6 +68,7 @@ let coordinatorClient: CoordinatorClient | null = null;
 let mediaStream: MediaStream | null = null;
 let audioContext: AudioContext | null = null;
 let workletNode: AudioWorkletNode | null = null;
+let analyserNode: AnalyserNode | null = null;
 let insertTextCallback: ((text: string) => { from: number; to: number } | void) | null = null;
 let getNoteContextCallback: (() => string) | null = null;
 let onTextInsertedCallback: ((originalText: string, from: number, to: number) => void) | null = null;
@@ -95,7 +96,15 @@ export function setOnTextInsertedCallback(cb: ((originalText: string, from: numb
   onTextInsertedCallback = cb;
 }
 
+export function getAnalyserNode(): AnalyserNode | null {
+  return analyserNode;
+}
+
 function cleanupMedia() {
+  if (analyserNode) {
+    try { analyserNode.disconnect(); } catch {}
+    analyserNode = null;
+  }
   if (workletNode) {
     try { workletNode.disconnect(); } catch {}
     workletNode = null;
@@ -441,6 +450,11 @@ export const useDictationStore = create<DictationState>()(
         processorOptions: { sampleRate: nativeSampleRate },
       });
 
+      analyserNode = audioContext.createAnalyser();
+      analyserNode.fftSize = 64;
+      analyserNode.smoothingTimeConstant = 0.4;
+      source.connect(analyserNode);
+
       workletNode.port.onmessage = async (e: MessageEvent<{ samples: ArrayBuffer }>) => {
         set({ status: 'transcribing' });
         cleanupMedia();
@@ -485,7 +499,7 @@ export const useDictationStore = create<DictationState>()(
                 insertTextIntoElement(target, finalText);
               }
             }
-          } catch {
+          } catch (ppErr) {
             const fallbackText = rawText;
             if (isCodeMirror && insertTextCallback) {
               const range = insertTextCallback(fallbackText);
@@ -495,6 +509,13 @@ export const useDictationStore = create<DictationState>()(
             } else if (target && !isCodeMirror) {
               insertTextIntoElement(target, fallbackText);
             }
+            const isTimeout = ppErr instanceof Error && ppErr.message.includes('timed out');
+            showGlobalToast({
+              description: isTimeout
+                ? 'Post-processing timed out — raw text inserted'
+                : 'Post-processing failed — raw text inserted',
+              variant: 'default',
+            });
           }
 
           set({ status: 'idle', error: null });

--- a/apps/frontend/stores/dictationStore.ts
+++ b/apps/frontend/stores/dictationStore.ts
@@ -500,14 +500,13 @@ export const useDictationStore = create<DictationState>()(
               }
             }
           } catch (ppErr) {
-            const fallbackText = rawText;
             if (isCodeMirror && insertTextCallback) {
-              const range = insertTextCallback(fallbackText);
+              const range = insertTextCallback(rawText);
               if (range && get().postProcessing.autoLearnCorrections && onTextInsertedCallback) {
-                onTextInsertedCallback(fallbackText, range.from, range.to);
+                onTextInsertedCallback(rawText, range.from, range.to);
               }
             } else if (target && !isCodeMirror) {
-              insertTextIntoElement(target, fallbackText);
+              insertTextIntoElement(target, rawText);
             }
             const isTimeout = ppErr instanceof Error && ppErr.message.includes('timed out');
             showGlobalToast({

--- a/apps/frontend/stores/dictationStore.ts
+++ b/apps/frontend/stores/dictationStore.ts
@@ -74,15 +74,7 @@ let getNoteContextCallback: (() => string) | null = null;
 let onTextInsertedCallback: ((originalText: string, from: number, to: number) => void) | null = null;
 let dictationConfig: DictationConfig | null = null;
 let recordingFocusTarget: FocusTarget | null = null;
-let serverStatusCleanup: (() => void) | null = null;
-let downloadProgressCleanup: (() => void) | null = null;
-let downloadCompleteCleanup: (() => void) | null = null;
-let downloadErrorCleanup: (() => void) | null = null;
-let hotkeyPressedCleanup: (() => void) | null = null;
-let hotkeyFailedCleanup: (() => void) | null = null;
-let gpuDownloadProgressCleanup: (() => void) | null = null;
-let gpuDownloadCompleteCleanup: (() => void) | null = null;
-let gpuDownloadErrorCleanup: (() => void) | null = null;
+let listenerCleanups: Array<() => void> = [];
 
 export function setInsertTextCallback(cb: ((text: string) => { from: number; to: number } | void) | null) {
   insertTextCallback = cb;
@@ -128,7 +120,7 @@ export const useDictationStore = create<DictationState>()(
     selectedModel: 'parakeet-v3',
     downloadProgress: null,
     settingsLoaded: false,
-    postProcessing: { enabled: false, provider: 'openai', apiKey: '', model: 'gpt-4o-mini', fillerRemoval: true, stutterCollapse: true, includeNoteContext: true, autoLearnCorrections: true, skipShortTranscriptions: true, shortTextThreshold: 3 } as DictationConfig['postProcessing'],
+    postProcessing: { enabled: false, provider: 'openai', apiKey: '', model: 'gpt-4o-mini', fillerRemoval: true, stutterCollapse: true, includeNoteContext: true, autoLearnCorrections: true, fuzzyCorrection: true, dictionaryInPrompt: true, skipShortTranscriptions: true, shortTextThreshold: 3 } as DictationConfig['postProcessing'],
     dictionary: [],
     hotkey: 'Control+D',
     enabled: false,
@@ -142,79 +134,42 @@ export const useDictationStore = create<DictationState>()(
     setClient: (client) => {
       coordinatorClient = client;
 
-      if (serverStatusCleanup) serverStatusCleanup();
-      serverStatusCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/server-status-changed',
-        (data: DictationServerInfo) => {
-          set({ serverStatus: data.status });
-        },
-      );
+      for (const cleanup of listenerCleanups) cleanup();
+      listenerCleanups = [];
 
-      if (downloadProgressCleanup) downloadProgressCleanup();
-      downloadProgressCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/download-progress',
-        (data: DownloadProgress) => {
-          set({ downloadProgress: data });
-        },
-      );
+      const on = (channel: string, handler: (...args: any[]) => void) => {
+        listenerCleanups.push(window.electronAPI.onCoordinatorNotification(channel, handler));
+      };
 
-      if (downloadCompleteCleanup) downloadCompleteCleanup();
-      downloadCompleteCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/download-complete',
-        () => {
-          set({ downloadProgress: null });
-          get().refreshModels();
-        },
-      );
-
-      if (downloadErrorCleanup) downloadErrorCleanup();
-      downloadErrorCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/download-error',
-        () => {
-          set({ downloadProgress: null });
-        },
-      );
-
-      if (hotkeyPressedCleanup) hotkeyPressedCleanup();
-      hotkeyPressedCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/hotkey-pressed',
-        () => {
-          get().toggleRecording();
-        },
-      );
-
-      if (hotkeyFailedCleanup) hotkeyFailedCleanup();
-      hotkeyFailedCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/hotkey-registration-failed',
-        (data: { hotkey: string; error: string }) => {
-          showGlobalToast({ description: `Hotkey registration failed: ${data.error}`, variant: 'error' });
-        },
-      );
-
-      if (gpuDownloadProgressCleanup) gpuDownloadProgressCleanup();
-      gpuDownloadProgressCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/gpu-binary-download-progress',
-        (data: GpuDownloadProgress) => {
-          set({ gpuBinaryDownloadProgress: data });
-        },
-      );
-
-      if (gpuDownloadCompleteCleanup) gpuDownloadCompleteCleanup();
-      gpuDownloadCompleteCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/gpu-binary-download-complete',
-        () => {
-          set({ gpuBinaryDownloading: false, gpuBinaryDownloaded: true, gpuBinaryDownloadProgress: null });
-        },
-      );
-
-      if (gpuDownloadErrorCleanup) gpuDownloadErrorCleanup();
-      gpuDownloadErrorCleanup = window.electronAPI.onCoordinatorNotification(
-        'dictation/gpu-binary-download-error',
-        (data: { error: string }) => {
-          set({ gpuBinaryDownloading: false, gpuBinaryDownloadProgress: null });
-          showGlobalToast({ description: `GPU binary download failed: ${data.error}`, variant: 'error' });
-        },
-      );
+      on('dictation/server-status-changed', (data: DictationServerInfo) => {
+        set({ serverStatus: data.status });
+      });
+      on('dictation/download-progress', (data: DownloadProgress) => {
+        set({ downloadProgress: data });
+      });
+      on('dictation/download-complete', () => {
+        set({ downloadProgress: null });
+        get().refreshModels();
+      });
+      on('dictation/download-error', () => {
+        set({ downloadProgress: null });
+      });
+      on('dictation/hotkey-pressed', () => {
+        get().toggleRecording();
+      });
+      on('dictation/hotkey-registration-failed', (data: { hotkey: string; error: string }) => {
+        showGlobalToast({ description: `Hotkey registration failed: ${data.error}`, variant: 'error' });
+      });
+      on('dictation/gpu-binary-download-progress', (data: GpuDownloadProgress) => {
+        set({ gpuBinaryDownloadProgress: data });
+      });
+      on('dictation/gpu-binary-download-complete', () => {
+        set({ gpuBinaryDownloading: false, gpuBinaryDownloaded: true, gpuBinaryDownloadProgress: null });
+      });
+      on('dictation/gpu-binary-download-error', (data: { error: string }) => {
+        set({ gpuBinaryDownloading: false, gpuBinaryDownloadProgress: null });
+        showGlobalToast({ description: `GPU binary download failed: ${data.error}`, variant: 'error' });
+      });
 
       client.call('dictation/server-status').then((info) => {
         set({ serverStatus: info.status });
@@ -500,6 +455,7 @@ export const useDictationStore = create<DictationState>()(
               }
             }
           } catch (ppErr) {
+            console.error('[Dictation] post-process catch:', ppErr);
             if (isCodeMirror && insertTextCallback) {
               const range = insertTextCallback(rawText);
               if (range && get().postProcessing.autoLearnCorrections && onTextInsertedCallback) {
@@ -508,18 +464,18 @@ export const useDictationStore = create<DictationState>()(
             } else if (target && !isCodeMirror) {
               insertTextIntoElement(target, rawText);
             }
-            const isTimeout = ppErr instanceof Error && ppErr.message.includes('timed out');
+            const isTimeout = ppErr instanceof Error && (ppErr.message.includes('timed out') || ppErr.message.includes('timeout'));
             showGlobalToast({
               description: isTimeout
-                ? 'Post-processing timed out — raw text inserted'
-                : 'Post-processing failed — raw text inserted',
+                ? 'Post-processing timed out\nRaw text inserted'
+                : 'Post-processing failed\nRaw text inserted',
               variant: 'default',
+              persistent: true,
             });
           }
 
           set({ status: 'idle', error: null });
-        } catch (err) {
-          console.error('[Dictation] Transcription failed:', err);
+        } catch {
           set({ status: 'error', error: 'Transcription failed' });
           showGlobalToast({ description: 'Transcription failed', variant: 'error' });
         }

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -50,6 +50,19 @@ export interface DictationServerInfo {
   modelName: DictationModelName | null;
 }
 
+export type OllamaModelCategory = 'Qwen' | 'Gemma' | 'NVIDIA';
+
+export interface OllamaModelInfo {
+  id: string;
+  label: string;
+  category: OllamaModelCategory;
+  parameterSize: string;
+  sizeMb: number;
+  description: string;
+  isRecommended?: boolean;
+  supportsThinking?: boolean;
+}
+
 export interface DictationConfig {
   enabled: boolean;
   selectedModel: DictationModelName;
@@ -68,6 +81,7 @@ export interface DictationConfig {
     dictionaryInPrompt: boolean;
     skipShortTranscriptions: boolean;
     shortTextThreshold: number;
+    thinking?: boolean;
   };
   dictionary: string[];
   accelerator?: 'cpu' | 'gpu';


### PR DESCRIPTION
## Summary
- Replaced the basic red pill recording indicator with a Handy-inspired waveform overlay — audio-reactive bars during recording with noise gating, temporal/spatial smoothing, and a sine wave loading animation during transcribing/post-processing
- Added Web Audio AnalyserNode for real-time frequency data, positioned overlay outside scroll container so it stays fixed at the editor bottom
- Improved post-processing: Ollama model selector with local model fetching, serialized config writes to prevent race conditions, error/timeout toasts, and multilingual self-correction support in the prompt

## Test plan
- [ ] Start dictation and verify waveform bars react to speech but stay flat during silence
- [ ] Stop recording and verify transcribing/processing shows smooth loading wave animation
- [ ] Test Ollama model dropdown in dictation post-processing settings
- [ ] Verify post-processing timeout shows a toast and inserts raw text