### PR TITLE
Add Pandoc export for DOCX, EPUB, HTML, ODT, LaTeX, plain text

### DIFF
--- a/apps/electron/src/main/coordinator/handlers/pandoc.ts
+++ b/apps/electron/src/main/coordinator/handlers/pandoc.ts
@@ -4,19 +4,10 @@ import { writeFile, unlink } from 'fs/promises';
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { app, dialog, type BrowserWindow } from 'electron';
-import type { PandocFormat, PandocBinaryStatus } from '@cushion/types';
+import { PANDOC_FORMAT_META, type PandocFormat, type PandocBinaryStatus } from '@cushion/types';
 import type { PandocBinaryManager } from '../pandoc-binary-manager';
 
 const execFilePromise = promisify(execFileCb);
-
-const FORMAT_META: Record<PandocFormat, { extension: string; filterName: string }> = {
-  docx:  { extension: 'docx', filterName: 'Word Document' },
-  epub:  { extension: 'epub', filterName: 'EPUB' },
-  html:  { extension: 'html', filterName: 'HTML' },
-  odt:   { extension: 'odt',  filterName: 'OpenDocument Text' },
-  latex: { extension: 'tex',  filterName: 'LaTeX' },
-  plain: { extension: 'txt',  filterName: 'Plain Text' },
-};
 
 export function handlePandocBinaryStatus(manager: PandocBinaryManager): Promise<PandocBinaryStatus> {
   return manager.isBinaryAvailable();
@@ -38,7 +29,7 @@ export async function handlePandocExport(
   const status = await manager.isBinaryAvailable();
   if (!status.available || !status.path) throw new Error('Pandoc not available');
 
-  const meta = FORMAT_META[params.format];
+  const meta = PANDOC_FORMAT_META[params.format];
   const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
     defaultPath: `${params.title}.${meta.extension}`,
     filters: [{ name: meta.filterName, extensions: [meta.extension] }],

--- a/apps/electron/src/main/coordinator/handlers/pandoc.ts
+++ b/apps/electron/src/main/coordinator/handlers/pandoc.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { writeFile, unlink } from 'fs/promises';
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+import { app, dialog, type BrowserWindow } from 'electron';
+import type { PandocFormat, PandocBinaryStatus } from '@cushion/types';
+import type { PandocBinaryManager } from '../pandoc-binary-manager';
+
+const execFilePromise = promisify(execFileCb);
+
+const FORMAT_META: Record<PandocFormat, { extension: string; filterName: string }> = {
+  docx:  { extension: 'docx', filterName: 'Word Document' },
+  epub:  { extension: 'epub', filterName: 'EPUB' },
+  html:  { extension: 'html', filterName: 'HTML' },
+  odt:   { extension: 'odt',  filterName: 'OpenDocument Text' },
+  latex: { extension: 'tex',  filterName: 'LaTeX' },
+  plain: { extension: 'txt',  filterName: 'Plain Text' },
+};
+
+export function handlePandocBinaryStatus(manager: PandocBinaryManager): Promise<PandocBinaryStatus> {
+  return manager.isBinaryAvailable();
+}
+
+export async function handlePandocEnsureBinary(manager: PandocBinaryManager) {
+  return manager.ensureBinary();
+}
+
+export function handlePandocCancelDownload(manager: PandocBinaryManager) {
+  return manager.cancelDownload();
+}
+
+export async function handlePandocExport(
+  manager: PandocBinaryManager,
+  params: { markdown: string; title: string; format: PandocFormat; workspacePath: string },
+  mainWindow: BrowserWindow,
+) {
+  const status = await manager.isBinaryAvailable();
+  if (!status.available || !status.path) throw new Error('Pandoc not available');
+
+  const meta = FORMAT_META[params.format];
+  const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
+    defaultPath: `${params.title}.${meta.extension}`,
+    filters: [{ name: meta.filterName, extensions: [meta.extension] }],
+  });
+  if (canceled || !filePath) return { success: false, path: null };
+
+  const tmpInput = path.join(app.getPath('temp'), `cushion-pandoc-${randomUUID()}.md`);
+  await writeFile(tmpInput, params.markdown, 'utf-8');
+
+  const args = [
+    tmpInput, '-o', filePath,
+    '-f', 'markdown-implicit_figures',
+    '-t', params.format,
+    '--eol=lf',
+    `--metadata=title:${params.title}`,
+  ];
+  if (['html', 'epub', 'latex'].includes(params.format)) args.push('--standalone');
+
+  try {
+    await execFilePromise(status.path, args, { timeout: 60000, windowsHide: true });
+    return { success: true, path: filePath };
+  } catch (err: any) {
+    throw new Error(`Pandoc export failed: ${err.stderr || err.message}`);
+  } finally {
+    await unlink(tmpInput).catch(() => {});
+  }
+}

--- a/apps/electron/src/main/coordinator/ipc-router.ts
+++ b/apps/electron/src/main/coordinator/ipc-router.ts
@@ -39,6 +39,13 @@ import {
   handleTrashEmpty,
 } from './handlers/trash';
 
+import { PandocBinaryManager } from './pandoc-binary-manager';
+import {
+  handlePandocBinaryStatus,
+  handlePandocEnsureBinary,
+  handlePandocCancelDownload,
+  handlePandocExport,
+} from './handlers/pandoc';
 import { DictationConfigManager } from './dictation-config';
 import { PostProcessor } from './post-processor';
 import { HotkeyManager } from './hotkey-manager';
@@ -79,6 +86,7 @@ import {
 let workspaceManager: WorkspaceManager;
 let configManager: ConfigManager;
 let configWatcher: ConfigWatcher;
+let pandocBinaryManager: PandocBinaryManager;
 let dictationConfigManager: DictationConfigManager;
 let postProcessor: PostProcessor;
 let hotkeyManager: HotkeyManager;
@@ -159,6 +167,9 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
 
   sherpaBinaryManager = new SherpaBinaryManager(notifyRenderer);
   await sherpaBinaryManager.init();
+
+  pandocBinaryManager = new PandocBinaryManager(notifyRenderer);
+  await pandocBinaryManager.init();
 
   await ensurePermissionDefaults();
 
@@ -388,6 +399,23 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
   ipcMain.handle('coordinator:dictation/ensure-gpu-binary', async () => {
     return handleDictationEnsureGpuBinary(sherpaBinaryManager);
   });
+
+  // Pandoc handlers
+  ipcMain.handle('coordinator:pandoc/binary-status', async () => {
+    return handlePandocBinaryStatus(pandocBinaryManager);
+  });
+
+  ipcMain.handle('coordinator:pandoc/ensure-binary', async () => {
+    return handlePandocEnsureBinary(pandocBinaryManager);
+  });
+
+  ipcMain.handle('coordinator:pandoc/cancel-download', async () => {
+    return handlePandocCancelDownload(pandocBinaryManager);
+  });
+
+  ipcMain.handle('coordinator:pandoc/export', async (_event, params: RPCParams<'pandoc/export'>) => {
+    return handlePandocExport(pandocBinaryManager, params, mainWindow);
+  });
 }
 
 export function stopCoordinator() {
@@ -396,4 +424,5 @@ export function stopCoordinator() {
   hotkeyManager?.dispose();
   sherpaModelManager?.dispose();
   sherpaManager?.dispose();
+  pandocBinaryManager?.cancelDownload();
 }

--- a/apps/electron/src/main/coordinator/pandoc-binary-manager.ts
+++ b/apps/electron/src/main/coordinator/pandoc-binary-manager.ts
@@ -9,14 +9,12 @@ import type { PandocBinaryStatus } from '@cushion/types';
 const PANDOC_VERSION = '3.6.4';
 const GITHUB_RELEASE_URL = `https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}`;
 
-const V = PANDOC_VERSION;
-
 const PANDOC_BINARIES: Record<string, { archiveName: string; binaryName: string }> = {
-  'win32-x64':    { archiveName: `pandoc-${V}-windows-x86_64.zip`,      binaryName: 'pandoc.exe' },
-  'darwin-arm64': { archiveName: `pandoc-${V}-arm64-macOS.zip`,          binaryName: 'pandoc' },
-  'darwin-x64':   { archiveName: `pandoc-${V}-x86_64-macOS.zip`,        binaryName: 'pandoc' },
-  'linux-x64':    { archiveName: `pandoc-${V}-linux-amd64.tar.gz`,      binaryName: 'pandoc' },
-  'linux-arm64':  { archiveName: `pandoc-${V}-linux-arm64.tar.gz`,      binaryName: 'pandoc' },
+  'win32-x64':    { archiveName: `pandoc-${PANDOC_VERSION}-windows-x86_64.zip`,      binaryName: 'pandoc.exe' },
+  'darwin-arm64': { archiveName: `pandoc-${PANDOC_VERSION}-arm64-macOS.zip`,          binaryName: 'pandoc' },
+  'darwin-x64':   { archiveName: `pandoc-${PANDOC_VERSION}-x86_64-macOS.zip`,        binaryName: 'pandoc' },
+  'linux-x64':    { archiveName: `pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz`,      binaryName: 'pandoc' },
+  'linux-arm64':  { archiveName: `pandoc-${PANDOC_VERSION}-linux-arm64.tar.gz`,      binaryName: 'pandoc' },
 };
 
 const MAX_REDIRECTS = 5;
@@ -33,7 +31,6 @@ export class PandocBinaryManager {
   private binDir: string;
   private notify: NotifyFn;
   private abortController: AbortController | null = null;
-  private cachedStatus: PandocBinaryStatus | null = null;
 
   constructor(notify: NotifyFn) {
     this.notify = notify;
@@ -61,28 +58,25 @@ export class PandocBinaryManager {
   async isBinaryAvailable(): Promise<PandocBinaryStatus> {
     const system = await this.checkSystemPandoc();
     if (system) {
-      this.cachedStatus = {
+      return {
         available: true,
         path: system.path,
         version: system.version,
         source: 'system',
       };
-      return this.cachedStatus;
     }
 
     const managed = this.getManagedPath();
     if (managed && existsSync(managed)) {
-      this.cachedStatus = {
+      return {
         available: true,
         path: managed,
         version: PANDOC_VERSION,
         source: 'managed',
       };
-      return this.cachedStatus;
     }
 
-    this.cachedStatus = { available: false, path: null, version: null, source: null };
-    return this.cachedStatus;
+    return { available: false, path: null, version: null, source: null };
   }
 
   async ensureBinary(): Promise<{ path: string }> {
@@ -98,10 +92,6 @@ export class PandocBinaryManager {
       return { cancelled: true };
     }
     return { cancelled: false };
-  }
-
-  getPandocPath(): string | null {
-    return this.cachedStatus?.path ?? null;
   }
 
   private checkSystemPandoc(): Promise<{ available: boolean; path: string; version: string } | null> {
@@ -140,7 +130,7 @@ export class PandocBinaryManager {
 
     try {
       const url = `${GITHUB_RELEASE_URL}/${config.archiveName}`;
-      await this.downloadFile(url, archivePath, 'pandoc/download');
+      await this.downloadWithRedirects(url, archivePath, 0, 'pandoc/download');
 
       await fs.mkdir(extractDir, { recursive: true });
       await this.extractArchive(archivePath, extractDir);
@@ -154,7 +144,6 @@ export class PandocBinaryManager {
         await fs.chmod(outputPath, 0o755);
       }
 
-      // macOS: remove quarantine flag
       if (process.platform === 'darwin') {
         await new Promise<void>((resolve) => {
           execFile('xattr', ['-dr', 'com.apple.quarantine', outputPath], { timeout: 5000 }, () => resolve());
@@ -215,10 +204,6 @@ export class PandocBinaryManager {
       }
     }
     return null;
-  }
-
-  private downloadFile(url: string, destPath: string, notifyPrefix: string): Promise<void> {
-    return this.downloadWithRedirects(url, destPath, 0, notifyPrefix);
   }
 
   private downloadWithRedirects(url: string, destPath: string, redirectCount: number, notifyPrefix: string): Promise<void> {

--- a/apps/electron/src/main/coordinator/pandoc-binary-manager.ts
+++ b/apps/electron/src/main/coordinator/pandoc-binary-manager.ts
@@ -1,0 +1,295 @@
+import fs from 'fs/promises';
+import { existsSync, createWriteStream } from 'fs';
+import { execFile, spawn } from 'child_process';
+import https from 'https';
+import path from 'path';
+import { app } from 'electron';
+import type { PandocBinaryStatus } from '@cushion/types';
+
+const PANDOC_VERSION = '3.6.4';
+const GITHUB_RELEASE_URL = `https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}`;
+
+const V = PANDOC_VERSION;
+
+const PANDOC_BINARIES: Record<string, { archiveName: string; binaryName: string }> = {
+  'win32-x64':    { archiveName: `pandoc-${V}-windows-x86_64.zip`,      binaryName: 'pandoc.exe' },
+  'darwin-arm64': { archiveName: `pandoc-${V}-arm64-macOS.zip`,          binaryName: 'pandoc' },
+  'darwin-x64':   { archiveName: `pandoc-${V}-x86_64-macOS.zip`,        binaryName: 'pandoc' },
+  'linux-x64':    { archiveName: `pandoc-${V}-linux-amd64.tar.gz`,      binaryName: 'pandoc' },
+  'linux-arm64':  { archiveName: `pandoc-${V}-linux-arm64.tar.gz`,      binaryName: 'pandoc' },
+};
+
+const MAX_REDIRECTS = 5;
+const ALLOWED_REDIRECT_HOSTS = new Set([
+  'github.com',
+  'objects.githubusercontent.com',
+  'github-releases.githubusercontent.com',
+  'release-assets.githubusercontent.com',
+]);
+
+type NotifyFn = (channel: string, data: unknown) => void;
+
+export class PandocBinaryManager {
+  private binDir: string;
+  private notify: NotifyFn;
+  private abortController: AbortController | null = null;
+  private cachedStatus: PandocBinaryStatus | null = null;
+
+  constructor(notify: NotifyFn) {
+    this.notify = notify;
+    this.binDir = path.join(app.getPath('userData'), 'bin', 'pandoc');
+  }
+
+  async init(): Promise<void> {
+    await fs.mkdir(this.binDir, { recursive: true });
+  }
+
+  private getBinaryKey(): string {
+    return `${process.platform}-${process.arch}`;
+  }
+
+  private getConfig() {
+    return PANDOC_BINARIES[this.getBinaryKey()] ?? null;
+  }
+
+  private getManagedPath(): string | null {
+    const config = this.getConfig();
+    if (!config) return null;
+    return path.join(this.binDir, config.binaryName);
+  }
+
+  async isBinaryAvailable(): Promise<PandocBinaryStatus> {
+    const system = await this.checkSystemPandoc();
+    if (system) {
+      this.cachedStatus = {
+        available: true,
+        path: system.path,
+        version: system.version,
+        source: 'system',
+      };
+      return this.cachedStatus;
+    }
+
+    const managed = this.getManagedPath();
+    if (managed && existsSync(managed)) {
+      this.cachedStatus = {
+        available: true,
+        path: managed,
+        version: PANDOC_VERSION,
+        source: 'managed',
+      };
+      return this.cachedStatus;
+    }
+
+    this.cachedStatus = { available: false, path: null, version: null, source: null };
+    return this.cachedStatus;
+  }
+
+  async ensureBinary(): Promise<{ path: string }> {
+    const status = await this.isBinaryAvailable();
+    if (status.available && status.path) return { path: status.path };
+    return this.downloadBinary();
+  }
+
+  cancelDownload(): { cancelled: boolean } {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+      return { cancelled: true };
+    }
+    return { cancelled: false };
+  }
+
+  getPandocPath(): string | null {
+    return this.cachedStatus?.path ?? null;
+  }
+
+  private checkSystemPandoc(): Promise<{ available: boolean; path: string; version: string } | null> {
+    return new Promise((resolve) => {
+      execFile('pandoc', ['--version'], { timeout: 5000, windowsHide: true }, (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        const versionMatch = stdout.match(/pandoc(?:\.exe)?\s+(\d+\.\d+(?:\.\d+)?)/);
+        const version = versionMatch?.[1] ?? 'unknown';
+
+        const whichCmd = process.platform === 'win32' ? 'where' : 'which';
+        execFile(whichCmd, ['pandoc'], { timeout: 5000, windowsHide: true }, (err2, pathOut) => {
+          if (err2) {
+            resolve({ available: true, path: 'pandoc', version });
+            return;
+          }
+          resolve({
+            available: true,
+            path: pathOut.trim().split('\n')[0].trim(),
+            version,
+          });
+        });
+      });
+    });
+  }
+
+  private async downloadBinary(): Promise<{ path: string }> {
+    const config = this.getConfig();
+    if (!config) throw new Error(`Unsupported platform/arch: ${this.getBinaryKey()}`);
+
+    this.abortController = new AbortController();
+    const archivePath = path.join(this.binDir, config.archiveName);
+    const extractDir = path.join(this.binDir, `temp-pandoc-${this.getBinaryKey()}`);
+
+    try {
+      const url = `${GITHUB_RELEASE_URL}/${config.archiveName}`;
+      await this.downloadFile(url, archivePath, 'pandoc/download');
+
+      await fs.mkdir(extractDir, { recursive: true });
+      await this.extractArchive(archivePath, extractDir);
+
+      const binaryPath = await this.findFileInDir(extractDir, config.binaryName);
+      if (!binaryPath) throw new Error(`Binary ${config.binaryName} not found in archive`);
+
+      const outputPath = path.join(this.binDir, config.binaryName);
+      await fs.copyFile(binaryPath, outputPath);
+      if (process.platform !== 'win32') {
+        await fs.chmod(outputPath, 0o755);
+      }
+
+      // macOS: remove quarantine flag
+      if (process.platform === 'darwin') {
+        await new Promise<void>((resolve) => {
+          execFile('xattr', ['-dr', 'com.apple.quarantine', outputPath], { timeout: 5000 }, () => resolve());
+        });
+      }
+
+      await fs.rm(extractDir, { recursive: true, force: true });
+      await fs.rm(archivePath, { force: true });
+
+      this.abortController = null;
+      this.notify('pandoc/download-complete', { path: outputPath });
+      return { path: outputPath };
+    } catch (err: any) {
+      await fs.rm(extractDir, { recursive: true, force: true }).catch(() => {});
+      await fs.rm(archivePath, { force: true }).catch(() => {});
+      this.abortController = null;
+      this.notify('pandoc/download-error', { error: err.message });
+      throw err;
+    }
+  }
+
+  private extractArchive(archivePath: string, destDir: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const cwd = path.dirname(archivePath);
+      const relArchive = path.basename(archivePath);
+      const relDest = path.relative(cwd, destDir);
+
+      const isGz = archivePath.endsWith('.tar.gz');
+      const args = isGz
+        ? ['-xzf', relArchive, '-C', relDest]
+        : ['-xf', relArchive, '-C', relDest];
+
+      const proc = spawn('tar', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        cwd,
+      });
+
+      let stderr = '';
+      proc.stderr.on('data', (d) => { stderr += d.toString(); });
+      proc.on('close', (code) => {
+        if (code !== 0) reject(new Error(`Archive extraction failed (code ${code}): ${stderr.slice(0, 300)}`));
+        else resolve();
+      });
+      proc.on('error', (err) => reject(new Error(`Failed to start tar: ${err.message}`)));
+    });
+  }
+
+  private async findFileInDir(dir: string, fileName: string, depth = 0): Promise<string | null> {
+    if (depth > 5) return null;
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name === fileName) return fullPath;
+      if (entry.isDirectory()) {
+        const found = await this.findFileInDir(fullPath, fileName, depth + 1);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+
+  private downloadFile(url: string, destPath: string, notifyPrefix: string): Promise<void> {
+    return this.downloadWithRedirects(url, destPath, 0, notifyPrefix);
+  }
+
+  private downloadWithRedirects(url: string, destPath: string, redirectCount: number, notifyPrefix: string): Promise<void> {
+    if (redirectCount > MAX_REDIRECTS) return Promise.reject(new Error('Too many redirects'));
+
+    return new Promise((resolve, reject) => {
+      if (!url.startsWith('https://')) {
+        reject(new Error('Only HTTPS downloads are allowed'));
+        return;
+      }
+
+      if (this.abortController?.signal.aborted) {
+        reject(new Error('Download cancelled'));
+        return;
+      }
+
+      const req = https.get(url, (res: any) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          try {
+            const redirectUrl = new URL(res.headers.location);
+            if (!ALLOWED_REDIRECT_HOSTS.has(redirectUrl.hostname)) {
+              reject(new Error(`Redirect to unexpected host: ${redirectUrl.hostname}`));
+              return;
+            }
+          } catch {
+            reject(new Error('Invalid redirect URL'));
+            return;
+          }
+          this.downloadWithRedirects(res.headers.location, destPath, redirectCount + 1, notifyPrefix)
+            .then(resolve, reject);
+          return;
+        }
+
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+
+        const totalBytes = parseInt(res.headers['content-length'] || '0', 10);
+        let downloadedBytes = 0;
+        let lastProgressTime = 0;
+
+        const writeStream = createWriteStream(destPath);
+
+        res.on('data', (chunk: Buffer) => {
+          downloadedBytes += chunk.length;
+          const now = Date.now();
+          if (now - lastProgressTime >= 200) {
+            lastProgressTime = now;
+            this.notify(`${notifyPrefix}-progress`, {
+              downloadedBytes,
+              totalBytes,
+              percent: totalBytes > 0 ? Math.round((downloadedBytes / totalBytes) * 100) : 0,
+            });
+          }
+        });
+
+        res.pipe(writeStream);
+        writeStream.on('finish', () => resolve());
+        writeStream.on('error', reject);
+        res.on('error', reject);
+      });
+
+      req.on('error', reject);
+
+      this.abortController?.signal.addEventListener('abort', () => {
+        req.destroy();
+        reject(new Error('Download cancelled'));
+      }, { once: true });
+    });
+  }
+}

--- a/apps/electron/src/main/pdf-export.ts
+++ b/apps/electron/src/main/pdf-export.ts
@@ -1,5 +1,7 @@
-import { ipcMain, dialog, BrowserWindow } from 'electron';
-import { writeFile } from 'fs/promises';
+import { ipcMain, dialog, BrowserWindow, app } from 'electron';
+import { writeFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
 import { PDFDocument, PDFDict, PDFName, PDFString, PDFArray, PDFRef } from 'pdf-lib';
 
 interface PdfExportOptions {
@@ -101,9 +103,26 @@ ipcMain.handle('export:pdf', async (_event, { html, title, options }: ExportPdfP
     webPreferences: { offscreen: true },
   });
 
+  const tmpPath = join(app.getPath('temp'), `cushion-print-${randomUUID()}.html`);
+
   try {
-    await win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await writeFile(tmpPath, html, 'utf-8');
+    await win.loadFile(tmpPath);
+
+    await win.webContents.executeJavaScript(`
+      new Promise((resolve) => {
+        const imgs = Array.from(document.images);
+        const pending = imgs.filter(i => !i.complete);
+        if (!pending.length) return resolve();
+        let n = pending.length;
+        const done = () => { if (--n <= 0) resolve(); };
+        pending.forEach(i => {
+          i.addEventListener('load', done, { once: true });
+          i.addEventListener('error', done, { once: true });
+        });
+        setTimeout(resolve, 10000);
+      })
+    `);
 
     const pdfBuffer = await win.webContents.printToPDF({
       pageSize: options.pageSize,
@@ -127,5 +146,6 @@ ipcMain.handle('export:pdf', async (_event, { html, title, options }: ExportPdfP
     return { success: false, path: filePath };
   } finally {
     win.destroy();
+    await unlink(tmpPath).catch(() => {});
   }
 });

--- a/apps/frontend/components/editor/EditorPanel.tsx
+++ b/apps/frontend/components/editor/EditorPanel.tsx
@@ -14,8 +14,9 @@ import type { WikiLinkNavigateCallback } from '@/lib/codemirror-wysiwyg';
 import { DiffReviewBar } from './DiffReviewBar';
 import { useDiffReviewStore } from '@/stores/diffReviewStore';
 import { exportToPdf } from '@/lib/pdf-export';
+import { exportWithPandoc } from '@/lib/pandoc-export';
 import { ExportOptionsDialog } from './ExportOptionsDialog';
-import type { PdfExportOptions } from '@cushion/types';
+import type { PdfExportOptions, PandocFormat } from '@cushion/types';
 import { getViewForFile } from '@/lib/view-registry';
 import { EditorPanelProvider } from './EditorPanelContext';
 import { RecordingOverlay } from './RecordingOverlay';
@@ -455,7 +456,18 @@ export function EditorPanel({
     const pathParts = currentFile.split(/[/\\]/);
     const fileName = pathParts[pathParts.length - 1];
     const baseName = fileName.includes('.') ? fileName.slice(0, fileName.lastIndexOf('.')) : fileName;
-    await exportToPdf(file.content, baseName, options);
+    await exportToPdf(file.content, baseName, options, filePaths ?? []);
+  }, [currentFile]);
+
+  const handleExportPandoc = useCallback(async (format: PandocFormat) => {
+    setShowExportDialog(false);
+    if (!currentFile) return;
+    const file = useWorkspaceStore.getState().openFiles.get(currentFile);
+    if (!file) return;
+    const pathParts = currentFile.split(/[/\\]/);
+    const fileName = pathParts[pathParts.length - 1];
+    const baseName = fileName.includes('.') ? fileName.slice(0, fileName.lastIndexOf('.')) : fileName;
+    await exportWithPandoc(file.content, baseName, format, filePaths ?? [], workspacePath ?? '');
   }, [currentFile]);
 
   const handleWikiLinkNavigate: WikiLinkNavigateCallback = useCallback(
@@ -626,7 +638,8 @@ export function EditorPanel({
       <ExportOptionsDialog
         isOpen={showExportDialog}
         onClose={() => setShowExportDialog(false)}
-        onExport={handleExportPdf}
+        onExportPdf={handleExportPdf}
+        onExportPandoc={handleExportPandoc}
       />
     </div>
     </EditorPanelProvider>

--- a/apps/frontend/components/editor/ExportOptionsDialog.tsx
+++ b/apps/frontend/components/editor/ExportOptionsDialog.tsx
@@ -1,17 +1,22 @@
-import { useState } from 'react';
-import { FileDown, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { FileDown, X, Loader2, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { PANDOC_FORMAT_META } from '@cushion/types';
 import type {
   PdfExportOptions,
   PdfPageSize,
   PdfOrientation,
   PdfMarginPreset,
+  PandocFormat,
+  PandocBinaryStatus,
 } from '@cushion/types';
+import { PandocDownloadGate } from './PandocDownloadGate';
 
 interface ExportOptionsDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onExport: (options: PdfExportOptions) => void;
+  onExportPdf: (options: PdfExportOptions) => void;
+  onExportPandoc: (format: PandocFormat) => void;
 }
 
 const PAGE_SIZES: { value: PdfPageSize; label: string }[] = [
@@ -31,10 +36,21 @@ const MARGINS: { value: PdfMarginPreset; label: string }[] = [
   { value: 'none', label: 'None' },
 ];
 
+const PANDOC_FORMATS: { value: PandocFormat; label: string; description: string }[] = [
+  { value: 'docx',  label: 'Word',         description: 'Microsoft Word document' },
+  { value: 'epub',  label: 'EPUB',          description: 'E-book format' },
+  { value: 'html',  label: 'HTML',          description: 'Standalone web page' },
+  { value: 'odt',   label: 'OpenDocument',  description: 'LibreOffice / OpenOffice' },
+  { value: 'latex', label: 'LaTeX',         description: 'TeX typesetting source' },
+  { value: 'plain', label: 'Plain Text',    description: 'Stripped plain text' },
+  { value: 'rtf',   label: 'RTF',           description: 'Rich text format' },
+];
+
 export function ExportOptionsDialog({
   isOpen,
   onClose,
-  onExport,
+  onExportPdf,
+  onExportPandoc,
 }: ExportOptionsDialogProps) {
   const [pageSize, setPageSize] = useState<PdfPageSize>('A4');
   const [orientation, setOrientation] = useState<PdfOrientation>('portrait');
@@ -42,126 +58,288 @@ export function ExportOptionsDialog({
   const [showLinkUrls, setShowLinkUrls] = useState(false);
   const [headerText, setHeaderText] = useState('');
   const [footerText, setFooterText] = useState('');
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   if (!isOpen) return null;
 
-  const handleExport = () => {
-    onExport({ pageSize, orientation, margins, showLinkUrls, headerText, footerText });
+  const handleExportPdf = () => {
+    onExportPdf({ pageSize, orientation, margins, showLinkUrls, headerText, footerText });
   };
 
   return (
+    <>
+      <div
+        className="fixed inset-0 z-confirm flex items-center justify-center bg-[var(--overlay-50)]"
+        onClick={onClose}
+      >
+        <div
+          className="bg-modal-bg rounded-lg w-[520px] max-w-[90%] flex flex-col shadow-lg animate-slide-in border border-modal-border"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-start gap-3 px-5 pt-5 pb-4">
+            <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-border-subtle text-foreground-muted">
+              <FileDown size={20} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-base font-semibold text-foreground">
+                Export PDF
+              </h3>
+              <p className="text-sm text-foreground-muted leading-normal">
+                Configure export settings
+              </p>
+            </div>
+            <button
+              className="shrink-0 p-1 rounded cursor-pointer flex items-center justify-center text-foreground-muted hover:bg-[var(--overlay-10)] hover:text-foreground transition-all"
+              onClick={onClose}
+              title="Close"
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="px-5 pb-4 space-y-4">
+            <OptionRow label="Page size">
+              <SegmentedControl
+                options={PAGE_SIZES}
+                value={pageSize}
+                onChange={setPageSize}
+              />
+            </OptionRow>
+
+            <OptionRow label="Orientation">
+              <SegmentedControl
+                options={ORIENTATIONS}
+                value={orientation}
+                onChange={setOrientation}
+              />
+            </OptionRow>
+
+            <OptionRow label="Margins">
+              <SegmentedControl
+                options={MARGINS}
+                value={margins}
+                onChange={setMargins}
+              />
+            </OptionRow>
+
+            <OptionRow label="Header">
+              <input
+                type="text"
+                value={headerText}
+                onChange={(e) => setHeaderText(e.target.value)}
+                placeholder="Optional"
+                className="w-48 px-2.5 py-1.5 rounded text-sm bg-transparent border border-modal-border text-foreground placeholder:text-foreground-muted/50 outline-none focus:border-accent transition-colors"
+              />
+            </OptionRow>
+
+            <OptionRow label="Footer">
+              <input
+                type="text"
+                value={footerText}
+                onChange={(e) => setFooterText(e.target.value)}
+                placeholder="Optional"
+                className="w-48 px-2.5 py-1.5 rounded text-sm bg-transparent border border-modal-border text-foreground placeholder:text-foreground-muted/50 outline-none focus:border-accent transition-colors"
+              />
+            </OptionRow>
+
+            <OptionRow label="Show link URLs">
+              <button
+                onClick={() => setShowLinkUrls(!showLinkUrls)}
+                className={cn(
+                  'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border transition-colors',
+                  showLinkUrls
+                    ? 'bg-accent border-accent'
+                    : 'bg-[var(--border-subtle)] border-border',
+                )}
+              >
+                <span
+                  className={cn(
+                    'inline-block size-4 rounded-full bg-surface shadow transition-transform',
+                    showLinkUrls ? 'translate-x-4' : 'translate-x-0.5',
+                  )}
+                />
+              </button>
+            </OptionRow>
+
+            {/* Advanced Formats button */}
+            <div className="flex items-center justify-between pt-1">
+              <div>
+                <div className="text-sm font-medium text-foreground">Advanced Formats</div>
+                <div className="text-xs text-foreground-muted">DOCX, EPUB, HTML, LaTeX and more</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen(true)}
+                className="text-xs text-foreground-muted hover:text-foreground transition-colors px-3 py-1.5 rounded-md border border-border hover:bg-background-secondary cursor-pointer"
+              >
+                Manage
+              </button>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-2 px-5 pt-4 pb-5">
+            <button
+              className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border border-modal-border bg-transparent text-foreground hover:bg-[var(--overlay-10)] transition-all"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border-none bg-accent text-surface hover:bg-accent-hover transition-all"
+              onClick={handleExportPdf}
+              autoFocus
+            >
+              Export
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {advancedOpen && (
+        <AdvancedFormatsDialog
+          onClose={() => setAdvancedOpen(false)}
+          onExport={(format) => {
+            setAdvancedOpen(false);
+            onExportPandoc(format);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function AdvancedFormatsDialog({
+  onClose,
+  onExport,
+}: {
+  onClose: () => void;
+  onExport: (format: PandocFormat) => void;
+}) {
+  const [pandocStatus, setPandocStatus] = useState<PandocBinaryStatus | null>(null);
+  const [checkingPandoc, setCheckingPandoc] = useState(true);
+  const [selectedFormat, setSelectedFormat] = useState<PandocFormat>('docx');
+
+  const checkPandocStatus = useCallback(async () => {
+    setCheckingPandoc(true);
+    try {
+      const status = await window.electronAPI.coordinatorInvoke('pandoc/binary-status', {});
+      setPandocStatus(status);
+    } catch {
+      setPandocStatus({ available: false, path: null, version: null, source: null });
+    } finally {
+      setCheckingPandoc(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkPandocStatus();
+  }, [checkPandocStatus]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const pandocReady = pandocStatus?.available === true;
+
+  return (
     <div
-      className="fixed inset-0 z-confirm flex items-center justify-center bg-[var(--overlay-50)]"
+      className="fixed inset-0 z-confirm flex items-start justify-center pt-[10%] bg-[var(--overlay-50)]"
       onClick={onClose}
     >
       <div
         className="bg-modal-bg rounded-lg w-[520px] max-w-[90%] flex flex-col shadow-lg animate-slide-in border border-modal-border"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Header */}
-        <div className="flex items-start gap-3 px-5 pt-5 pb-4">
-          <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-border-subtle text-foreground-muted">
-            <FileDown size={20} />
-          </div>
-          <div className="flex-1 min-w-0">
-            <h3 className="text-base font-semibold text-foreground">
-              Export PDF
-            </h3>
-            <p className="text-sm text-foreground-muted leading-normal">
-              Configure export settings
-            </p>
-          </div>
+        <div className="flex items-center justify-between px-5 pt-5 pb-2">
+          <h3 className="text-base font-semibold text-foreground">Advanced Formats</h3>
           <button
-            className="shrink-0 p-1 rounded cursor-pointer flex items-center justify-center text-foreground-muted hover:bg-[var(--overlay-10)] hover:text-foreground transition-all"
+            className="p-1 rounded cursor-pointer flex items-center justify-center text-foreground-muted hover:bg-[var(--overlay-10)] hover:text-foreground transition-all"
             onClick={onClose}
-            title="Close"
           >
             <X size={18} />
           </button>
         </div>
 
-        {/* Body */}
-        <div className="px-5 pb-4 space-y-4">
-          <OptionRow label="Page size">
-            <SegmentedControl
-              options={PAGE_SIZES}
-              value={pageSize}
-              onChange={setPageSize}
-            />
-          </OptionRow>
+        <p className="text-xs text-foreground-muted px-5 mb-4">
+          Export to additional formats via Pandoc.
+          {pandocReady && pandocStatus!.source === 'system' && (
+            <span className="text-foreground-faint ml-1">
+              Using system Pandoc {pandocStatus!.version}
+            </span>
+          )}
+        </p>
 
-          <OptionRow label="Orientation">
-            <SegmentedControl
-              options={ORIENTATIONS}
-              value={orientation}
-              onChange={setOrientation}
-            />
-          </OptionRow>
+        {/* Pandoc status gate */}
+        {checkingPandoc && (
+          <div className="px-5 pb-5 flex items-center justify-center py-10">
+            <Loader2 size={16} className="animate-spin text-foreground-muted mr-2" />
+            <span className="text-sm text-foreground-muted">Checking Pandoc...</span>
+          </div>
+        )}
 
-          <OptionRow label="Margins">
-            <SegmentedControl
-              options={MARGINS}
-              value={margins}
-              onChange={setMargins}
-            />
-          </OptionRow>
+        {!checkingPandoc && pandocStatus && !pandocStatus.available && (
+          <div className="px-5 pb-5 py-4">
+            <PandocDownloadGate onInstalled={checkPandocStatus} />
+          </div>
+        )}
 
-          <OptionRow label="Header">
-            <input
-              type="text"
-              value={headerText}
-              onChange={(e) => setHeaderText(e.target.value)}
-              placeholder="Optional"
-              className="w-48 px-2.5 py-1.5 rounded text-sm bg-transparent border border-modal-border text-foreground placeholder:text-foreground-muted/50 outline-none focus:border-accent transition-colors"
-            />
-          </OptionRow>
+        {/* Format list */}
+        {!checkingPandoc && pandocReady && (
+          <>
+            <div className="px-5 pb-4 space-y-1.5 max-h-[55vh] overflow-y-auto thin-scrollbar">
+              {PANDOC_FORMATS.map((fmt) => {
+                const isSelected = selectedFormat === fmt.value;
+                const meta = PANDOC_FORMAT_META[fmt.value];
+                return (
+                  <div
+                    key={fmt.value}
+                    onClick={() => setSelectedFormat(fmt.value)}
+                    className={cn(
+                      'rounded-md border px-3.5 py-2.5 transition-all cursor-pointer',
+                      isSelected
+                        ? 'border-[var(--accent-primary)] bg-[var(--accent-primary-12)]'
+                        : 'border-[var(--border)] hover:border-[var(--border-subtle)] hover:bg-[var(--overlay-10)]',
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-sm text-foreground">{fmt.label}</span>
+                      <span className="text-[11px] text-foreground-faint">.{meta.extension}</span>
+                      {isSelected && (
+                        <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-[var(--accent-primary)] bg-[var(--accent-primary-12)] px-1.5 py-0.5 rounded">
+                          <Check size={10} />
+                          Selected
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-foreground-muted mt-0.5">{fmt.description}</p>
+                  </div>
+                );
+              })}
+            </div>
 
-          <OptionRow label="Footer">
-            <input
-              type="text"
-              value={footerText}
-              onChange={(e) => setFooterText(e.target.value)}
-              placeholder="Optional"
-              className="w-48 px-2.5 py-1.5 rounded text-sm bg-transparent border border-modal-border text-foreground placeholder:text-foreground-muted/50 outline-none focus:border-accent transition-colors"
-            />
-          </OptionRow>
-
-          <OptionRow label="Show link URLs">
-            <button
-              onClick={() => setShowLinkUrls(!showLinkUrls)}
-              className={cn(
-                'relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border transition-colors',
-                showLinkUrls
-                  ? 'bg-accent border-accent'
-                  : 'bg-[var(--border-subtle)] border-border',
-              )}
-            >
-              <span
-                className={cn(
-                  'inline-block size-4 rounded-full bg-surface shadow transition-transform',
-                  showLinkUrls ? 'translate-x-4' : 'translate-x-0.5',
-                )}
-              />
-            </button>
-          </OptionRow>
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-end gap-2 px-5 pt-4 pb-5">
-          <button
-            className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border border-modal-border bg-transparent text-foreground hover:bg-[var(--overlay-10)] transition-all"
-            onClick={onClose}
-          >
-            Cancel
-          </button>
-          <button
-            className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border-none bg-accent text-surface hover:bg-accent-hover transition-all"
-            onClick={handleExport}
-            autoFocus
-          >
-            Export
-          </button>
-        </div>
+            <div className="flex items-center justify-end gap-2 px-5 pt-3 pb-5">
+              <button
+                className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border border-modal-border bg-transparent text-foreground hover:bg-[var(--overlay-10)] transition-all"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border-none bg-accent text-surface hover:bg-accent-hover transition-all"
+                onClick={() => onExport(selectedFormat)}
+              >
+                Export {PANDOC_FORMAT_META[selectedFormat].label.split(' ')[0]}
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/components/editor/ExportOptionsDialog.tsx
+++ b/apps/frontend/components/editor/ExportOptionsDialog.tsx
@@ -43,7 +43,6 @@ const PANDOC_FORMATS: { value: PandocFormat; label: string; description: string 
   { value: 'odt',   label: 'OpenDocument',  description: 'LibreOffice / OpenOffice' },
   { value: 'latex', label: 'LaTeX',         description: 'TeX typesetting source' },
   { value: 'plain', label: 'Plain Text',    description: 'Stripped plain text' },
-  { value: 'rtf',   label: 'RTF',           description: 'Rich text format' },
 ];
 
 export function ExportOptionsDialog({
@@ -76,7 +75,6 @@ export function ExportOptionsDialog({
           className="bg-modal-bg rounded-lg w-[520px] max-w-[90%] flex flex-col shadow-lg animate-slide-in border border-modal-border"
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Header */}
           <div className="flex items-start gap-3 px-5 pt-5 pb-4">
             <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-border-subtle text-foreground-muted">
               <FileDown size={20} />
@@ -98,7 +96,6 @@ export function ExportOptionsDialog({
             </button>
           </div>
 
-          {/* Body */}
           <div className="px-5 pb-4 space-y-4">
             <OptionRow label="Page size">
               <SegmentedControl
@@ -163,7 +160,6 @@ export function ExportOptionsDialog({
               </button>
             </OptionRow>
 
-            {/* Advanced Formats button */}
             <div className="flex items-center justify-between pt-1">
               <div>
                 <div className="text-sm font-medium text-foreground">Advanced Formats</div>
@@ -179,7 +175,6 @@ export function ExportOptionsDialog({
             </div>
           </div>
 
-          {/* Footer */}
           <div className="flex items-center justify-end gap-2 px-5 pt-4 pb-5">
             <button
               className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border border-modal-border bg-transparent text-foreground hover:bg-[var(--overlay-10)] transition-all"
@@ -276,7 +271,6 @@ function AdvancedFormatsDialog({
           )}
         </p>
 
-        {/* Pandoc status gate */}
         {checkingPandoc && (
           <div className="px-5 pb-5 flex items-center justify-center py-10">
             <Loader2 size={16} className="animate-spin text-foreground-muted mr-2" />
@@ -290,7 +284,6 @@ function AdvancedFormatsDialog({
           </div>
         )}
 
-        {/* Format list */}
         {!checkingPandoc && pandocReady && (
           <>
             <div className="px-5 pb-4 space-y-1.5 max-h-[55vh] overflow-y-auto thin-scrollbar">

--- a/apps/frontend/components/editor/PandocDownloadGate.tsx
+++ b/apps/frontend/components/editor/PandocDownloadGate.tsx
@@ -46,9 +46,7 @@ export function PandocDownloadGate({ onInstalled }: PandocDownloadGateProps) {
     setState({ phase: 'downloading', percent: 0, downloadedBytes: 0, totalBytes: 0 });
     try {
       await window.electronAPI.coordinatorInvoke('pandoc/ensure-binary', {});
-    } catch {
-      // error handled via notification
-    }
+    } catch {}
   }, []);
 
   const handleCancel = useCallback(async () => {

--- a/apps/frontend/components/editor/PandocDownloadGate.tsx
+++ b/apps/frontend/components/editor/PandocDownloadGate.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Download, RefreshCw, AlertCircle } from 'lucide-react';
+
+interface PandocDownloadGateProps {
+  onInstalled: () => void;
+}
+
+type GateState =
+  | { phase: 'idle' }
+  | { phase: 'downloading'; percent: number; downloadedBytes: number; totalBytes: number }
+  | { phase: 'error'; message: string };
+
+export function PandocDownloadGate({ onInstalled }: PandocDownloadGateProps) {
+  const [state, setState] = useState<GateState>({ phase: 'idle' });
+
+  useEffect(() => {
+    const unsubs: (() => void)[] = [];
+
+    unsubs.push(
+      window.electronAPI.onCoordinatorNotification('pandoc/download-progress', (data: any) => {
+        setState({
+          phase: 'downloading',
+          percent: data.percent,
+          downloadedBytes: data.downloadedBytes,
+          totalBytes: data.totalBytes,
+        });
+      }),
+    );
+
+    unsubs.push(
+      window.electronAPI.onCoordinatorNotification('pandoc/download-complete', () => {
+        onInstalled();
+      }),
+    );
+
+    unsubs.push(
+      window.electronAPI.onCoordinatorNotification('pandoc/download-error', (data: any) => {
+        setState({ phase: 'error', message: data.error });
+      }),
+    );
+
+    return () => unsubs.forEach((u) => u());
+  }, [onInstalled]);
+
+  const handleDownload = useCallback(async () => {
+    setState({ phase: 'downloading', percent: 0, downloadedBytes: 0, totalBytes: 0 });
+    try {
+      await window.electronAPI.coordinatorInvoke('pandoc/ensure-binary', {});
+    } catch {
+      // error handled via notification
+    }
+  }, []);
+
+  const handleCancel = useCallback(async () => {
+    await window.electronAPI.coordinatorInvoke('pandoc/cancel-download', {});
+    setState({ phase: 'idle' });
+  }, []);
+
+  const handleRecheck = useCallback(async () => {
+    const status = await window.electronAPI.coordinatorInvoke('pandoc/binary-status', {});
+    if (status.available) onInstalled();
+  }, [onInstalled]);
+
+  if (state.phase === 'downloading') {
+    const downloadedMb = (state.downloadedBytes / 1024 / 1024).toFixed(1);
+    const totalMb = state.totalBytes > 0 ? (state.totalBytes / 1024 / 1024).toFixed(1) : '?';
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between text-sm text-foreground-muted">
+          <span>Downloading Pandoc...</span>
+          <span>{downloadedMb} / {totalMb} MB</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-border-subtle overflow-hidden">
+          <div
+            className="h-full bg-accent rounded-full transition-all duration-200"
+            style={{ width: `${state.percent}%` }}
+          />
+        </div>
+        <button
+          onClick={handleCancel}
+          className="px-3 py-1.5 rounded text-sm cursor-pointer border border-modal-border bg-transparent text-foreground-muted hover:bg-[var(--overlay-10)] transition-all"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  if (state.phase === 'error') {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm text-foreground-muted">
+          <AlertCircle size={16} />
+          <span>{state.message}</span>
+        </div>
+        <button
+          onClick={handleDownload}
+          className="px-3 py-1.5 rounded text-sm cursor-pointer border border-modal-border bg-transparent text-foreground-muted hover:bg-[var(--overlay-10)] transition-all"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm text-foreground-muted">
+        <Download size={16} />
+        <span>Advanced formats require Pandoc</span>
+      </div>
+      <p className="text-xs text-foreground-faint leading-relaxed">
+        Pandoc is a free document converter (~35 MB download).
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleDownload}
+          className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer border-none bg-accent text-surface hover:bg-accent-hover transition-all"
+        >
+          Download
+        </button>
+        <button
+          onClick={handleRecheck}
+          className="flex items-center gap-1.5 px-3 py-2 rounded-md text-sm cursor-pointer border border-modal-border bg-transparent text-foreground-muted hover:bg-[var(--overlay-10)] transition-all"
+        >
+          <RefreshCw size={14} />
+          I already have Pandoc
+        </button>
+      </div>
+      <p className="text-[11px] text-foreground-faint">
+        Pandoc by MacFarlane, Krewinkel &amp; Rosenthal — GPL-2.0
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/lib/pandoc-export.ts
+++ b/apps/frontend/lib/pandoc-export.ts
@@ -1,0 +1,91 @@
+import type { PandocFormat } from '@cushion/types';
+import { resolveWikiLink } from './wiki-link-resolver';
+
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico', '.avif']);
+const WIKI_EMBED_REGEX = /!\[\[([^\]]+?)\]\]/g;
+const WIKI_LINK_REGEX = /\[\[([^\[\]|#\n]+)(#[^\[\]|#\n]*)?(\|[^\[\]\n]*)?\]\]/g;
+const HIGHLIGHT_REGEX = /==((?:(?!==).)+)==/g;
+const CANCELED_TASK_REGEX = /^(\s*[-*+] )\[-\] (.+)$/gm;
+const STD_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g;
+
+function toAbsolute(relativePath: string, workspacePath: string): string {
+  if (!workspacePath) return relativePath;
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (/^[a-zA-Z]:/.test(normalized) || normalized.startsWith('/')) return relativePath;
+  return `${workspacePath.replace(/\\/g, '/')}/${normalized}`;
+}
+
+function preprocessForPandocExport(markdown: string, filePaths: string[], workspacePath: string): string {
+  let result = markdown;
+
+  // Wiki-embeds (must run before wiki-links so `![[` is consumed first)
+  result = result.replace(WIKI_EMBED_REGEX, (_match, inner: string) => {
+    const pipeIdx = inner.lastIndexOf('|');
+    let path = pipeIdx !== -1 ? inner.slice(0, pipeIdx) : inner;
+    const param = pipeIdx !== -1 ? inner.slice(pipeIdx + 1) : '';
+
+    const hashIdx = path.indexOf('#');
+    if (hashIdx !== -1) path = path.slice(0, hashIdx);
+
+    const ext = path.slice(path.lastIndexOf('.')).toLowerCase();
+
+    const resolved = resolveWikiLink(path, filePaths);
+    const target = resolved.state !== 'empty' && resolved.targets.length > 0
+      ? resolved.targets[0]
+      : path;
+    const absTarget = toAbsolute(target, workspacePath);
+
+    if (IMAGE_EXTS.has(ext)) {
+      const alt = param && !/^\d+$/.test(param) ? param : '';
+      return `![${alt}](<${absTarget}>)`;
+    }
+
+    const display = param || path;
+    return `[${display}](<${absTarget}>)`;
+  });
+
+  // Wiki-links
+  result = result.replace(WIKI_LINK_REGEX, (_match, rawHref: string, contentId: string | undefined, displayText: string | undefined) => {
+    const href = rawHref.trim();
+    const anchor = contentId ? contentId.trim() : '';
+    const display = displayText ? displayText.slice(1).trim() : '';
+    const fullHref = anchor ? `${href}${anchor}` : href;
+
+    if (display) return `[${display}](${fullHref})`;
+
+    const filename = href.split('/').pop() || href;
+    const label = anchor ? `${filename} > ${anchor.slice(1)}` : filename;
+    return `[${label}](${fullHref})`;
+  });
+
+  // Resolve standard markdown images to absolute paths
+  result = result.replace(STD_IMAGE_REGEX, (match, alt: string, href: string) => {
+    if (/^https?:\/\/|^data:/.test(href)) return match;
+    const clean = href.replace(/^<|>$/g, '');
+    return `![${alt}](<${toAbsolute(clean, workspacePath)}>)`;
+  });
+
+  // Highlights
+  result = result.replace(HIGHLIGHT_REGEX, '<mark>$1</mark>');
+
+  // Canceled tasks
+  result = result.replace(CANCELED_TASK_REGEX, '$1[ ] ~~$2~~');
+
+  return result;
+}
+
+export async function exportWithPandoc(
+  markdown: string,
+  title: string,
+  format: PandocFormat,
+  filePaths: string[],
+  workspacePath: string,
+): Promise<{ success: boolean; path: string | null }> {
+  const processed = preprocessForPandocExport(markdown, filePaths, workspacePath);
+  return window.electronAPI.coordinatorInvoke('pandoc/export', {
+    markdown: processed,
+    title,
+    format,
+    workspacePath,
+  });
+}

--- a/apps/frontend/lib/pandoc-export.ts
+++ b/apps/frontend/lib/pandoc-export.ts
@@ -58,7 +58,6 @@ function preprocessForPandocExport(markdown: string, filePaths: string[], worksp
     return `[${label}](${fullHref})`;
   });
 
-  // Resolve standard markdown images to absolute paths
   result = result.replace(STD_IMAGE_REGEX, (match, alt: string, href: string) => {
     if (/^https?:\/\/|^data:/.test(href)) return match;
     const clean = href.replace(/^<|>$/g, '');

--- a/apps/frontend/lib/pdf-export.ts
+++ b/apps/frontend/lib/pdf-export.ts
@@ -1,4 +1,5 @@
-import { marked, Renderer } from 'marked';
+import { marked, Renderer, type Tokens } from 'marked';
+import markedKatex from 'marked-katex-extension';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 import typescript from 'highlight.js/lib/languages/typescript';
@@ -14,6 +15,9 @@ import yaml from 'highlight.js/lib/languages/yaml';
 import markdown from 'highlight.js/lib/languages/markdown';
 import hljsTheme from 'highlight.js/styles/github.css?raw';
 import type { PdfExportOptions } from '@cushion/types';
+import { getSharedCoordinatorClient } from './shared-coordinator-client';
+import { resolveWikiLink } from './wiki-link-resolver';
+import { isRemoteSrc } from './codemirror-wysiwyg/embed-utils';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('js', javascript);
@@ -37,6 +41,10 @@ hljs.registerLanguage('yml', yaml);
 hljs.registerLanguage('markdown', markdown);
 hljs.registerLanguage('md', markdown);
 
+marked.use(markedKatex({ throwOnError: false, output: 'mathml' }));
+
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico', '.avif']);
+
 const MARGIN_MAP: Record<PdfExportOptions['margins'], string> = {
   default: '25mm 20mm',
   narrow: '15mm 10mm',
@@ -47,8 +55,9 @@ export async function exportToPdf(
   markdown: string,
   title: string,
   options: PdfExportOptions,
+  filePaths: string[],
 ): Promise<void> {
-  const html = buildPdfHtml(markdown, title, options);
+  const html = await buildPdfHtml(markdown, title, options, filePaths);
   await window.electronAPI.exportPdf({ html, title, options });
 }
 
@@ -62,11 +71,69 @@ function slugify(text: string): string {
     .trim();
 }
 
-function buildPdfHtml(
+function preprocessWikiImageEmbeds(source: string, filePaths: string[]): string {
+  return source.replace(/!\[\[([^\]]+?)\]\]/g, (_match, inner: string) => {
+    const pipeIdx = inner.lastIndexOf('|');
+    let path = pipeIdx !== -1 ? inner.slice(0, pipeIdx) : inner;
+    const alt = pipeIdx !== -1 ? inner.slice(pipeIdx + 1) : '';
+
+    const hashIdx = path.indexOf('#');
+    if (hashIdx !== -1) path = path.slice(0, hashIdx);
+
+    const ext = path.slice(path.lastIndexOf('.')).toLowerCase();
+    if (!IMAGE_EXTS.has(ext)) return _match;
+
+    const resolved = resolveWikiLink(path, filePaths);
+    const target = resolved.state !== 'empty' && resolved.targets.length > 0
+      ? resolved.targets[0]
+      : path;
+    return `![${alt}](<${target}>)`;
+  });
+}
+
+function fixImagePathsWithSpaces(source: string): string {
+  return source.replace(/!\[([^\]]*)\]\(([^)<][^)]*\s[^)]*)\)/g, (_match, alt: string, url: string) => {
+    return `![${alt}](<${url}>)`;
+  });
+}
+
+async function resolveImagePaths(source: string): Promise<Map<string, string>> {
+  const tokens = marked.lexer(source);
+  const localPaths = new Set<string>();
+  marked.walkTokens(tokens, (token) => {
+    if (token.type === 'image') {
+      const href = (token as Tokens.Image).href;
+      if (href && !isRemoteSrc(href)) localPaths.add(href);
+    }
+  });
+
+  const client = await getSharedCoordinatorClient();
+  const entries = await Promise.allSettled(
+    [...localPaths].map(async (path) => {
+      const { base64, mimeType } = await client.readFileBase64(path);
+      return [path, `data:${mimeType};base64,${base64}`] as const;
+    }),
+  );
+
+  const imageMap = new Map<string, string>();
+  for (const entry of entries) {
+    if (entry.status === 'fulfilled') {
+      imageMap.set(entry.value[0], entry.value[1]);
+    }
+  }
+  return imageMap;
+}
+
+async function buildPdfHtml(
   source: string,
   title: string,
   options: PdfExportOptions,
-): string {
+  filePaths: string[],
+): Promise<string> {
+  source = preprocessWikiImageEmbeds(source, filePaths);
+  source = fixImagePathsWithSpaces(source);
+  const imageMap = await resolveImagePaths(source);
+
   const renderer = new Renderer();
 
   renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
@@ -83,6 +150,12 @@ function buildPdfHtml(
   renderer.heading = ({ text, depth }: { text: string; depth: number }) => {
     const id = slugify(text);
     return `<h${depth} id="${escapeHtml(id)}">${text}</h${depth}>\n`;
+  };
+
+  renderer.image = ({ href, title: imgTitle, text }: Tokens.Image): string => {
+    const src = imageMap.get(href) ?? href;
+    const titleAttr = imgTitle ? ` title="${escapeHtml(imgTitle)}"` : '';
+    return `<img src="${src}" alt="${escapeHtml(text)}"${titleAttr} />`;
   };
 
   const body = marked.parse(source, { async: false, renderer }) as string;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -55,6 +55,7 @@
     "katex": "^0.16.28",
     "lucide-react": "^1.7.0",
     "marked": "^17.0.1",
+    "marked-katex-extension": "^5.1.7",
     "monaco-editor": "^0.55.1",
     "morphdom": "^2.7.8",
     "motion": "^12.38.0",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/electron": {
       "name": "electron-app",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@cushion/types": "workspace:*",
         "chokidar": "^5.0.0",
@@ -79,6 +79,7 @@
         "katex": "^0.16.28",
         "lucide-react": "^1.7.0",
         "marked": "^17.0.1",
+        "marked-katex-extension": "^5.1.7",
         "monaco-editor": "^0.55.1",
         "morphdom": "^2.7.8",
         "motion": "^12.38.0",
@@ -1351,6 +1352,8 @@
     "make-fetch-happen": ["make-fetch-happen@14.0.3", "", { "dependencies": { "@npmcli/agent": "^3.0.0", "cacache": "^19.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ=="],
 
     "marked": ["marked@17.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg=="],
+
+    "marked-katex-extension": ["marked-katex-extension@5.1.7", "", { "peerDependencies": { "katex": ">=0.16 <0.17", "marked": ">=4 <18" } }, "sha512-CVFzrqwpXGVaHByqcVvO/JfzW/OMWrAF3pEfNYNIruzBzM64moANSHapCg1qbzEN+NGf5unHwkMfwJIXHzyDAw=="],
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -124,3 +124,4 @@ export interface FileChangedOnDiskNotification {
 export * from './rpc.js';
 export * from './config.js';
 export * from './pdf-export.js';
+export * from './pandoc-export.js';

--- a/packages/types/src/pandoc-export.ts
+++ b/packages/types/src/pandoc-export.ts
@@ -1,0 +1,27 @@
+export type PandocFormat = 'docx' | 'epub' | 'html' | 'odt' | 'latex' | 'plain';
+
+export type ExportFormat = 'pdf' | PandocFormat;
+
+export interface PandocExportOptions {
+  format: PandocFormat;
+}
+
+export interface PandocBinaryStatus {
+  available: boolean;
+  path: string | null;
+  version: string | null;
+  source: 'system' | 'managed' | null;
+}
+
+export const PANDOC_FORMAT_META: Record<PandocFormat, {
+  label: string;
+  extension: string;
+  filterName: string;
+}> = {
+  docx:  { label: 'Word (.docx)',       extension: 'docx', filterName: 'Word Document' },
+  epub:  { label: 'EPUB (.epub)',        extension: 'epub', filterName: 'EPUB' },
+  html:  { label: 'HTML (.html)',        extension: 'html', filterName: 'HTML' },
+  odt:   { label: 'OpenDocument (.odt)', extension: 'odt',  filterName: 'OpenDocument Text' },
+  latex: { label: 'LaTeX (.tex)',        extension: 'tex',  filterName: 'LaTeX' },
+  plain: { label: 'Plain Text (.txt)',   extension: 'txt',  filterName: 'Plain Text' },
+};

--- a/packages/types/src/pandoc-export.ts
+++ b/packages/types/src/pandoc-export.ts
@@ -1,11 +1,5 @@
 export type PandocFormat = 'docx' | 'epub' | 'html' | 'odt' | 'latex' | 'plain';
 
-export type ExportFormat = 'pdf' | PandocFormat;
-
-export interface PandocExportOptions {
-  format: PandocFormat;
-}
-
 export interface PandocBinaryStatus {
   available: boolean;
   path: string | null;

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -1,6 +1,8 @@
 import type {
   FileTreeNode,
   FileChange,
+  PandocBinaryStatus,
+  PandocFormat,
 } from './index.js';
 
 export interface TrashItem {
@@ -305,6 +307,24 @@ export interface RPCMethodMap {
     params: void;
     result: { path: string };
   };
+
+  // Pandoc
+  'pandoc/binary-status': {
+    params: void;
+    result: PandocBinaryStatus;
+  };
+  'pandoc/ensure-binary': {
+    params: void;
+    result: { path: string };
+  };
+  'pandoc/cancel-download': {
+    params: void;
+    result: { cancelled: boolean };
+  };
+  'pandoc/export': {
+    params: { markdown: string; title: string; format: PandocFormat; workspacePath: string };
+    result: { success: boolean; path: string | null };
+  };
 }
 
 export interface RPCServerNotificationMap {
@@ -351,6 +371,14 @@ export interface RPCServerNotificationMap {
     completed?: number;
     percent: number;
   };
+
+  'pandoc/download-progress': {
+    downloadedBytes: number;
+    totalBytes: number;
+    percent: number;
+  };
+  'pandoc/download-complete': { path: string };
+  'pandoc/download-error': { error: string };
 }
 
 export type RPCMethodName = keyof RPCMethodMap;


### PR DESCRIPTION
## Summary
- Adds Pandoc-based export supporting DOCX, EPUB, HTML, ODT, LaTeX, and plain text formats
- Frontend preprocessing pipeline normalizes wiki-links, wiki-embeds, highlights, and canceled tasks to standard markdown before passing to Pandoc
- Pandoc binary manager handles downloading and managing the Pandoc binary with a download gate UI
- Improves existing PDF export to load HTML from temp files for reliable local image rendering

## Test plan
- [ ] Export a note with wiki-links, wiki-embeds, highlights, and canceled tasks to each format
- [ ] Verify images (both wiki-embed and standard markdown) appear correctly in DOCX, HTML, EPUB
- [ ] Test with notes containing paths with spaces
- [ ] Verify Pandoc binary download flow works on fresh install
- [ ] Test in production `.exe` build