### PR TITLE
Add extension system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ notes/
 
 # AI tools
 .claude/
+.cushion/
 
 # Build outputs
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ notes/
 
 # AI tools
 .claude/
+
+# Extensions (local user extensions)
 .cushion/
 
 # Build outputs

--- a/apps/electron/electron.vite.config.ts
+++ b/apps/electron/electron.vite.config.ts
@@ -8,7 +8,7 @@ const frontendRoot = resolve(__dirname, '../frontend');
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ['@cushion/extension-api'] })],
     build: {
       outDir: 'out/main',
       lib: {
@@ -36,6 +36,7 @@ export default defineConfig({
     resolve: {
       alias: {
         '@': frontendRoot,
+        '@extensions': resolve(__dirname, '../../packages/extension-api/manifests'),
       },
     },
     css: {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -11,6 +11,7 @@
     "type-check": "tsc -b"
   },
   "dependencies": {
+    "@cushion/extension-api": "workspace:*",
     "@cushion/types": "workspace:*",
     "chokidar": "^5.0.0",
     "ignore": "^7.0.5",

--- a/apps/electron/src/main/coordinator/handlers/extensions.ts
+++ b/apps/electron/src/main/coordinator/handlers/extensions.ts
@@ -4,48 +4,39 @@ import os from 'os';
 import { parseManifest } from '@cushion/extension-api';
 import type { DiscoveredExtension } from '@cushion/types';
 
+const EXTENSIONS_DIR = path.join(os.homedir(), '.cushion', 'extensions');
 const MAX_SOURCE_BYTES = 5 * 1024 * 1024;
 
-async function discoverExtensionsInDir(
-  dir: string,
-): Promise<DiscoveredExtension[]> {
+function resolveExtensionDir(dirName: string): string {
+  return path.join(EXTENSIONS_DIR, path.basename(dirName));
+}
+
+export async function handleDiscoverGlobal(): Promise<{ extensions: DiscoveredExtension[] }> {
   let entries;
   try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
+    entries = await fs.readdir(EXTENSIONS_DIR, { withFileTypes: true });
   } catch {
-    return [];
+    return { extensions: [] };
   }
 
-  const results: DiscoveredExtension[] = [];
+  const extensions: DiscoveredExtension[] = [];
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     try {
-      const manifestPath = path.join(dir, entry.name, 'cushion-extension.json');
+      const manifestPath = path.join(EXTENSIONS_DIR, entry.name, 'cushion-extension.json');
       const raw = await fs.readFile(manifestPath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      const manifest = parseManifest(parsed);
+      const manifest = parseManifest(JSON.parse(raw));
       if (!manifest) {
         console.warn(`[Extensions] Invalid manifest in ${entry.name}`);
         continue;
       }
-      results.push({ manifest, dirName: entry.name });
+      extensions.push({ manifest, dirName: entry.name });
     } catch {
       console.warn(`[Extensions] Skipping ${entry.name}: no valid manifest`);
     }
   }
 
-  return results;
-}
-
-function resolveExtensionDir(dirName: string): string {
-  const safe = path.basename(dirName);
-  return path.join(os.homedir(), '.cushion', 'extensions', safe);
-}
-
-export async function handleDiscoverGlobal(): Promise<{ extensions: DiscoveredExtension[] }> {
-  const dir = path.join(os.homedir(), '.cushion', 'extensions');
-  const extensions = await discoverExtensionsInDir(dir);
   return { extensions };
 }
 
@@ -60,7 +51,7 @@ export async function handleReadSource(
   if (!manifest) throw new Error(`Invalid manifest for ${params.dirName}`);
 
   if (!manifest.main) throw new Error(`Extension ${params.dirName} has no main entry point`);
-  const mainPath = path.join(extDir, manifest.main);
+  const mainPath = path.join(extDir, path.basename(manifest.main));
   const stat = await fs.stat(mainPath);
   if (stat.size > MAX_SOURCE_BYTES) {
     throw new Error(`Extension source exceeds 5MB limit (${params.dirName})`);
@@ -81,7 +72,7 @@ export async function handleReadIcon(
     const manifest = parseManifest(JSON.parse(raw));
     if (!manifest?.icon) return { svg: null };
 
-    const iconPath = path.join(extDir, manifest.icon);
+    const iconPath = path.join(extDir, path.basename(manifest.icon));
     const svg = await fs.readFile(iconPath, 'utf-8');
     return { svg };
   } catch {

--- a/apps/electron/src/main/coordinator/handlers/extensions.ts
+++ b/apps/electron/src/main/coordinator/handlers/extensions.ts
@@ -1,0 +1,90 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { parseManifest } from '@cushion/extension-api';
+import type { DiscoveredExtension } from '@cushion/types';
+
+const MAX_SOURCE_BYTES = 5 * 1024 * 1024;
+
+async function discoverExtensionsInDir(
+  dir: string,
+): Promise<DiscoveredExtension[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: DiscoveredExtension[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const manifestPath = path.join(dir, entry.name, 'cushion-extension.json');
+      const raw = await fs.readFile(manifestPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      const manifest = parseManifest(parsed);
+      if (!manifest) {
+        console.warn(`[Extensions] Invalid manifest in ${entry.name}`);
+        continue;
+      }
+      results.push({ manifest, dirName: entry.name });
+    } catch {
+      console.warn(`[Extensions] Skipping ${entry.name}: no valid manifest`);
+    }
+  }
+
+  return results;
+}
+
+function resolveExtensionDir(dirName: string): string {
+  const safe = path.basename(dirName);
+  return path.join(os.homedir(), '.cushion', 'extensions', safe);
+}
+
+export async function handleDiscoverGlobal(): Promise<{ extensions: DiscoveredExtension[] }> {
+  const dir = path.join(os.homedir(), '.cushion', 'extensions');
+  const extensions = await discoverExtensionsInDir(dir);
+  return { extensions };
+}
+
+export async function handleReadSource(
+  params: { dirName: string },
+): Promise<{ source: string }> {
+  const extDir = resolveExtensionDir(params.dirName);
+
+  const manifestPath = path.join(extDir, 'cushion-extension.json');
+  const raw = await fs.readFile(manifestPath, 'utf-8');
+  const manifest = parseManifest(JSON.parse(raw));
+  if (!manifest) throw new Error(`Invalid manifest for ${params.dirName}`);
+
+  if (!manifest.main) throw new Error(`Extension ${params.dirName} has no main entry point`);
+  const mainPath = path.join(extDir, manifest.main);
+  const stat = await fs.stat(mainPath);
+  if (stat.size > MAX_SOURCE_BYTES) {
+    throw new Error(`Extension source exceeds 5MB limit (${params.dirName})`);
+  }
+
+  const source = await fs.readFile(mainPath, 'utf-8');
+  return { source };
+}
+
+export async function handleReadIcon(
+  params: { dirName: string },
+): Promise<{ svg: string | null }> {
+  const extDir = resolveExtensionDir(params.dirName);
+
+  const manifestPath = path.join(extDir, 'cushion-extension.json');
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf-8');
+    const manifest = parseManifest(JSON.parse(raw));
+    if (!manifest?.icon) return { svg: null };
+
+    const iconPath = path.join(extDir, manifest.icon);
+    const svg = await fs.readFile(iconPath, 'utf-8');
+    return { svg };
+  } catch {
+    return { svg: null };
+  }
+}

--- a/apps/electron/src/main/coordinator/ipc-router.ts
+++ b/apps/electron/src/main/coordinator/ipc-router.ts
@@ -61,6 +61,12 @@ import {
 } from './handlers/ollama';
 
 import {
+  handleDiscoverGlobal,
+  handleReadSource,
+  handleReadIcon,
+} from './handlers/extensions';
+
+import {
   handleDictationListModels,
   handleDictationDownloadModel,
   handleDictationCancelDownload,
@@ -415,6 +421,19 @@ export async function initCoordinator(mainWindow: BrowserWindow) {
 
   ipcMain.handle('coordinator:pandoc/export', async (_event, params: RPCParams<'pandoc/export'>) => {
     return handlePandocExport(pandocBinaryManager, params, mainWindow);
+  });
+
+  // Extension handlers
+  ipcMain.handle('coordinator:extensions/discover-global', async () => {
+    return handleDiscoverGlobal();
+  });
+
+  ipcMain.handle('coordinator:extensions/read-source', async (_event, params: RPCParams<'extensions/read-source'>) => {
+    return handleReadSource(params);
+  });
+
+  ipcMain.handle('coordinator:extensions/read-icon', async (_event, params: RPCParams<'extensions/read-icon'>) => {
+    return handleReadIcon(params);
   });
 }
 

--- a/apps/electron/src/main/coordinator/workspace-manager.ts
+++ b/apps/electron/src/main/coordinator/workspace-manager.ts
@@ -48,10 +48,6 @@ export class WorkspaceManager {
   );
   private gitignoreStack: Array<{ basePath: string; ig: Ignore }> = [];
 
-  getProjectPath(): string | null {
-    return this.currentWorkspace?.projectPath ?? null;
-  }
-
   setFileFilter(respectGitignore: boolean, extensions: string[]) {
     this.respectGitignore = respectGitignore;
     this.allowedExtensions = new Set(extensions.map((e) => e.toLowerCase()));

--- a/apps/electron/src/main/coordinator/workspace-manager.ts
+++ b/apps/electron/src/main/coordinator/workspace-manager.ts
@@ -48,6 +48,10 @@ export class WorkspaceManager {
   );
   private gitignoreStack: Array<{ basePath: string; ig: Ignore }> = [];
 
+  getProjectPath(): string | null {
+    return this.currentWorkspace?.projectPath ?? null;
+  }
+
   setFileFilter(respectGitignore: boolean, extensions: string[]) {
     this.respectGitignore = respectGitignore;
     this.allowedExtensions = new Set(extensions.map((e) => e.toLowerCase()));

--- a/apps/frontend/components/editor/EditorPane.tsx
+++ b/apps/frontend/components/editor/EditorPane.tsx
@@ -8,7 +8,7 @@ import { buildNewFilePath } from '@/lib/wiki-link-resolver';
 import { uint8ArrayToBase64 } from '@/lib/pdf-bytes';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
 import type { EditorView } from '@codemirror/view';
-import { isBinaryFile } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/view-registry';
 import type { WikiLinkNavigateCallback } from '@/lib/codemirror-wysiwyg';
 import { DiffReviewBar } from './DiffReviewBar';
 import { useDiffReviewStore } from '@/stores/diffReviewStore';
@@ -585,16 +585,9 @@ export function EditorPane({
           const isMarkdown = /\.(md|markdown)$/i.test(fp);
 
           if (resolved) {
-            if (resolved.source === 'extension' || resolved.source === 'bundled') {
-              return (
-                <div key={fp} style={{ display: isActive ? undefined : 'none', height: isActive ? '100%' : undefined }}>
-                  <ExtensionHost filePath={fp} component={resolved.component} binary={resolved.binary} isActive={isActive} />
-                </div>
-              );
-            }
             return (
-              <div key={fp} style={{ display: isActive ? undefined : 'none', height: isActive ? '100%' : undefined }} className={isActive ? 'contents' : undefined}>
-                <resolved.component filePath={fp} />
+              <div key={fp} style={{ display: isActive ? undefined : 'none', height: isActive ? '100%' : undefined }}>
+                <ExtensionHost filePath={fp} component={resolved.component} binary={resolved.binary} isActive={isActive} />
               </div>
             );
           }

--- a/apps/frontend/components/editor/EditorPane.tsx
+++ b/apps/frontend/components/editor/EditorPane.tsx
@@ -8,7 +8,7 @@ import { buildNewFilePath } from '@/lib/wiki-link-resolver';
 import { uint8ArrayToBase64 } from '@/lib/pdf-bytes';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
 import type { EditorView } from '@codemirror/view';
-import { BINARY_FILE_EXTENSIONS } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/binary-extensions';
 import type { WikiLinkNavigateCallback } from '@/lib/codemirror-wysiwyg';
 import { DiffReviewBar } from './DiffReviewBar';
 import { useDiffReviewStore } from '@/stores/diffReviewStore';
@@ -17,6 +17,7 @@ import { exportWithPandoc } from '@/lib/pandoc-export';
 import { ExportOptionsDialog } from './ExportOptionsDialog';
 import type { PdfExportOptions, PandocFormat } from '@cushion/types';
 import { getViewForFile } from '@/lib/view-registry';
+import { ExtensionHost } from './ExtensionHost';
 import { EditorPanelProvider } from './EditorPanelContext';
 import { RecordingOverlay } from './RecordingOverlay';
 import { setInsertTextCallback, setGetNoteContextCallback, setOnTextInsertedCallback, useDictationStore } from '@/stores/dictationStore';
@@ -285,8 +286,7 @@ export function EditorPane({
     ({ files, view, filePath }: { files: File[]; view: EditorView; filePath: string }) => {
       if (!files.length) return;
 
-      const noteDir = filePath.split('/').slice(0, -1).join('/');
-      const pasteFolder = joinWorkspacePath(noteDir, '.attachments');
+      const pasteFolder = '.cushion/attachments';
 
       const selection = view.state.selection.main;
       const timestamp = new Date();
@@ -295,15 +295,6 @@ export function EditorPane({
         const filename = buildPastedImageName(timestamp, index, extension);
         const relativePath = joinWorkspacePath(pasteFolder, filename);
         return { file, relativePath };
-      });
-
-      const insertText = targets
-        .map((target) => `![[${target.relativePath}]]`)
-        .join('\n');
-
-      view.dispatch({
-        changes: { from: selection.from, to: selection.to, insert: insertText },
-        selection: { anchor: selection.from + insertText.length },
       });
 
       void (async () => {
@@ -323,6 +314,15 @@ export function EditorPane({
             alert('Failed to save pasted image: ' + target.relativePath);
           }
         }
+
+        const insertText = targets
+          .map((target) => `![[${target.relativePath}]]`)
+          .join('\n');
+
+        view.dispatch({
+          changes: { from: selection.from, to: selection.to, insert: insertText },
+          selection: { anchor: selection.from + insertText.length },
+        });
       })();
     },
     [client]
@@ -483,7 +483,7 @@ export function EditorPane({
     async (href, resolvedPath, createIfMissing) => {
       if (resolvedPath) {
         try {
-          if (BINARY_FILE_EXTENSIONS.test(resolvedPath)) {
+          if (isBinaryFile(resolvedPath)) {
             openFile(resolvedPath, '');
             return;
           }
@@ -585,6 +585,13 @@ export function EditorPane({
           const isMarkdown = /\.(md|markdown)$/i.test(fp);
 
           if (resolved) {
+            if (resolved.source === 'extension' || resolved.source === 'bundled') {
+              return (
+                <div key={fp} style={{ display: isActive ? undefined : 'none', height: isActive ? '100%' : undefined }}>
+                  <ExtensionHost filePath={fp} component={resolved.component} binary={resolved.binary} isActive={isActive} />
+                </div>
+              );
+            }
             return (
               <div key={fp} style={{ display: isActive ? undefined : 'none', height: isActive ? '100%' : undefined }} className={isActive ? 'contents' : undefined}>
                 <resolved.component filePath={fp} />
@@ -604,6 +611,13 @@ export function EditorPane({
           }
 
           if (isActive) {
+            if (isBinaryFile(fp)) {
+              return (
+                <div key={fp} className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                  No viewer available for this file type
+                </div>
+              );
+            }
             return (
               <div key={fp} className="contents">
                 <Suspense fallback={<div className="flex-1" />}>

--- a/apps/frontend/components/editor/ExcalidrawExtension.tsx
+++ b/apps/frontend/components/editor/ExcalidrawExtension.tsx
@@ -115,7 +115,6 @@ function ExcalidrawCanvas({ ctx, initialData }: ExcalidrawCanvasProps) {
     }, null, 2);
   }, []);
 
-  // Watch for external changes
   useEffect(() => {
     return ctx.file.onExternalChange((content) => {
       if (!content?.trim()) return;
@@ -127,9 +126,7 @@ function ExcalidrawCanvas({ ctx, initialData }: ExcalidrawCanvasProps) {
           elementsRef.current = parsed.elements ?? [];
           filesRef.current = parsed.files ?? {};
         }
-      } catch {
-        // Invalid JSON — ignore
-      }
+      } catch {}
     });
   }, [ctx.file]);
 

--- a/apps/frontend/components/editor/ExcalidrawExtension.tsx
+++ b/apps/frontend/components/editor/ExcalidrawExtension.tsx
@@ -1,9 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { Excalidraw } from '@excalidraw/excalidraw';
 import '@excalidraw/excalidraw/index.css';
-import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
-import { useAppearanceStore } from '@/stores/appearanceStore';
-import type { ViewProps } from '@/lib/view-registry';
+import type { ExtensionContext } from '@cushion/extension-api';
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types';
 
 if (typeof window !== 'undefined') {
@@ -19,7 +17,6 @@ const DEFAULT_SCENE = {
   files: {},
 };
 
-// appState keys to strip before saving (volatile/session-only state)
 const VOLATILE_APP_STATE_KEYS = new Set([
   'collaborators',
   'cursorButton',
@@ -40,7 +37,7 @@ const VOLATILE_APP_STATE_KEYS = new Set([
   'previousSelectedElementIds',
 ]);
 
-export function ExcalidrawView({ filePath }: ViewProps) {
+export function ExcalidrawExtension({ ctx }: { ctx: ExtensionContext }) {
   const [initialData, setInitialData] = useState<Record<string, any> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,14 +46,9 @@ export function ExcalidrawView({ filePath }: ViewProps) {
     setInitialData(null);
     setError(null);
 
-    getSharedCoordinatorClient()
-      .then((client) => {
+    ctx.file.read()
+      .then((content) => {
         if (cancelled) return;
-        return client.readFile(filePath);
-      })
-      .then((result) => {
-        if (cancelled || !result) return;
-        const { content } = result;
         if (!content || !content.trim()) {
           setInitialData(DEFAULT_SCENE);
           return;
@@ -73,7 +65,7 @@ export function ExcalidrawView({ filePath }: ViewProps) {
       });
 
     return () => { cancelled = true; };
-  }, [filePath]);
+  }, [ctx.file]);
 
   if (error) {
     return (
@@ -91,29 +83,20 @@ export function ExcalidrawView({ filePath }: ViewProps) {
     );
   }
 
-  return <ExcalidrawCanvas key={filePath} filePath={filePath} initialData={initialData} />;
+  return <ExcalidrawCanvas ctx={ctx} initialData={initialData} />;
 }
 
 interface ExcalidrawCanvasProps {
-  filePath: string;
+  ctx: ExtensionContext;
   initialData: Record<string, any>;
 }
 
-function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
-  const resolvedTheme = useAppearanceStore((s) => s.resolvedTheme);
+function ExcalidrawCanvas({ ctx, initialData }: ExcalidrawCanvasProps) {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const elementsRef = useRef<any[]>(initialData.elements ?? []);
   const appStateRef = useRef<Record<string, any>>(initialData.appState ?? {});
   const filesRef = useRef<Record<string, any>>(initialData.files ?? {});
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const filePathRef = useRef(filePath);
-  // skip our own saves
-  const lastSavedJsonRef = useRef<string | null>(null);
   const mountedRef = useRef(false);
-
-  useEffect(() => {
-    filePathRef.current = filePath;
-  }, [filePath]);
 
   const buildJson = useCallback(() => {
     const cleanAppState: Record<string, any> = {};
@@ -132,45 +115,11 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
     }, null, 2);
   }, []);
 
-  const flush = useCallback(async () => {
-    const json = buildJson();
-    try {
-      const client = await getSharedCoordinatorClient();
-      lastSavedJsonRef.current = json;
-      await client.saveFile(filePathRef.current, json);
-    } catch (err) {
-      console.error('[ExcalidrawView] Save failed:', err);
-    }
-  }, [buildJson]);
-
-  const scheduleSave = useCallback(() => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(flush, 1000);
-  }, [flush]);
-
+  // Watch for external changes
   useEffect(() => {
-    return () => {
-      if (saveTimerRef.current) {
-        clearTimeout(saveTimerRef.current);
-        flush();
-      }
-    };
-  }, [flush]);
-
-  // Watch for external file changes
-  useEffect(() => {
-    let unsubDisk: (() => void) | undefined;
-    let unsubFiles: (() => void) | undefined;
-
-    const reload = async () => {
+    return ctx.file.onExternalChange((content) => {
+      if (!content?.trim()) return;
       try {
-        const client = await getSharedCoordinatorClient();
-        const { content } = await client.readFile(filePathRef.current);
-        if (!content?.trim()) return;
-
-        // If it matches what we last saved, it's our own write — skip
-        if (content === lastSavedJsonRef.current) return;
-
         const parsed = JSON.parse(content);
         const api = apiRef.current;
         if (api) {
@@ -179,24 +128,10 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
           filesRef.current = parsed.files ?? {};
         }
       } catch {
-        // File may have been deleted or is invalid JSON
+        // Invalid JSON — ignore
       }
-    };
-
-    getSharedCoordinatorClient().then((client) => {
-      unsubDisk = client.onFileChangedOnDisk((changedPath) => {
-        if (changedPath !== filePath) return;
-        reload();
-      });
-
-      unsubFiles = client.onFilesChanged((changes) => {
-        if (!changes.some((c) => c.path === filePath)) return;
-        reload();
-      });
     });
-
-    return () => { unsubDisk?.(); unsubFiles?.(); };
-  }, [filePath]);
+  }, [ctx.file]);
 
   const handleChange = useCallback(
     (elements: readonly any[], appState: Record<string, any>, files: any) => {
@@ -209,13 +144,13 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
         return;
       }
 
-      scheduleSave();
+      ctx.file.update(buildJson());
     },
-    [scheduleSave],
+    [ctx.file, buildJson],
   );
 
   return (
-    <div className="w-full h-full">
+    <div className="w-full h-full min-w-0 overflow-hidden">
       <Excalidraw
         excalidrawAPI={(api) => { apiRef.current = api; }}
         initialData={{
@@ -224,7 +159,7 @@ function ExcalidrawCanvas({ filePath, initialData }: ExcalidrawCanvasProps) {
           files: initialData.files,
         }}
         onChange={handleChange}
-        theme={resolvedTheme}
+        theme={ctx.theme}
         UIOptions={{
           canvasActions: {
             loadScene: false,

--- a/apps/frontend/components/editor/ExtensionErrorBoundary.tsx
+++ b/apps/frontend/components/editor/ExtensionErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+interface Props {
+  filePath: string;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ExtensionErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ExtensionErrorBoundary] Extension crashed:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          className="flex flex-col items-center justify-center h-full gap-3 p-6 text-sm"
+          style={{ color: 'var(--foreground)' }}
+        >
+          <div className="font-medium" style={{ color: 'var(--accent-red)' }}>
+            Extension crashed
+          </div>
+          <div className="text-center max-w-md" style={{ color: 'var(--muted-foreground)' }}>
+            {this.state.error.message}
+          </div>
+          <div className="text-xs truncate max-w-md" style={{ color: 'var(--muted-foreground)' }}>
+            {this.props.filePath}
+          </div>
+          <button
+            onClick={() => this.setState({ error: null })}
+            className="mt-2 px-3 py-1.5 rounded text-xs transition-colors"
+            style={{
+              backgroundColor: 'var(--muted)',
+              color: 'var(--foreground)',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/frontend/components/editor/ExtensionHost.tsx
+++ b/apps/frontend/components/editor/ExtensionHost.tsx
@@ -1,6 +1,6 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ComponentType } from 'react';
-import type { ExtensionContext, ExtensionDimensions } from '@cushion/extension-api';
+import type { ExtensionContext } from '@cushion/extension-api';
 import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
 import { useAppearanceStore } from '@/stores/appearanceStore';
 import { ExtensionErrorBoundary } from './ExtensionErrorBoundary';
@@ -15,7 +15,6 @@ interface ExtensionHostProps {
 export function ExtensionHost({ filePath, component: Component, binary, isActive = false }: ExtensionHostProps) {
   const theme = useAppearanceStore((s) => s.resolvedTheme);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [dimensions, setDimensions] = useState<ExtensionDimensions>({ width: 0, height: 0 });
 
   const pendingRef = useRef<string | null>(null);
   const pendingBinaryRef = useRef(false);
@@ -28,32 +27,6 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
     filePathRef.current = filePath;
   }, [filePath]);
 
-  // -- Dimensions via ResizeObserver --
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    const observer = new ResizeObserver((entries) => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        const entry = entries[0];
-        if (entry) {
-          setDimensions({
-            width: entry.contentRect.width,
-            height: entry.contentRect.height,
-          });
-        }
-      }, 100);
-    });
-    observer.observe(el);
-    return () => {
-      observer.disconnect();
-      if (timer) clearTimeout(timer);
-    };
-  }, []);
-
-  // -- Save pipeline --
   const flush = useCallback(async () => {
     const content = pendingRef.current;
     if (content === null) return;
@@ -88,7 +61,6 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
     saveTimerRef.current = setTimeout(flush, 1000);
   }, [flush]);
 
-  // Flush on unmount
   useEffect(() => {
     return () => {
       if (saveTimerRef.current) {
@@ -100,7 +72,6 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
     };
   }, [flush]);
 
-  // -- Skip-own-write: watch for external file changes --
   useEffect(() => {
     let unsubDisk: (() => void) | undefined;
     let unsubFiles: (() => void) | undefined;
@@ -110,7 +81,6 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
         const client = await getSharedCoordinatorClient();
         const fp = filePathRef.current;
         if (binary) {
-          // Binary extensions get null — they should call read() themselves
           for (const cb of externalChangeCallbacksRef.current) {
             cb(null);
           }
@@ -121,9 +91,7 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
             cb(content);
           }
         }
-      } catch {
-        // File may have been deleted
-      }
+      } catch {}
     };
 
     getSharedCoordinatorClient().then((client) => {
@@ -144,7 +112,6 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
     };
   }, [filePath, binary]);
 
-  // -- Ctrl+S handler --
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -158,7 +125,6 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
     return () => el.removeEventListener('keydown', handleKeyDown);
   }, [flush]);
 
-  // -- Build context (file API memoized separately for reference stability) --
   const onExternalChange = useCallback((callback: (content: string | null) => void) => {
     externalChangeCallbacksRef.current.add(callback);
     return () => {
@@ -184,39 +150,17 @@ export function ExtensionHost({ filePath, component: Component, binary, isActive
     updateBase64,
     flush,
     onExternalChange,
-    async readOther(workspacePath: string) {
-      const client = await getSharedCoordinatorClient();
-      const result = await client.readFile(workspacePath);
-      return result.content;
-    },
-    async readOtherBase64(workspacePath: string) {
-      const client = await getSharedCoordinatorClient();
-      return client.readFileBase64(workspacePath);
-    },
   }), [filePath, binary, update, updateBase64, flush, onExternalChange]);
 
   const ctx = useMemo<ExtensionContext>(() => ({
     filePath,
     theme,
-    dimensions,
     file: fileApi,
     isActive,
-  }), [filePath, theme, dimensions, fileApi, isActive]);
-
-  // -- CSS variable pass-through --
-  const containerStyle = useMemo(() => ({
-    height: '100%',
-    minWidth: 0,
-    '--ext-background': 'var(--background)',
-    '--ext-foreground': 'var(--foreground)',
-    '--ext-accent-primary': 'var(--accent-primary)',
-    '--ext-border': 'var(--border)',
-    '--ext-muted': 'var(--muted)',
-    '--ext-muted-foreground': 'var(--muted-foreground)',
-  } as React.CSSProperties), []);
+  }), [filePath, theme, fileApi, isActive]);
 
   return (
-    <div ref={containerRef} className="overflow-x-hidden" style={containerStyle}>
+    <div ref={containerRef} className="overflow-x-hidden" style={{ height: '100%', minWidth: 0 }}>
       <ExtensionErrorBoundary filePath={filePath}>
         <Suspense fallback={
           <div className="flex items-center justify-center h-full text-muted-foreground">

--- a/apps/frontend/components/editor/ExtensionHost.tsx
+++ b/apps/frontend/components/editor/ExtensionHost.tsx
@@ -1,0 +1,231 @@
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ComponentType } from 'react';
+import type { ExtensionContext, ExtensionDimensions } from '@cushion/extension-api';
+import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
+import { useAppearanceStore } from '@/stores/appearanceStore';
+import { ExtensionErrorBoundary } from './ExtensionErrorBoundary';
+
+interface ExtensionHostProps {
+  filePath: string;
+  component: ComponentType<{ ctx: ExtensionContext }>;
+  binary?: boolean;
+  isActive?: boolean;
+}
+
+export function ExtensionHost({ filePath, component: Component, binary, isActive = false }: ExtensionHostProps) {
+  const theme = useAppearanceStore((s) => s.resolvedTheme);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState<ExtensionDimensions>({ width: 0, height: 0 });
+
+  const pendingRef = useRef<string | null>(null);
+  const pendingBinaryRef = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastWrittenRef = useRef<string | null>(null);
+  const filePathRef = useRef(filePath);
+  const externalChangeCallbacksRef = useRef<Set<(content: string | null) => void>>(new Set());
+
+  useEffect(() => {
+    filePathRef.current = filePath;
+  }, [filePath]);
+
+  // -- Dimensions via ResizeObserver --
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const observer = new ResizeObserver((entries) => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        const entry = entries[0];
+        if (entry) {
+          setDimensions({
+            width: entry.contentRect.width,
+            height: entry.contentRect.height,
+          });
+        }
+      }, 100);
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  // -- Save pipeline --
+  const flush = useCallback(async () => {
+    const content = pendingRef.current;
+    if (content === null) return;
+    pendingRef.current = null;
+
+    try {
+      const client = await getSharedCoordinatorClient();
+      const fp = filePathRef.current;
+      if (pendingBinaryRef.current) {
+        await client.saveFileBase64(fp, content);
+      } else {
+        await client.saveFile(fp, content);
+      }
+      lastWrittenRef.current = content;
+      pendingBinaryRef.current = false;
+    } catch (err) {
+      console.error('[ExtensionHost] Save failed:', err);
+    }
+  }, []);
+
+  const update = useCallback((content: string) => {
+    pendingRef.current = content;
+    pendingBinaryRef.current = false;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(flush, 1000);
+  }, [flush]);
+
+  const updateBase64 = useCallback((base64: string) => {
+    pendingRef.current = base64;
+    pendingBinaryRef.current = true;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(flush, 1000);
+  }, [flush]);
+
+  // Flush on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+      if (pendingRef.current !== null) {
+        flush();
+      }
+    };
+  }, [flush]);
+
+  // -- Skip-own-write: watch for external file changes --
+  useEffect(() => {
+    let unsubDisk: (() => void) | undefined;
+    let unsubFiles: (() => void) | undefined;
+
+    const reload = async () => {
+      try {
+        const client = await getSharedCoordinatorClient();
+        const fp = filePathRef.current;
+        if (binary) {
+          // Binary extensions get null — they should call read() themselves
+          for (const cb of externalChangeCallbacksRef.current) {
+            cb(null);
+          }
+        } else {
+          const content = (await client.readFile(fp)).content;
+          if (content === lastWrittenRef.current) return;
+          for (const cb of externalChangeCallbacksRef.current) {
+            cb(content);
+          }
+        }
+      } catch {
+        // File may have been deleted
+      }
+    };
+
+    getSharedCoordinatorClient().then((client) => {
+      unsubDisk = client.onFileChangedOnDisk((changedPath) => {
+        if (changedPath !== filePath) return;
+        reload();
+      });
+
+      unsubFiles = client.onFilesChanged((changes) => {
+        if (!changes.some((c) => c.path === filePath)) return;
+        reload();
+      });
+    });
+
+    return () => {
+      unsubDisk?.();
+      unsubFiles?.();
+    };
+  }, [filePath, binary]);
+
+  // -- Ctrl+S handler --
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        flush();
+      }
+    };
+    el.addEventListener('keydown', handleKeyDown);
+    return () => el.removeEventListener('keydown', handleKeyDown);
+  }, [flush]);
+
+  // -- Build context (file API memoized separately for reference stability) --
+  const onExternalChange = useCallback((callback: (content: string | null) => void) => {
+    externalChangeCallbacksRef.current.add(callback);
+    return () => {
+      externalChangeCallbacksRef.current.delete(callback);
+    };
+  }, []);
+
+  const fileApi = useMemo(() => ({
+    async read() {
+      const client = await getSharedCoordinatorClient();
+      if (binary) {
+        const result = await client.readFileBase64(filePath);
+        return result.base64;
+      }
+      const result = await client.readFile(filePath);
+      return result.content;
+    },
+    async readChunk(offset: number, length: number) {
+      const client = await getSharedCoordinatorClient();
+      return client.readFileBase64Chunk(filePath, offset, length);
+    },
+    update,
+    updateBase64,
+    flush,
+    onExternalChange,
+    async readOther(workspacePath: string) {
+      const client = await getSharedCoordinatorClient();
+      const result = await client.readFile(workspacePath);
+      return result.content;
+    },
+    async readOtherBase64(workspacePath: string) {
+      const client = await getSharedCoordinatorClient();
+      return client.readFileBase64(workspacePath);
+    },
+  }), [filePath, binary, update, updateBase64, flush, onExternalChange]);
+
+  const ctx = useMemo<ExtensionContext>(() => ({
+    filePath,
+    theme,
+    dimensions,
+    file: fileApi,
+    isActive,
+  }), [filePath, theme, dimensions, fileApi, isActive]);
+
+  // -- CSS variable pass-through --
+  const containerStyle = useMemo(() => ({
+    height: '100%',
+    minWidth: 0,
+    '--ext-background': 'var(--background)',
+    '--ext-foreground': 'var(--foreground)',
+    '--ext-accent-primary': 'var(--accent-primary)',
+    '--ext-border': 'var(--border)',
+    '--ext-muted': 'var(--muted)',
+    '--ext-muted-foreground': 'var(--muted-foreground)',
+  } as React.CSSProperties), []);
+
+  return (
+    <div ref={containerRef} className="overflow-x-hidden" style={containerStyle}>
+      <ExtensionErrorBoundary filePath={filePath}>
+        <Suspense fallback={
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            Loading extension…
+          </div>
+        }>
+          <Component ctx={ctx} />
+        </Suspense>
+      </ExtensionErrorBoundary>
+    </div>
+  );
+}

--- a/apps/frontend/components/editor/ImageExtension.tsx
+++ b/apps/frontend/components/editor/ImageExtension.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatShortcutList, useShortcutBindings, useShortcutHandler } from '@/lib/shortcuts';
@@ -34,10 +34,9 @@ export function ImageExtension({ ctx }: { ctx: ExtensionContext }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const imageShortcuts = useShortcutBindings(IMAGE_SHORTCUT_IDS);
 
-  const mimeType = useMemo(() => getMimeType(ctx.filePath), [ctx.filePath]);
-  const fileName = useMemo(() => ctx.filePath.split(/[/\\]/).pop() || ctx.filePath, [ctx.filePath]);
+  const mimeType = getMimeType(ctx.filePath);
+  const fileName = ctx.filePath.split(/[/\\]/).pop() || ctx.filePath;
 
-  // Load image on mount
   useEffect(() => {
     let cancelled = false;
     ctx.file.read().then((data) => {
@@ -48,7 +47,6 @@ export function ImageExtension({ ctx }: { ctx: ExtensionContext }) {
     return () => { cancelled = true; };
   }, [ctx.file]);
 
-  // Reload on external change
   useEffect(() => {
     return ctx.file.onExternalChange((content) => {
       if (content === null) {
@@ -61,7 +59,6 @@ export function ImageExtension({ ctx }: { ctx: ExtensionContext }) {
   const zoomOut = useCallback(() => setScale(s => Math.max(s / 1.25, 0.1)), []);
   const resetView = useCallback(() => { setScale(1); setPosition({ x: 0, y: 0 }); }, []);
 
-  // Ctrl+Scroll zoom
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -75,12 +72,11 @@ export function ImageExtension({ ctx }: { ctx: ExtensionContext }) {
     return () => el.removeEventListener('wheel', onWheel);
   }, []);
 
-  // Keyboard shortcuts — only active when this tab is visible
-  const imageHandlers = useMemo(() => ({
-    'image.zoom.in': () => { zoomIn(); },
-    'image.zoom.out': () => { zoomOut(); },
-    'image.reset': () => { resetView(); },
-  } as const), [zoomIn, zoomOut, resetView]);
+  const imageHandlers = {
+    'image.zoom.in': zoomIn,
+    'image.zoom.out': zoomOut,
+    'image.reset': resetView,
+  } as const;
 
   useShortcutHandler({ handlers: imageHandlers, enabled: ctx.isActive });
 

--- a/apps/frontend/components/editor/ImageExtension.tsx
+++ b/apps/frontend/components/editor/ImageExtension.tsx
@@ -1,43 +1,31 @@
-
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatShortcutList, useShortcutBindings, useShortcutHandler } from '@/lib/shortcuts';
-import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
-import type { ViewProps } from '@/lib/view-registry';
+import type { ExtensionContext } from '@cushion/extension-api';
 
 const IMAGE_SHORTCUT_IDS = ['image.zoom.in', 'image.zoom.out', 'image.reset'] as const;
 
-export function ImageViewer({ filePath }: ViewProps) {
-  const [imageData, setImageData] = useState<{ base64: string; mimeType: string } | null>(null);
+const MIME_MAP: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+};
 
-  useEffect(() => {
-    let cancelled = false;
-    getSharedCoordinatorClient().then((client) => {
-      if (cancelled) return;
-      return client.readFileBase64(filePath);
-    }).then((result) => {
-      if (!cancelled && result) setImageData({ base64: result.base64, mimeType: result.mimeType });
-    }).catch((err) => {
-      console.error('[ImageViewer] Failed to load image:', err);
-    });
-    return () => { cancelled = true; };
-  }, [filePath]);
-
-  if (!imageData) {
-    return <div className="flex items-center justify-center h-full text-muted-foreground">Loading image…</div>;
-  }
-
-  return <ImageViewerInner filePath={filePath} base64Data={imageData.base64} mimeType={imageData.mimeType} />;
+function getMimeType(filePath: string): string {
+  const dot = filePath.lastIndexOf('.');
+  if (dot < 0) return 'application/octet-stream';
+  const ext = filePath.slice(dot + 1).toLowerCase();
+  return MIME_MAP[ext] ?? 'application/octet-stream';
 }
 
-interface ImageViewerInnerProps {
-  filePath: string;
-  base64Data: string;
-  mimeType: string;
-}
-
-function ImageViewerInner({ filePath, base64Data, mimeType }: ImageViewerInnerProps) {
+export function ImageExtension({ ctx }: { ctx: ExtensionContext }) {
+  const [base64, setBase64] = useState<string | null>(null);
   const [scale, setScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [dragging, setDragging] = useState(false);
@@ -46,14 +34,34 @@ function ImageViewerInner({ filePath, base64Data, mimeType }: ImageViewerInnerPr
   const containerRef = useRef<HTMLDivElement>(null);
   const imageShortcuts = useShortcutBindings(IMAGE_SHORTCUT_IDS);
 
-  const fileName = filePath.split(/[/\\]/).pop() || filePath;
-  const dataUri = `data:${mimeType};base64,${base64Data}`;
+  const mimeType = useMemo(() => getMimeType(ctx.filePath), [ctx.filePath]);
+  const fileName = useMemo(() => ctx.filePath.split(/[/\\]/).pop() || ctx.filePath, [ctx.filePath]);
+
+  // Load image on mount
+  useEffect(() => {
+    let cancelled = false;
+    ctx.file.read().then((data) => {
+      if (!cancelled) setBase64(data);
+    }).catch((err) => {
+      console.error('[ImageExtension] Failed to load image:', err);
+    });
+    return () => { cancelled = true; };
+  }, [ctx.file]);
+
+  // Reload on external change
+  useEffect(() => {
+    return ctx.file.onExternalChange((content) => {
+      if (content === null) {
+        ctx.file.read().then(setBase64).catch(() => {});
+      }
+    });
+  }, [ctx.file]);
 
   const zoomIn = useCallback(() => setScale(s => Math.min(s * 1.25, 10)), []);
   const zoomOut = useCallback(() => setScale(s => Math.max(s / 1.25, 0.1)), []);
   const resetView = useCallback(() => { setScale(1); setPosition({ x: 0, y: 0 }); }, []);
 
-  // Ctrl+Scroll zoom — non-customizable platform gesture, not in shortcut registry
+  // Ctrl+Scroll zoom
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -67,14 +75,14 @@ function ImageViewerInner({ filePath, base64Data, mimeType }: ImageViewerInnerPr
     return () => el.removeEventListener('wheel', onWheel);
   }, []);
 
-  // Keyboard shortcuts (US-E1)
+  // Keyboard shortcuts — only active when this tab is visible
   const imageHandlers = useMemo(() => ({
     'image.zoom.in': () => { zoomIn(); },
     'image.zoom.out': () => { zoomOut(); },
     'image.reset': () => { resetView(); },
   } as const), [zoomIn, zoomOut, resetView]);
 
-  useShortcutHandler({ handlers: imageHandlers });
+  useShortcutHandler({ handlers: imageHandlers, enabled: ctx.isActive });
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     if (e.button !== 0) return;
@@ -94,9 +102,14 @@ function ImageViewerInner({ filePath, base64Data, mimeType }: ImageViewerInnerPr
 
   const onPointerUp = useCallback(() => setDragging(false), []);
 
+  if (!base64) {
+    return <div className="flex items-center justify-center h-full text-muted-foreground">Loading image…</div>;
+  }
+
+  const dataUri = `data:${mimeType};base64,${base64}`;
+
   return (
     <div className="flex flex-col h-full w-full">
-      {/* Toolbar */}
       <div className="flex items-center gap-1 px-4 py-2 border-b border-border/50 flex-shrink-0">
         <span className="text-sm text-muted-foreground truncate mr-auto">{fileName}</span>
         <button
@@ -132,7 +145,6 @@ function ImageViewerInner({ filePath, base64Data, mimeType }: ImageViewerInnerPr
         </button>
       </div>
 
-      {/* Image canvas */}
       <div
         ref={containerRef}
         className={cn(

--- a/apps/frontend/components/editor/PdfExtension.tsx
+++ b/apps/frontend/components/editor/PdfExtension.tsx
@@ -5,7 +5,6 @@ import { formatShortcutList, useShortcutBindings, useShortcutHandler } from '@/l
 import {
   PDF_SHORTCUT_IDS,
   AnnotationEditorType,
-  AnnotationEditorParamsType,
   HIGHLIGHT_COLORS,
   type EditorMode,
 } from './pdf-constants';
@@ -21,8 +20,7 @@ import {
 } from '@/lib/pdf-telemetry';
 import { base64ToUint8Array, uint8ArrayToBase64, downloadPdf, printPdf } from '@/lib/pdf-bytes';
 import { isPdfProgressiveLoadingEnabled } from '@/lib/pdf-feature-flags';
-import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
-import type { ViewProps } from '@/lib/view-registry';
+import type { ExtensionContext } from '@cushion/extension-api';
 
 interface PdfBase64Chunk {
   base64: string;
@@ -170,7 +168,7 @@ function createCoordinatorRangeTransport(
       } catch (error) {
         if (!aborted) {
           const normalizedError = normalizeError(error, 'Failed to read PDF chunk');
-          console.error('[PdfViewerNative] Failed to read PDF chunk:', normalizedError);
+          console.error('[PdfExtension] Failed to read PDF chunk:', normalizedError);
           reportFatalError(normalizedError);
         }
       } finally {
@@ -189,54 +187,53 @@ function createCoordinatorRangeTransport(
   return transport;
 }
 
-/**
- * Self-contained PDF viewer — loads its own data, handles saving.
- * Registered in the view registry for `.pdf` files.
- */
-export function PdfViewerNative({ filePath }: ViewProps) {
+export function PdfExtension({ ctx }: { ctx: ExtensionContext }) {
   const [pdfState, setPdfState] = useState<{
     base64Data?: string;
     telemetrySession: PdfTelemetrySession | null;
     progressiveLoading: PdfProgressiveLoadingConfig | null;
   } | null>(null);
 
+  const fileApi = ctx.file;
+  const filePath = ctx.filePath;
+
   useEffect(() => {
     let cancelled = false;
 
-    getSharedCoordinatorClient().then(async (client) => {
-      if (cancelled) return;
+    (async () => {
+      try {
+        if (pdfProgressiveLoadingEnabled) {
+          const readChunk = (offset: number, length: number) =>
+            fileApi.readChunk(offset, length);
+          setPdfState({
+            telemetrySession: null,
+            progressiveLoading: { readChunk, rangeChunkSize: DEFAULT_PDF_RANGE_CHUNK_SIZE },
+          });
+          return;
+        }
 
-      if (pdfProgressiveLoadingEnabled) {
-        const readChunk = (offset: number, length: number) =>
-          client.readFileBase64Chunk(filePath, offset, length);
-        setPdfState({
-          telemetrySession: null,
-          progressiveLoading: { readChunk, rangeChunkSize: DEFAULT_PDF_RANGE_CHUNK_SIZE },
+        const readStartedAtMs = pdfTelemetryNow();
+        const base64 = await fileApi.read();
+        if (cancelled) return;
+
+        const session = createPdfTelemetrySession({
+          filePath,
+          base64Data: base64,
+          fileReadDurationMs: pdfTelemetryNow() - readStartedAtMs,
         });
-        return;
+
+        setPdfState({
+          base64Data: base64,
+          telemetrySession: session,
+          progressiveLoading: null,
+        });
+      } catch (err) {
+        console.error('[PdfExtension] Failed to load PDF:', err);
       }
-
-      const readStartedAtMs = pdfTelemetryNow();
-      const result = await client.readFileBase64(filePath);
-      if (cancelled) return;
-
-      const session = createPdfTelemetrySession({
-        filePath,
-        base64Data: result.base64,
-        fileReadDurationMs: pdfTelemetryNow() - readStartedAtMs,
-      });
-
-      setPdfState({
-        base64Data: result.base64,
-        telemetrySession: session,
-        progressiveLoading: null,
-      });
-    }).catch((err) => {
-      console.error('[PdfViewerNative] Failed to load PDF:', err);
-    });
+    })();
 
     return () => { cancelled = true; };
-  }, [filePath]);
+  }, [filePath, fileApi]);
 
   if (!pdfState) {
     return <div className="flex items-center justify-center h-full text-muted-foreground">Loading PDF…</div>;
@@ -244,7 +241,7 @@ export function PdfViewerNative({ filePath }: ViewProps) {
 
   return (
     <PdfViewerInner
-      filePath={filePath}
+      ctx={ctx}
       base64Data={pdfState.base64Data}
       telemetrySession={pdfState.telemetrySession}
       progressiveLoading={pdfState.progressiveLoading}
@@ -253,18 +250,19 @@ export function PdfViewerNative({ filePath }: ViewProps) {
 }
 
 interface PdfViewerInnerProps {
-  filePath: string;
+  ctx: ExtensionContext;
   base64Data?: string;
   telemetrySession?: PdfTelemetrySession | null;
   progressiveLoading?: PdfProgressiveLoadingConfig | null;
 }
 
 function PdfViewerInner({
-  filePath,
+  ctx,
   base64Data,
   telemetrySession,
   progressiveLoading,
 }: PdfViewerInnerProps) {
+  const filePath = ctx.filePath;
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
@@ -285,7 +283,6 @@ function PdfViewerInner({
   const pendingSavedBytesRef = useRef<Uint8Array | null>(null);
   const lastSavedBytesRef = useRef<Uint8Array | null>(null);
 
-  // Extracted hooks
   const {
     zoom,
     setZoom,
@@ -310,7 +307,6 @@ function PdfViewerInner({
     closeSearch,
   } = usePdfSearch(eventBusRef);
 
-  // Add image via file picker: enters stamp mode, then triggers keyboard add
   const handleAddImage = useCallback(() => {
     const viewer = pdfViewerRef.current;
     if (!viewer) return;
@@ -332,7 +328,6 @@ function PdfViewerInner({
     }, 100);
   }, []);
 
-  // Dispatch annotation editor param change
   const dispatchParam = useCallback((type: number, value: any) => {
     const eventBus = eventBusRef.current;
     if (!eventBus) return;
@@ -366,11 +361,9 @@ function PdfViewerInner({
       return base64ToUint8Array(base64Data);
     }
 
-    // For progressive mode, re-read from coordinator
-    const client = await getSharedCoordinatorClient();
-    const result = await client.readFileBase64(filePath);
-    return base64ToUint8Array(result.base64);
-  }, [base64Data, filePath]);
+    const result = await ctx.file.read();
+    return base64ToUint8Array(result);
+  }, [base64Data, ctx.file]);
 
   const annotatedFileName = filePath
     .split(/[/\\]/)
@@ -379,14 +372,14 @@ function PdfViewerInner({
 
   const persistPdfBytes = useCallback(async (data: Uint8Array) => {
     try {
-      const client = await getSharedCoordinatorClient();
       const base64 = uint8ArrayToBase64(data);
-      await client.saveFileBase64(filePath, base64);
+      ctx.file.updateBase64(base64);
+      await ctx.file.flush();
     } catch (err) {
-      console.error('[PdfViewerNative] PDF save failed:', err);
+      console.error('[PdfExtension] PDF save failed:', err);
       alert('Failed to save PDF: ' + (err instanceof Error ? err.message : 'Unknown error'));
     }
-  }, [filePath]);
+  }, [ctx.file]);
 
   useEffect(() => {
     const cssHref = `${import.meta.env.BASE_URL}pdfjs/pdf_viewer.css`;
@@ -603,7 +596,7 @@ function PdfViewerInner({
 
       } catch (err) {
         if (cancelled) return;
-        console.error('[PdfViewerNative] Load error:', err);
+        console.error('[PdfExtension] Load error:', err);
         setError(err instanceof Error ? err.message : 'Failed to load PDF');
         setLoading(false);
       }
@@ -683,7 +676,7 @@ function PdfViewerInner({
     try {
       viewer.annotationEditorMode = { mode: modeMap[editorMode] };
     } catch (err) {
-      console.error('[PdfViewerNative] Failed to set editor mode:', err);
+      console.error('[PdfExtension] Failed to set editor mode:', err);
     }
   }, [editorMode]);
 
@@ -708,7 +701,7 @@ function PdfViewerInner({
       downloadPdf(originalBytes, fileName);
     } catch (err) {
       const normalizedError = normalizeError(err, 'Failed to download original PDF');
-      console.error('[PdfViewerNative] Download original failed:', normalizedError);
+      console.error('[PdfExtension] Download original failed:', normalizedError);
       alert('Failed to download original PDF: ' + normalizedError.message);
     }
   }, [fileName, readOriginalPdfBytes]);
@@ -726,7 +719,7 @@ function PdfViewerInner({
       downloadPdf(annotatedBytes, annotatedFileName);
     } catch (err) {
       const normalizedError = normalizeError(err, 'Failed to download annotated PDF');
-      console.error('[PdfViewerNative] Download annotated failed:', normalizedError);
+      console.error('[PdfExtension] Download annotated failed:', normalizedError);
       alert('Failed to download annotated PDF: ' + normalizedError.message);
     }
   }, [annotatedFileName, hasChanges, readOriginalPdfBytes]);
@@ -737,7 +730,7 @@ function PdfViewerInner({
       await printPdf(originalBytes);
     } catch (err) {
       const normalizedError = normalizeError(err, 'Failed to print PDF');
-      console.error('[PdfViewerNative] Print failed:', normalizedError);
+      console.error('[PdfExtension] Print failed:', normalizedError);
       alert('Failed to print PDF: ' + normalizedError.message);
     }
   }, [readOriginalPdfBytes]);
@@ -777,7 +770,7 @@ function PdfViewerInner({
       }
     } catch (err) {
       const normalizedError = normalizeError(err, 'Failed to save PDF');
-      console.error('[PdfViewerNative] Save failed:', normalizedError);
+      console.error('[PdfExtension] Save failed:', normalizedError);
       setSaveError(normalizedError.message);
     } finally {
       setSaving(false);
@@ -807,7 +800,7 @@ function PdfViewerInner({
     showSearch,
   ]);
 
-  useShortcutHandler({ handlers: pdfHandlers });
+  useShortcutHandler({ handlers: pdfHandlers, enabled: ctx.isActive });
 
   const searchShortcutLabel = formatShortcutList(pdfShortcuts['pdf.search.open']);
   const cancelShortcutLabel = formatShortcutList(pdfShortcuts['pdf.search.close']);
@@ -830,7 +823,7 @@ function PdfViewerInner({
   }
 
   return (
-    <div className="pdfjs-viewer-shell flex flex-col h-full bg-background">
+    <div className="pdfjs-viewer-shell flex flex-col h-full bg-background min-w-0">
       <PdfToolbar
         editorMode={editorMode}
         setEditorMode={setEditorMode}
@@ -901,7 +894,6 @@ function PdfViewerInner({
         />
       )}
 
-      {/* required by pdf.js */}
       <div className="flex-1 relative min-h-0">
         <div
           ref={containerRef}
@@ -933,4 +925,4 @@ function PdfViewerInner({
   );
 }
 
-export default PdfViewerNative;
+export default PdfExtension;

--- a/apps/frontend/components/editor/PdfToolbar.tsx
+++ b/apps/frontend/components/editor/PdfToolbar.tsx
@@ -80,7 +80,7 @@ export function PdfToolbar({
   const [highlightColor, setHighlightColor] = useState(DEFAULT_HIGHLIGHT_COLOR);
 
   return (
-    <div className="flex items-center gap-1 px-2 py-1 bg-tab-container border-b border-border text-sm select-none">
+    <div className="flex items-center gap-1 px-2 bg-tab-container border-b border-border text-sm select-none min-w-0 h-9 flex-shrink-0">
       {/* Search button */}
       <button
         className={cn("p-1.5 rounded transition-colors", showSearch ? "bg-[var(--interactive-hover)] text-foreground" : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted")}
@@ -106,44 +106,146 @@ export function PdfToolbar({
         <MousePointer size={18} />
       </button>
 
-      <button
-        className={cn(
-          "p-1.5 rounded transition-colors",
-          editorMode === "freetext"
-            ? "bg-accent text-white"
-            : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted"
+      <div className="relative">
+        <button
+          className={cn(
+            "p-1.5 rounded transition-colors",
+            editorMode === "freetext"
+              ? "bg-accent text-white"
+              : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted"
+          )}
+          onClick={() => setEditorMode(editorMode === 'freetext' ? 'none' : 'freetext')}
+          title="Add text annotation"
+        >
+          <Type size={18} />
+        </button>
+        {editorMode === 'freetext' && (
+          <div className="absolute top-full left-0 mt-1 z-50 flex items-center gap-2 px-2 py-1.5 rounded-md border border-border bg-tab-container shadow-lg whitespace-nowrap">
+            <input
+              type="color"
+              value={freetextColor}
+              onChange={(e) => {
+                setFreetextColor(e.target.value);
+                dispatchParam(AnnotationEditorParamsType.FREETEXT_COLOR, e.target.value);
+              }}
+              className="w-5 h-5 rounded cursor-pointer border border-border bg-transparent"
+              title="Text color"
+            />
+            <input
+              type="range"
+              min={5}
+              max={100}
+              step={1}
+              value={freetextSize}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                setFreetextSize(v);
+                dispatchParam(AnnotationEditorParamsType.FREETEXT_SIZE, v);
+              }}
+              className="w-20 accent-accent"
+              title={`Font size: ${freetextSize}px`}
+            />
+            <span className="text-foreground-faint text-xs">{freetextSize}px</span>
+          </div>
         )}
-        onClick={() => setEditorMode(editorMode === 'freetext' ? 'none' : 'freetext')}
-        title="Add text annotation"
-      >
-        <Type size={18} />
-      </button>
+      </div>
 
-      <button
-        className={cn(
-          "p-1.5 rounded transition-colors",
-          editorMode === "ink"
-            ? "bg-accent text-white"
-            : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted"
+      <div className="relative">
+        <button
+          className={cn(
+            "p-1.5 rounded transition-colors",
+            editorMode === "ink"
+              ? "bg-accent text-white"
+              : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted"
+          )}
+          onClick={() => setEditorMode(editorMode === 'ink' ? 'none' : 'ink')}
+          title="Draw / Ink annotation"
+        >
+          <Pencil size={18} />
+        </button>
+        {editorMode === 'ink' && (
+          <div className="absolute top-full left-0 mt-1 z-50 flex items-center gap-2 px-2 py-1.5 rounded-md border border-border bg-tab-container shadow-lg whitespace-nowrap">
+            <input
+              type="color"
+              value={inkColor}
+              onChange={(e) => {
+                setInkColor(e.target.value);
+                dispatchParam(AnnotationEditorParamsType.INK_COLOR, e.target.value);
+              }}
+              className="w-5 h-5 rounded cursor-pointer border border-border bg-transparent"
+              title="Ink color"
+            />
+            <label className="text-foreground-faint text-xs">Size</label>
+            <input
+              type="range"
+              min={1}
+              max={20}
+              step={1}
+              value={inkThickness}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                setInkThickness(v);
+                dispatchParam(AnnotationEditorParamsType.INK_THICKNESS, v);
+              }}
+              className="w-16 accent-accent"
+              title={`Thickness: ${inkThickness}px`}
+            />
+            <span className="text-foreground-faint text-xs w-4">{inkThickness}</span>
+            <label className="text-foreground-faint text-xs ml-1">Opacity</label>
+            <input
+              type="range"
+              min={0.05}
+              max={1}
+              step={0.05}
+              value={inkOpacity}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                setInkOpacity(v);
+                dispatchParam(AnnotationEditorParamsType.INK_OPACITY, v);
+              }}
+              className="w-16 accent-accent"
+              title={`Opacity: ${Math.round(inkOpacity * 100)}%`}
+            />
+            <span className="text-foreground-faint text-xs w-7">{Math.round(inkOpacity * 100)}%</span>
+          </div>
         )}
-        onClick={() => setEditorMode(editorMode === 'ink' ? 'none' : 'ink')}
-        title="Draw / Ink annotation"
-      >
-        <Pencil size={18} />
-      </button>
+      </div>
 
-      <button
-        className={cn(
-          "p-1.5 rounded transition-colors",
-          editorMode === "highlight"
-            ? "bg-accent text-white"
-            : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted"
+      <div className="relative">
+        <button
+          className={cn(
+            "p-1.5 rounded transition-colors",
+            editorMode === "highlight"
+              ? "bg-accent text-white"
+              : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted"
+          )}
+          onClick={() => setEditorMode(editorMode === 'highlight' ? 'none' : 'highlight')}
+          title="Highlight text"
+        >
+          <Highlighter size={18} />
+        </button>
+        {editorMode === 'highlight' && (
+          <div className="absolute top-full left-0 mt-1 z-50 flex items-center gap-1 px-2 py-1.5 rounded-md border border-border bg-tab-container shadow-lg">
+            {HIGHLIGHT_COLORS.map((c) => (
+              <button
+                key={c.hex}
+                className={cn(
+                  "w-5 h-5 rounded-full border-2 transition-colors",
+                  highlightColor.toUpperCase() === c.hex
+                    ? "border-white scale-110"
+                    : "border-transparent hover:border-foreground-muted"
+                )}
+                style={{ backgroundColor: c.hex }}
+                onClick={() => {
+                  setHighlightColor(c.hex);
+                  dispatchParam(AnnotationEditorParamsType.HIGHLIGHT_COLOR, c.hex);
+                }}
+                title={c.name}
+              />
+            ))}
+          </div>
         )}
-        onClick={() => setEditorMode(editorMode === 'highlight' ? 'none' : 'highlight')}
-        title="Highlight text"
-      >
-        <Highlighter size={18} />
-      </button>
+      </div>
 
       <button
         className={cn(
@@ -157,106 +259,6 @@ export function PdfToolbar({
       >
         <ImageIcon size={18} />
       </button>
-
-      {/* Tool-specific params inline */}
-      {editorMode === 'freetext' && (
-        <div className="flex items-center gap-2 ml-1">
-          <input
-            type="color"
-            value={freetextColor}
-            onChange={(e) => {
-              setFreetextColor(e.target.value);
-              dispatchParam(AnnotationEditorParamsType.FREETEXT_COLOR, e.target.value);
-            }}
-            className="w-6 h-6 rounded cursor-pointer border border-border bg-transparent"
-            title="Text color"
-          />
-          <input
-            type="range"
-            min={5}
-            max={100}
-            step={1}
-            value={freetextSize}
-            onChange={(e) => {
-              const v = Number(e.target.value);
-              setFreetextSize(v);
-              dispatchParam(AnnotationEditorParamsType.FREETEXT_SIZE, v);
-            }}
-            className="w-20 accent-accent"
-            title={`Font size: ${freetextSize}px`}
-          />
-          <span className="text-foreground-faint text-xs w-6">{freetextSize}</span>
-        </div>
-      )}
-
-      {editorMode === 'ink' && (
-        <div className="flex items-center gap-2 ml-1">
-          <input
-            type="color"
-            value={inkColor}
-            onChange={(e) => {
-              setInkColor(e.target.value);
-              dispatchParam(AnnotationEditorParamsType.INK_COLOR, e.target.value);
-            }}
-            className="w-6 h-6 rounded cursor-pointer border border-border bg-transparent"
-            title="Ink color"
-          />
-          <label className="text-foreground-faint text-xs">Size</label>
-          <input
-            type="range"
-            min={1}
-            max={20}
-            step={1}
-            value={inkThickness}
-            onChange={(e) => {
-              const v = Number(e.target.value);
-              setInkThickness(v);
-              dispatchParam(AnnotationEditorParamsType.INK_THICKNESS, v);
-            }}
-            className="w-16 accent-accent"
-            title={`Thickness: ${inkThickness}px`}
-          />
-          <span className="text-foreground-faint text-xs w-4">{inkThickness}</span>
-          <label className="text-foreground-faint text-xs ml-1">Opacity</label>
-          <input
-            type="range"
-            min={0.05}
-            max={1}
-            step={0.05}
-            value={inkOpacity}
-            onChange={(e) => {
-              const v = Number(e.target.value);
-              setInkOpacity(v);
-              dispatchParam(AnnotationEditorParamsType.INK_OPACITY, v);
-            }}
-            className="w-16 accent-accent"
-            title={`Opacity: ${Math.round(inkOpacity * 100)}%`}
-          />
-          <span className="text-foreground-faint text-xs w-7">{Math.round(inkOpacity * 100)}%</span>
-        </div>
-      )}
-
-      {editorMode === 'highlight' && (
-        <div className="flex items-center gap-1 ml-1">
-          {HIGHLIGHT_COLORS.map((c) => (
-            <button
-              key={c.hex}
-              className={cn(
-                "w-6 h-6 rounded-full border-2 transition-colors",
-                highlightColor.toUpperCase() === c.hex
-                  ? "border-white scale-110"
-                  : "border-transparent hover:border-foreground-muted"
-              )}
-              style={{ backgroundColor: c.hex }}
-              onClick={() => {
-                setHighlightColor(c.hex);
-                dispatchParam(AnnotationEditorParamsType.HIGHLIGHT_COLOR, c.hex);
-              }}
-              title={c.name}
-            />
-          ))}
-        </div>
-      )}
 
       {/* Center: Page navigation */}
       <div className="flex-1 flex items-center justify-center gap-0.5">
@@ -427,7 +429,7 @@ export function PdfSearchBar({
   const showMatchesCount = searchQuery.length > 0 || searchMatchesCount.total > 0;
 
   return (
-    <div className="flex flex-wrap items-center gap-2 px-3 py-2 bg-[var(--background-secondary-alt)] border-b border-border">
+    <div className="flex items-center gap-2 px-3 bg-[var(--background-secondary-alt)] border-b border-border h-9 flex-shrink-0 overflow-x-auto min-w-0 thin-scrollbar">
       <Search size={16} className="text-foreground-faint" />
       <input
         ref={searchInputRef}
@@ -510,7 +512,7 @@ export function PdfSearchBar({
       </button>
 
       {searchStatusMessage && (
-        <span className="basis-full text-xs text-foreground-faint pl-6">{searchStatusMessage}</span>
+        <span className="text-xs text-foreground-faint whitespace-nowrap">{searchStatusMessage}</span>
       )}
     </div>
   );

--- a/apps/frontend/components/editor/PdfToolbar.tsx
+++ b/apps/frontend/components/editor/PdfToolbar.tsx
@@ -71,7 +71,6 @@ export function PdfToolbar({
   dispatchParam,
   shortcutLabels,
 }: PdfToolbarProps) {
-  // Toolbar param state
   const [freetextColor, setFreetextColor] = useState(DEFAULT_FREETEXT_COLOR);
   const [freetextSize, setFreetextSize] = useState(14);
   const [inkColor, setInkColor] = useState(DEFAULT_INK_COLOR);
@@ -81,7 +80,6 @@ export function PdfToolbar({
 
   return (
     <div className="flex items-center gap-1 px-2 bg-tab-container border-b border-border text-sm select-none min-w-0 h-9 flex-shrink-0">
-      {/* Search button */}
       <button
         className={cn("p-1.5 rounded transition-colors", showSearch ? "bg-[var(--interactive-hover)] text-foreground" : "hover:bg-[var(--background-modifier-hover)] text-foreground-muted")}
         onClick={onToggleSearch}
@@ -92,7 +90,6 @@ export function PdfToolbar({
 
       <div className="w-px h-5 bg-border mx-0.5" />
 
-      {/* Annotation tools */}
       <button
         className={cn(
           "p-1.5 rounded transition-colors",
@@ -260,7 +257,6 @@ export function PdfToolbar({
         <ImageIcon size={18} />
       </button>
 
-      {/* Center: Page navigation */}
       <div className="flex-1 flex items-center justify-center gap-0.5">
         <button
           className="p-1.5 rounded hover:bg-[var(--background-modifier-hover)] text-foreground-muted transition-colors disabled:opacity-40"
@@ -294,7 +290,6 @@ export function PdfToolbar({
         </div>
       </div>
 
-      {/* Right: Zoom + Actions */}
       <div className="flex items-center gap-0.5">
         <button
           className="p-1.5 rounded hover:bg-[var(--background-modifier-hover)] text-foreground-muted transition-colors"

--- a/apps/frontend/components/editor/index.ts
+++ b/apps/frontend/components/editor/index.ts
@@ -1,4 +1,0 @@
-export { CodeEditor } from './CodeEditor';
-export { EditorTabs } from './EditorTabs';
-export { PdfExtension } from './PdfExtension';
-export { FileHeader } from './FileHeader';

--- a/apps/frontend/components/editor/index.ts
+++ b/apps/frontend/components/editor/index.ts
@@ -1,4 +1,4 @@
 export { CodeEditor } from './CodeEditor';
 export { EditorTabs } from './EditorTabs';
-export { PdfViewerNative } from './PdfViewerNative';
+export { PdfExtension } from './PdfExtension';
 export { FileHeader } from './FileHeader';

--- a/apps/frontend/components/settings/ExtensionsSettings.tsx
+++ b/apps/frontend/components/settings/ExtensionsSettings.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { readDisabledSet, loadGlobalExtensions, unloadExternalExtensions } from '@/lib/extension-loader';
+import { registerBuiltinViews } from '@/lib/register-builtin-views';
+import { cn } from '@/lib/utils';
+import { VisibilityToggle } from '@/components/chat/CustomizeDialog';
+import imageManifest from '@extensions/cushion-image/cushion-extension.json';
+import pdfManifest from '@extensions/cushion-pdf/cushion-extension.json';
+import excalidrawManifest from '@extensions/cushion-excalidraw/cushion-extension.json';
+import type { ExtensionManifest } from '@cushion/extension-api';
+import type { DiscoveredExtension } from '@cushion/types';
+
+type ExtensionItem = {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  fileTypes: string[];
+  source: 'bundled' | 'external';
+};
+
+const bundledManifests: ExtensionManifest[] = [
+  imageManifest as ExtensionManifest,
+  pdfManifest as ExtensionManifest,
+  excalidrawManifest as ExtensionManifest,
+];
+
+function manifestToItem(manifest: ExtensionManifest, source: 'bundled' | 'external'): ExtensionItem {
+  return {
+    id: manifest.id,
+    name: manifest.name,
+    version: manifest.version,
+    description: manifest.description,
+    fileTypes: manifest.fileTypes.flatMap((ft) => ft.extensions),
+    source,
+  };
+}
+
+export function ExtensionsSettings() {
+  const hasWorkspace = useWorkspaceStore((s) => !!s.metadata?.projectPath);
+  const [extensions, setExtensions] = useState<ExtensionItem[]>([]);
+  const [disabled, setDisabled] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      const client = await getSharedCoordinatorClient();
+
+      const items: ExtensionItem[] = bundledManifests.map((m) => manifestToItem(m, 'bundled'));
+
+      try {
+        const { extensions: discovered } = await client.discoverGlobalExtensions();
+        for (const ext of discovered as DiscoveredExtension[]) {
+          if (!items.some((i) => i.id === ext.manifest.id)) {
+            items.push(manifestToItem(ext.manifest, 'external'));
+          }
+        }
+      } catch {}
+
+      let disabledSet = new Set<string>();
+      if (hasWorkspace) {
+        try {
+          disabledSet = await readDisabledSet(client);
+        } catch {}
+      }
+
+      if (!cancelled) {
+        setExtensions(items);
+        setDisabled(disabledSet);
+        setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [hasWorkspace]);
+
+  const handleToggle = async (id: string, enable: boolean) => {
+    const next = new Set(disabled);
+    if (enable) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setDisabled(next);
+
+    const client = await getSharedCoordinatorClient();
+    await client.writeConfig('extensions.json', JSON.stringify({ disabled: [...next] }, null, 2));
+
+    unloadExternalExtensions();
+    await loadGlobalExtensions(client, hasWorkspace);
+    registerBuiltinViews(next);
+  };
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return extensions;
+    return extensions.filter((ext) => {
+      const haystack = `${ext.name} ${ext.description ?? ''} ${ext.fileTypes.join(' ')}`.toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [extensions, searchQuery]);
+
+  const enabledCount = extensions.filter((e) => !disabled.has(e.id)).length;
+
+  if (!hasWorkspace) {
+    return (
+      <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+        Open a workspace to manage extensions
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3">
+        <div className="flex h-8 items-center gap-2 rounded-md bg-surface px-2">
+          <Search size={16} className="shrink-0 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search extensions"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-full w-full border-none bg-transparent text-[14px] text-foreground placeholder:text-muted-foreground focus:outline-none"
+            autoFocus
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto no-scrollbar px-2 pb-2">
+        {loading ? (
+          <div className="px-3 py-8 text-center text-sm text-muted-foreground">Loading extensions...</div>
+        ) : filtered.length === 0 ? (
+          <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+            {searchQuery ? 'No matching extensions' : 'No extensions available'}
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {filtered.map((ext) => {
+              const isEnabled = !disabled.has(ext.id);
+              const label = `${isEnabled ? 'Disable' : 'Enable'} ${ext.name}`;
+
+              return (
+                <div
+                  key={ext.id}
+                  className="flex w-full cursor-pointer items-center gap-4 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--overlay-10)]"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleToggle(ext.id, !isEnabled)}
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Enter' && e.key !== ' ') return;
+                    e.preventDefault();
+                    handleToggle(ext.id, !isEnabled);
+                  }}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-[14px] text-foreground">{ext.name}</span>
+                      <span className="text-[11px] text-muted-foreground">{ext.version}</span>
+                      <span className={cn(
+                        'rounded px-1.5 py-0.5 text-[10px] leading-none',
+                        ext.source === 'bundled'
+                          ? 'bg-[var(--overlay-10)] text-muted-foreground'
+                          : 'bg-[var(--accent-primary)]/15 text-[var(--accent-primary)]',
+                      )}>
+                        {ext.source === 'bundled' ? 'Bundled' : 'External'}
+                      </span>
+                    </div>
+                    {ext.description && (
+                      <span className="block truncate text-[13px] text-muted-foreground">
+                        {ext.description}
+                      </span>
+                    )}
+                    <span className="block truncate text-[12px] text-muted-foreground/70">
+                      {ext.fileTypes.join(', ')}
+                    </span>
+                  </div>
+                  <div className="flex w-9 shrink-0 justify-end">
+                    <VisibilityToggle
+                      checked={isEnabled}
+                      label={label}
+                      onChange={(next) => handleToggle(ext.id, next)}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {!loading && extensions.length > 0 && (
+        <div className="border-t border-border px-4 py-2.5 text-xs text-muted-foreground">
+          {enabledCount} of {extensions.length} extensions enabled
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/settings/SettingsPanel.tsx
+++ b/apps/frontend/components/settings/SettingsPanel.tsx
@@ -1,10 +1,11 @@
 
 import { useState } from 'react';
-import { AudioLines, Keyboard, Palette, Settings as SettingsIcon, SlidersHorizontal, X } from 'lucide-react';
+import { AudioLines, Keyboard, Palette, Puzzle, Settings as SettingsIcon, SlidersHorizontal, X } from 'lucide-react';
 import { ShortcutsSettings } from './ShortcutsSettings';
 import { ConfigSettings } from './ConfigSettings';
 import { AppearanceSettings } from './AppearanceSettings';
 import { DictationSettings } from './DictationSettings';
+import { ExtensionsSettings } from './ExtensionsSettings';
 import { cn } from '@/lib/utils';
 
 interface SettingsPanelProps {
@@ -16,6 +17,7 @@ const sections = [
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'dictation', label: 'Whisper', icon: AudioLines },
   { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
+  { id: 'extensions', label: 'Extensions', icon: Puzzle },
 ] as const;
 
 export function SettingsPanel({ onClose }: SettingsPanelProps) {
@@ -65,6 +67,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
           {activeSection === 'appearance' && <AppearanceSettings />}
           {activeSection === 'dictation' && <DictationSettings />}
           {activeSection === 'shortcuts' && <ShortcutsSettings />}
+          {activeSection === 'extensions' && <ExtensionsSettings />}
         </section>
       </div>
     </div>

--- a/apps/frontend/components/workspace/FileBrowser.tsx
+++ b/apps/frontend/components/workspace/FileBrowser.tsx
@@ -10,7 +10,7 @@ import { useDictationStore } from '@/stores/dictationStore';
 import { useMediaQuery } from 'usehooks-ts';
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
 import { LogoSpinner } from '@/components/ui/LogoSpinner';
-import { isBinaryFile } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/view-registry';
 import { resolveConflict } from '@/lib/conflict-resolution';
 import { useToast } from '@/components/chat/Toast';
 import { cn } from '@/lib/utils';

--- a/apps/frontend/components/workspace/FileBrowser.tsx
+++ b/apps/frontend/components/workspace/FileBrowser.tsx
@@ -10,7 +10,7 @@ import { useDictationStore } from '@/stores/dictationStore';
 import { useMediaQuery } from 'usehooks-ts';
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
 import { LogoSpinner } from '@/components/ui/LogoSpinner';
-import { BINARY_FILE_EXTENSIONS } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/binary-extensions';
 import { resolveConflict } from '@/lib/conflict-resolution';
 import { useToast } from '@/components/chat/Toast';
 import { cn } from '@/lib/utils';
@@ -162,7 +162,7 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(
       return;
     }
 
-    if (BINARY_FILE_EXTENSIONS.test(filePath)) {
+    if (isBinaryFile(filePath)) {
       onFileOpen(filePath, '');
       return;
     }

--- a/apps/frontend/hooks/useFileTree.ts
+++ b/apps/frontend/hooks/useFileTree.ts
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useDiffReviewStore } from '@/stores/diffReviewStore';
-import { BINARY_FILE_EXTENSIONS } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/binary-extensions';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
 import type { WorkspaceMetadata } from '@cushion/types';
 
@@ -111,7 +111,7 @@ export function useFileTree({
       if (diffState.reviewingFilePath === filePath) return;
       if (diffState.fileSnapshots[filePath]) return;
 
-      if (BINARY_FILE_EXTENSIONS.test(filePath)) return;
+      if (isBinaryFile(filePath)) return;
 
       const state = useWorkspaceStore.getState();
       const openFile = state.openFiles.get(filePath);

--- a/apps/frontend/hooks/useFileTree.ts
+++ b/apps/frontend/hooks/useFileTree.ts
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useDiffReviewStore } from '@/stores/diffReviewStore';
-import { isBinaryFile } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/view-registry';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
 import type { WorkspaceMetadata } from '@cushion/types';
 

--- a/apps/frontend/lib/binary-extensions.ts
+++ b/apps/frontend/lib/binary-extensions.ts
@@ -1,2 +1,1 @@
-/** Regex matching binary file extensions handled by specialized viewers (images + PDFs). */
-export const BINARY_FILE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|bmp|ico|pdf)$/i;
+export { isBinaryFile } from './view-registry';

--- a/apps/frontend/lib/binary-extensions.ts
+++ b/apps/frontend/lib/binary-extensions.ts
@@ -1,1 +1,0 @@
-export { isBinaryFile } from './view-registry';

--- a/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/hide-markup.ts
@@ -16,7 +16,7 @@ import { NoteEmbedWidget } from './widgets/note-embed-widget';
 import { UnsupportedEmbedWidget } from './widgets/unsupported-embed-widget';
 import { classifyEmbed, embedSourceRevealEffect, type EmbedType } from './embed-utils';
 import { MathWidget } from './widgets/math-widget';
-import { filePathsField } from './wiki-link-plugin';
+import { filePathsField, setFilePathsEffect } from './wiki-link-plugin';
 import { resolveWikiLink } from '../wiki-link-resolver';
 
 function getChildRanges(node: { node: { cursor: () => { iterate: (cb: (node: { type: { name: string }; from: number; to: number }) => void) => void } } }) {
@@ -654,7 +654,7 @@ export const widgetDecorationsField = StateField.define<DecorationSet>({
     return buildWidgetDecorations(state);
   },
   update(value, tr) {
-    if (tr.effects.some(e => e.is(embedSourceRevealEffect) || (e.is(mouseSelectEffect) && !e.value))) {
+    if (tr.effects.some(e => e.is(embedSourceRevealEffect) || (e.is(mouseSelectEffect) && !e.value) || e.is(setFilePathsEffect))) {
       return buildWidgetDecorations(tr.state);
     }
     const treeChanged = syntaxTree(tr.state) !== syntaxTree(tr.startState);

--- a/apps/frontend/lib/coordinator-client.ts
+++ b/apps/frontend/lib/coordinator-client.ts
@@ -137,10 +137,6 @@ export class CoordinatorClient {
     return this.call('extensions/read-source', { dirName });
   }
 
-  readExtensionIcon(dirName: string) {
-    return this.call('extensions/read-icon', { dirName });
-  }
-
   onFilesChanged(callback: (changes: import('@cushion/types').FileChange[]) => void): () => void {
     this.filesChangedCallbacks.push(callback);
     return () => {

--- a/apps/frontend/lib/coordinator-client.ts
+++ b/apps/frontend/lib/coordinator-client.ts
@@ -129,6 +129,18 @@ export class CoordinatorClient {
     return this.call('config/write', { file, content });
   }
 
+  discoverGlobalExtensions() {
+    return this.call('extensions/discover-global');
+  }
+
+  readExtensionSource(dirName: string) {
+    return this.call('extensions/read-source', { dirName });
+  }
+
+  readExtensionIcon(dirName: string) {
+    return this.call('extensions/read-icon', { dirName });
+  }
+
   onFilesChanged(callback: (changes: import('@cushion/types').FileChange[]) => void): () => void {
     this.filesChangedCallbacks.push(callback);
     return () => {

--- a/apps/frontend/lib/extension-loader.ts
+++ b/apps/frontend/lib/extension-loader.ts
@@ -1,0 +1,83 @@
+import React from 'react';
+import { registerExternalExtensionView, unregisterExternalViews } from './view-registry';
+import type { CoordinatorClient } from './coordinator-client';
+import type { DiscoveredExtension, ExtensionsConfig } from '@cushion/types';
+
+const blobUrls: string[] = [];
+
+function createLazyExtension(
+  client: CoordinatorClient,
+  dirName: string,
+) {
+  return React.lazy(async () => {
+    const { source } = await client.readExtensionSource(dirName);
+    const stripped = source.replace(/^import\s+.*?\s+from\s+["']react["'];?\s*$/gm, '');
+    const shimmed = [
+      'const React = window.__CushionReact;',
+      'const { useState, useEffect, useCallback, useMemo, useRef, useReducer, useContext, useLayoutEffect, memo, forwardRef, createContext, Fragment, createElement, cloneElement, isValidElement, Children } = React;',
+      stripped,
+    ].join('\n');
+
+    const blob = new Blob([shimmed], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    blobUrls.push(url);
+
+    const mod = await import(/* @vite-ignore */ url);
+    return { default: mod.default };
+  });
+}
+
+function registerDiscovered(
+  client: CoordinatorClient,
+  extensions: DiscoveredExtension[],
+) {
+  for (const { manifest, dirName } of extensions) {
+    if (!manifest.main) {
+      console.warn(`[Extensions] Skipping ${dirName}: no main entry point`);
+      continue;
+    }
+    const allExts: string[] = [];
+    let binary = false;
+    for (const ft of manifest.fileTypes) {
+      allExts.push(...ft.extensions);
+      if (ft.binary) binary = true;
+    }
+
+    registerExternalExtensionView(manifest.id, {
+      displayName: manifest.name,
+      component: createLazyExtension(client, dirName),
+      extensions: allExts,
+      icon: manifest.icon,
+      binary,
+    });
+  }
+}
+
+export async function readDisabledSet(client: CoordinatorClient): Promise<Set<string>> {
+  try {
+    const { content } = await client.readConfig('extensions.json');
+    if (content) {
+      const parsed: ExtensionsConfig = JSON.parse(content);
+      if (Array.isArray(parsed.disabled)) {
+        return new Set(parsed.disabled);
+      }
+    }
+  } catch {}
+  return new Set();
+}
+
+export async function loadGlobalExtensions(client: CoordinatorClient, hasWorkspace: boolean = false): Promise<Set<string>> {
+  const disabled = hasWorkspace ? await readDisabledSet(client) : new Set<string>();
+  const { extensions } = await client.discoverGlobalExtensions();
+  const filtered = extensions.filter((ext) => !disabled.has(ext.manifest.id));
+  registerDiscovered(client, filtered);
+  return disabled;
+}
+
+export function unloadExternalExtensions(): void {
+  unregisterExternalViews();
+  for (const url of blobUrls) {
+    URL.revokeObjectURL(url);
+  }
+  blobUrls.length = 0;
+}

--- a/apps/frontend/lib/extension-loader.ts
+++ b/apps/frontend/lib/extension-loader.ts
@@ -36,19 +36,11 @@ function registerDiscovered(
       console.warn(`[Extensions] Skipping ${dirName}: no main entry point`);
       continue;
     }
-    const allExts: string[] = [];
-    let binary = false;
-    for (const ft of manifest.fileTypes) {
-      allExts.push(...ft.extensions);
-      if (ft.binary) binary = true;
-    }
-
     registerExternalExtensionView(manifest.id, {
       displayName: manifest.name,
       component: createLazyExtension(client, dirName),
-      extensions: allExts,
-      icon: manifest.icon,
-      binary,
+      extensions: manifest.fileTypes.flatMap((ft) => ft.extensions),
+      binary: manifest.fileTypes.some((ft) => ft.binary),
     });
   }
 }

--- a/apps/frontend/lib/register-builtin-views.ts
+++ b/apps/frontend/lib/register-builtin-views.ts
@@ -1,29 +1,31 @@
-import { registerView } from './view-registry';
-import { ImageViewer } from '@/components/editor/ImageViewer';
-import { PdfViewerNative } from '@/components/editor/PdfViewerNative';
-import { ExcalidrawView } from '@/components/editor/ExcalidrawView';
+import { registerBundledView, unregisterView } from './view-registry';
+import { ImageExtension } from '@/components/editor/ImageExtension';
+import { PdfExtension } from '@/components/editor/PdfExtension';
+import { ExcalidrawExtension } from '@/components/editor/ExcalidrawExtension';
+import imageManifest from '@extensions/cushion-image/cushion-extension.json';
+import pdfManifest from '@extensions/cushion-pdf/cushion-extension.json';
+import excalidrawManifest from '@extensions/cushion-excalidraw/cushion-extension.json';
+import type { ExtensionManifest } from '@cushion/extension-api';
 
-let registered = false;
+const builtins: Array<{ manifest: ExtensionManifest; component: typeof ImageExtension }> = [
+  { manifest: imageManifest as ExtensionManifest, component: ImageExtension },
+  { manifest: pdfManifest as ExtensionManifest, component: PdfExtension },
+  { manifest: excalidrawManifest as ExtensionManifest, component: ExcalidrawExtension },
+];
 
-export function registerBuiltinViews(): void {
-  if (registered) return;
-  registered = true;
+const registeredIds = new Set<string>();
 
-  registerView('image', {
-    displayName: 'Image Viewer',
-    component: ImageViewer,
-    extensions: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'],
-  });
+export function registerBuiltinViews(disabled?: Set<string>): void {
+  for (const { manifest, component } of builtins) {
+    const isDisabled = disabled?.has(manifest.id);
+    const isRegistered = registeredIds.has(manifest.id);
 
-  registerView('pdf', {
-    displayName: 'PDF Viewer',
-    component: PdfViewerNative,
-    extensions: ['pdf'],
-  });
-
-  registerView('excalidraw', {
-    displayName: 'Excalidraw',
-    component: ExcalidrawView,
-    extensions: ['excalidraw'],
-  });
+    if (isDisabled && isRegistered) {
+      unregisterView(manifest.id);
+      registeredIds.delete(manifest.id);
+    } else if (!isDisabled && !isRegistered) {
+      registerBundledView(manifest, component);
+      registeredIds.add(manifest.id);
+    }
+  }
 }

--- a/apps/frontend/lib/view-registry.ts
+++ b/apps/frontend/lib/view-registry.ts
@@ -1,21 +1,11 @@
 import type { ComponentType } from 'react';
 import type { ExtensionContext, ExtensionManifest } from '@cushion/extension-api';
 
-export interface ViewProps {
-  filePath: string;
-}
-
 interface ViewRegistrationBase {
   id: string;
   displayName: string;
   extensions: string[];
-  icon?: string;
   binary?: boolean;
-}
-
-export interface BuiltinViewRegistration extends ViewRegistrationBase {
-  source: 'builtin';
-  component: ComponentType<ViewProps>;
 }
 
 export interface BundledViewRegistration extends ViewRegistrationBase {
@@ -28,35 +18,20 @@ export interface ExtensionViewRegistration extends ViewRegistrationBase {
   component: ComponentType<{ ctx: ExtensionContext }>;
 }
 
-export type ViewRegistration = BuiltinViewRegistration | BundledViewRegistration | ExtensionViewRegistration;
+export type ViewRegistration = BundledViewRegistration | ExtensionViewRegistration;
 
 const viewsById = new Map<string, ViewRegistration>();
-const extensionIndex = new Map<string, string>(); // ext → view id
+const extensionIndex = new Map<string, string>();
 const binaryExtensions = new Set<string>();
 const externalIds = new Set<string>();
 
-// Seed with known binary extensions that may not have registered viewers
 const BUILTIN_BINARY_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico', 'pdf'];
 for (const ext of BUILTIN_BINARY_EXTS) {
   binaryExtensions.add(ext);
 }
 
-/** Strip leading dot so both "png" and ".png" work. */
 function normalizeExt(ext: string): string {
   return ext.replace(/^\./, '').toLowerCase();
-}
-
-export function registerView(
-  id: string,
-  config: { displayName: string; component: ComponentType<ViewProps>; extensions: string[]; icon?: string; binary?: boolean },
-): void {
-  const registration: BuiltinViewRegistration = { id, source: 'builtin', ...config };
-  viewsById.set(id, registration);
-  for (const ext of config.extensions) {
-    const norm = normalizeExt(ext);
-    extensionIndex.set(norm, id);
-    if (config.binary) binaryExtensions.add(norm);
-  }
 }
 
 export function registerBundledView(
@@ -83,7 +58,7 @@ export function registerBundledView(
 
 export function registerExtensionView(
   id: string,
-  config: { displayName: string; component: ComponentType<{ ctx: ExtensionContext }>; extensions: string[]; icon?: string; binary?: boolean },
+  config: { displayName: string; component: ComponentType<{ ctx: ExtensionContext }>; extensions: string[]; binary?: boolean },
 ): void {
   const registration: ExtensionViewRegistration = { id, source: 'extension', ...config };
   viewsById.set(id, registration);
@@ -110,10 +85,6 @@ export function unregisterView(id: string): void {
       if (!BUILTIN_BINARY_EXTS.includes(ext)) binaryExtensions.delete(ext);
     }
   }
-}
-
-export function getAllViews(): ViewRegistration[] {
-  return Array.from(viewsById.values());
 }
 
 export function unregisterExternalViews(): void {

--- a/apps/frontend/lib/view-registry.ts
+++ b/apps/frontend/lib/view-registry.ts
@@ -1,18 +1,45 @@
 import type { ComponentType } from 'react';
+import type { ExtensionContext, ExtensionManifest } from '@cushion/extension-api';
 
 export interface ViewProps {
   filePath: string;
 }
 
-export interface ViewRegistration {
+interface ViewRegistrationBase {
   id: string;
   displayName: string;
-  component: ComponentType<ViewProps>;
   extensions: string[];
+  icon?: string;
+  binary?: boolean;
 }
+
+export interface BuiltinViewRegistration extends ViewRegistrationBase {
+  source: 'builtin';
+  component: ComponentType<ViewProps>;
+}
+
+export interface BundledViewRegistration extends ViewRegistrationBase {
+  source: 'bundled';
+  component: ComponentType<{ ctx: ExtensionContext }>;
+}
+
+export interface ExtensionViewRegistration extends ViewRegistrationBase {
+  source: 'extension';
+  component: ComponentType<{ ctx: ExtensionContext }>;
+}
+
+export type ViewRegistration = BuiltinViewRegistration | BundledViewRegistration | ExtensionViewRegistration;
 
 const viewsById = new Map<string, ViewRegistration>();
 const extensionIndex = new Map<string, string>(); // ext → view id
+const binaryExtensions = new Set<string>();
+const externalIds = new Set<string>();
+
+// Seed with known binary extensions that may not have registered viewers
+const BUILTIN_BINARY_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico', 'pdf'];
+for (const ext of BUILTIN_BINARY_EXTS) {
+  binaryExtensions.add(ext);
+}
 
 /** Strip leading dot so both "png" and ".png" work. */
 function normalizeExt(ext: string): string {
@@ -21,13 +48,79 @@ function normalizeExt(ext: string): string {
 
 export function registerView(
   id: string,
-  config: { displayName: string; component: ComponentType<ViewProps>; extensions: string[] },
+  config: { displayName: string; component: ComponentType<ViewProps>; extensions: string[]; icon?: string; binary?: boolean },
 ): void {
-  const registration: ViewRegistration = { id, ...config };
+  const registration: BuiltinViewRegistration = { id, source: 'builtin', ...config };
   viewsById.set(id, registration);
   for (const ext of config.extensions) {
-    extensionIndex.set(normalizeExt(ext), id);
+    const norm = normalizeExt(ext);
+    extensionIndex.set(norm, id);
+    if (config.binary) binaryExtensions.add(norm);
   }
+}
+
+export function registerBundledView(
+  manifest: ExtensionManifest,
+  component: ComponentType<{ ctx: ExtensionContext }>,
+): void {
+  const allExts = manifest.fileTypes.flatMap((ft) => ft.extensions);
+  const isBinary = manifest.fileTypes.some((ft) => ft.binary);
+  const registration: BundledViewRegistration = {
+    id: manifest.id,
+    source: 'bundled',
+    displayName: manifest.name,
+    component,
+    extensions: allExts,
+    binary: isBinary || undefined,
+  };
+  viewsById.set(manifest.id, registration);
+  for (const ext of allExts) {
+    const norm = normalizeExt(ext);
+    extensionIndex.set(norm, manifest.id);
+    if (isBinary) binaryExtensions.add(norm);
+  }
+}
+
+export function registerExtensionView(
+  id: string,
+  config: { displayName: string; component: ComponentType<{ ctx: ExtensionContext }>; extensions: string[]; icon?: string; binary?: boolean },
+): void {
+  const registration: ExtensionViewRegistration = { id, source: 'extension', ...config };
+  viewsById.set(id, registration);
+  for (const ext of config.extensions) {
+    const norm = normalizeExt(ext);
+    extensionIndex.set(norm, id);
+    if (config.binary) binaryExtensions.add(norm);
+  }
+}
+
+export function registerExternalExtensionView(
+  id: string,
+  config: { displayName: string; component: ComponentType<{ ctx: ExtensionContext }>; extensions: string[]; icon?: string; binary?: boolean },
+): void {
+  registerExtensionView(id, config);
+  externalIds.add(id);
+}
+
+export function unregisterView(id: string): void {
+  viewsById.delete(id);
+  for (const [ext, viewId] of extensionIndex) {
+    if (viewId === id) {
+      extensionIndex.delete(ext);
+      if (!BUILTIN_BINARY_EXTS.includes(ext)) binaryExtensions.delete(ext);
+    }
+  }
+}
+
+export function getAllViews(): ViewRegistration[] {
+  return Array.from(viewsById.values());
+}
+
+export function unregisterExternalViews(): void {
+  for (const id of externalIds) {
+    unregisterView(id);
+  }
+  externalIds.clear();
 }
 
 export function getViewForFile(filePath: string): ViewRegistration | null {
@@ -37,4 +130,11 @@ export function getViewForFile(filePath: string): ViewRegistration | null {
   const id = extensionIndex.get(ext);
   if (!id) return null;
   return viewsById.get(id) ?? null;
+}
+
+export function isBinaryFile(filePath: string): boolean {
+  const dot = filePath.lastIndexOf('.');
+  if (dot < 0) return false;
+  const ext = filePath.slice(dot + 1).toLowerCase();
+  return binaryExtensions.has(ext);
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -34,6 +34,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.40.0",
+    "@cushion/extension-api": "workspace:*",
     "@cushion/types": "workspace:*",
     "@excalidraw/excalidraw": "^0.18.0",
     "@lezer/common": "^1.2.3",

--- a/apps/frontend/src/Home.tsx
+++ b/apps/frontend/src/Home.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { registerBuiltinViews } from '@/lib/register-builtin-views';
-
-registerBuiltinViews();
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useChatStore } from '@/stores/chatStore';
 import { getSharedCoordinatorClient } from '@/lib/shared-coordinator-client';
@@ -27,9 +25,10 @@ import { useExplorerStore } from '@/stores/explorerStore';
 import { useConfigSync } from '@/hooks/useConfigSync';
 import { useDiffReviewBridge } from '@/hooks/useDiffReviewBridge';
 import { EditorTabRow } from '@/components/editor/EditorTabRow';
-import { BINARY_FILE_EXTENSIONS } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/binary-extensions';
 import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
+import { loadGlobalExtensions, unloadExternalExtensions } from '@/lib/extension-loader';
 
 const APP_SHORTCUT_IDS = [
   'app.quickSwitcher.open',
@@ -170,6 +169,26 @@ export default function Home() {
       cancelled = true;
     };
   }, [setClient]);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+
+    async function loadExtensions() {
+      unloadExternalExtensions();
+      let disabled: Set<string> | undefined;
+      try {
+        disabled = await loadGlobalExtensions(client!, !!metadata?.projectPath);
+      } catch (err) {
+        console.warn('[Home] Failed to load global extensions:', err);
+      }
+      if (cancelled) return;
+      registerBuiltinViews(disabled);
+    }
+
+    loadExtensions();
+    return () => { cancelled = true; };
+  }, [client, metadata?.projectPath]);
 
   useEffect(() => {
     const directory = metadata?.projectPath;
@@ -392,7 +411,7 @@ export default function Home() {
     if (!client) return;
 
     try {
-      if (BINARY_FILE_EXTENSIONS.test(filePath)) {
+      if (isBinaryFile(filePath)) {
         openFile(filePath, '');
         return;
       }

--- a/apps/frontend/src/Home.tsx
+++ b/apps/frontend/src/Home.tsx
@@ -25,7 +25,7 @@ import { useExplorerStore } from '@/stores/explorerStore';
 import { useConfigSync } from '@/hooks/useConfigSync';
 import { useDiffReviewBridge } from '@/hooks/useDiffReviewBridge';
 import { EditorTabRow } from '@/components/editor/EditorTabRow';
-import { isBinaryFile } from '@/lib/binary-extensions';
+import { isBinaryFile } from '@/lib/view-registry';
 import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import type { CoordinatorClient } from '@/lib/coordinator-client';
 import { loadGlobalExtensions, unloadExternalExtensions } from '@/lib/extension-loader';
@@ -160,7 +160,7 @@ export default function Home() {
           useDictationStore.getState().setClient(shared);
         }
       } catch (err) {
-        console.error('[Page] Failed to connect to coordinator:', err);
+        console.error('[Home] Failed to connect to coordinator:', err);
       }
     }
 
@@ -198,7 +198,7 @@ export default function Home() {
     }
 
     connectChat(directory).catch((err) => {
-      console.error('[Page] Failed to connect to OpenCode:', err);
+      console.error('[Home] Failed to connect to OpenCode:', err);
     });
 
     return () => {
@@ -280,7 +280,7 @@ export default function Home() {
       fetchFileTree();
       openFile(name, '');
     } catch (err) {
-      console.error('[Page] Failed to create new note:', err);
+      console.error('[Home] Failed to create new note:', err);
     }
   }, [client, openFile, fetchFileTree, filePaths]);
 
@@ -422,7 +422,7 @@ export default function Home() {
       const { content } = await client.readFile(filePath);
       openFile(filePath, content);
     } catch (err) {
-      console.error('[Page] Failed to navigate to file:', err);
+      console.error('[Home] Failed to navigate to file:', err);
     }
   }, [client, openFile]);
 
@@ -436,7 +436,7 @@ export default function Home() {
       fetchFileTree();
       openFile(filePath, '');
     } catch (err) {
-      console.error('[Page] Failed to create file:', err);
+      console.error('[Home] Failed to create file:', err);
     }
   }, [client, openFile, fetchFileTree]);
 

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -4,6 +4,8 @@ import '../app/globals.css';
 import 'katex/dist/katex.min.css';
 import Home from './Home';
 
+(window as any).__CushionReact = React;
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Home />

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -16,12 +16,16 @@
     "isolatedModules": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@extensions/*": ["../../packages/extension-api/manifests/*"]
     }
   },
   "references": [
     {
       "path": "../../packages/types"
+    },
+    {
+      "path": "../../packages/extension-api"
     }
   ],
   "include": [

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),
+      '@extensions': path.resolve(__dirname, '../../packages/extension-api/manifests'),
     },
   },
   optimizeDeps: {

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       "name": "electron-app",
       "version": "0.1.1",
       "dependencies": {
+        "@cushion/extension-api": "workspace:*",
         "@cushion/types": "workspace:*",
         "chokidar": "^5.0.0",
         "ignore": "^7.0.5",
@@ -58,6 +59,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/theme-one-dark": "^6.1.2",
         "@codemirror/view": "^6.40.0",
+        "@cushion/extension-api": "workspace:*",
         "@cushion/types": "workspace:*",
         "@excalidraw/excalidraw": "^0.18.0",
         "@lezer/common": "^1.2.3",
@@ -137,6 +139,10 @@
         "vite": "^6.3.5",
       },
     },
+    "packages/extension-api": {
+      "name": "@cushion/extension-api",
+      "version": "0.1.0",
+    },
     "packages/tsconfig": {
       "name": "@cushion/tsconfig",
       "version": "0.1.0",
@@ -144,6 +150,9 @@
     "packages/types": {
       "name": "@cushion/types",
       "version": "0.1.0",
+      "dependencies": {
+        "@cushion/extension-api": "workspace:*",
+      },
     },
   },
   "overrides": {
@@ -293,6 +302,8 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.2", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@cushion/extension-api": ["@cushion/extension-api@workspace:packages/extension-api"],
 
     "@cushion/tsconfig": ["@cushion/tsconfig@workspace:packages/tsconfig"],
 

--- a/packages/extension-api/manifests/cushion-excalidraw/cushion-extension.json
+++ b/packages/extension-api/manifests/cushion-excalidraw/cushion-extension.json
@@ -1,0 +1,9 @@
+{
+  "id": "cushion.excalidraw",
+  "name": "Excalidraw",
+  "version": "0.1.0",
+  "description": "Edit Excalidraw drawings",
+  "fileTypes": [
+    { "extensions": ["excalidraw"] }
+  ]
+}

--- a/packages/extension-api/manifests/cushion-image/cushion-extension.json
+++ b/packages/extension-api/manifests/cushion-image/cushion-extension.json
@@ -1,0 +1,9 @@
+{
+  "id": "cushion.image-viewer",
+  "name": "Image Viewer",
+  "version": "0.1.0",
+  "description": "View image files",
+  "fileTypes": [
+    { "extensions": ["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "ico"], "binary": true }
+  ]
+}

--- a/packages/extension-api/manifests/cushion-pdf/cushion-extension.json
+++ b/packages/extension-api/manifests/cushion-pdf/cushion-extension.json
@@ -1,0 +1,9 @@
+{
+  "id": "cushion.pdf-viewer",
+  "name": "PDF Viewer",
+  "version": "0.1.0",
+  "description": "View and annotate PDF files",
+  "fileTypes": [
+    { "extensions": ["pdf"], "binary": true }
+  ]
+}

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -12,13 +12,9 @@
       "default": "./src/index.ts"
     }
   },
-  "files": [
-    "src"
-  ],
-  "scripts": {
+"scripts": {
     "build": "tsc -b",
     "type-check": "tsc -b",
-    "typecheck": "tsc -b",
     "lint": "tsc --noEmit"
   }
 }

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@cushion/types",
+  "name": "@cushion/extension-api",
   "version": "0.1.0",
   "private": true,
   "license": "MIT",
-  "description": "Shared type definitions for Cushion workspace, file, terminal, and document tracking",
+  "description": "Extension API types and validation for Cushion extensions",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
@@ -15,9 +15,6 @@
   "files": [
     "src"
   ],
-  "dependencies": {
-    "@cushion/extension-api": "workspace:*"
-  },
   "scripts": {
     "build": "tsc -b",
     "type-check": "tsc -b",

--- a/packages/extension-api/src/context.ts
+++ b/packages/extension-api/src/context.ts
@@ -1,8 +1,3 @@
-export interface ExtensionDimensions {
-  width: number;
-  height: number;
-}
-
 export interface ChunkResult {
   base64: string;
   mimeType: string;
@@ -12,33 +7,17 @@ export interface ChunkResult {
 }
 
 export interface ExtensionFileAPI {
-  /** Read the extension's own file (text or base64 depending on binary flag). */
   read(): Promise<string>;
-  /** Read a chunk of the file as base64. */
   readChunk(offset: number, length: number): Promise<ChunkResult>;
-  /** Tell Cushion the content changed. Cushion handles debouncing and writing to disk. */
   update(content: string): void;
-  /** Same as update() but for binary content (base64-encoded). */
   updateBase64(base64: string): void;
-  /** Flush any pending writes immediately (for explicit save scenarios). */
   flush(): Promise<void>;
-  /** Subscribe to external file changes. Text extensions get content, binary get null. */
   onExternalChange(callback: (content: string | null) => void): () => void;
-  /** Read another file (text) by workspace-relative path. */
-  readOther(workspacePath: string): Promise<string>;
-  /** Read another file (base64) by workspace-relative path. */
-  readOtherBase64(workspacePath: string): Promise<{ base64: string; mimeType: string }>;
 }
 
 export interface ExtensionContext {
-  /** Absolute workspace-relative path to the file being viewed. */
   filePath: string;
-  /** File API for reading, writing, and watching the current file. */
   file: ExtensionFileAPI;
-  /** Current resolved theme ('light' or 'dark'). */
   theme: 'light' | 'dark';
-  /** Container dimensions, updated via ResizeObserver. */
-  dimensions: ExtensionDimensions;
-  /** Whether this extension's tab is currently active/visible. */
   isActive: boolean;
 }

--- a/packages/extension-api/src/context.ts
+++ b/packages/extension-api/src/context.ts
@@ -1,0 +1,44 @@
+export interface ExtensionDimensions {
+  width: number;
+  height: number;
+}
+
+export interface ChunkResult {
+  base64: string;
+  mimeType: string;
+  offset: number;
+  bytesRead: number;
+  totalBytes: number;
+}
+
+export interface ExtensionFileAPI {
+  /** Read the extension's own file (text or base64 depending on binary flag). */
+  read(): Promise<string>;
+  /** Read a chunk of the file as base64. */
+  readChunk(offset: number, length: number): Promise<ChunkResult>;
+  /** Tell Cushion the content changed. Cushion handles debouncing and writing to disk. */
+  update(content: string): void;
+  /** Same as update() but for binary content (base64-encoded). */
+  updateBase64(base64: string): void;
+  /** Flush any pending writes immediately (for explicit save scenarios). */
+  flush(): Promise<void>;
+  /** Subscribe to external file changes. Text extensions get content, binary get null. */
+  onExternalChange(callback: (content: string | null) => void): () => void;
+  /** Read another file (text) by workspace-relative path. */
+  readOther(workspacePath: string): Promise<string>;
+  /** Read another file (base64) by workspace-relative path. */
+  readOtherBase64(workspacePath: string): Promise<{ base64: string; mimeType: string }>;
+}
+
+export interface ExtensionContext {
+  /** Absolute workspace-relative path to the file being viewed. */
+  filePath: string;
+  /** File API for reading, writing, and watching the current file. */
+  file: ExtensionFileAPI;
+  /** Current resolved theme ('light' or 'dark'). */
+  theme: 'light' | 'dark';
+  /** Container dimensions, updated via ResizeObserver. */
+  dimensions: ExtensionDimensions;
+  /** Whether this extension's tab is currently active/visible. */
+  isActive: boolean;
+}

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,0 +1,18 @@
+export type {
+  ExtensionContext,
+  ExtensionFileAPI,
+  ExtensionDimensions,
+  ChunkResult,
+} from './context.js';
+
+export type {
+  ExtensionManifest,
+  ExtensionFileType,
+} from './manifest.js';
+
+export {
+  validateManifest,
+  parseManifest,
+} from './validate-manifest.js';
+
+export type { ValidationResult } from './validate-manifest.js';

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,18 +1,7 @@
 export type {
   ExtensionContext,
-  ExtensionFileAPI,
-  ExtensionDimensions,
-  ChunkResult,
 } from './context.js';
 
-export type {
-  ExtensionManifest,
-  ExtensionFileType,
-} from './manifest.js';
+export type { ExtensionManifest } from './manifest.js';
 
-export {
-  validateManifest,
-  parseManifest,
-} from './validate-manifest.js';
-
-export type { ValidationResult } from './validate-manifest.js';
+export { parseManifest } from './validate-manifest.js';

--- a/packages/extension-api/src/manifest.ts
+++ b/packages/extension-api/src/manifest.ts
@@ -1,0 +1,27 @@
+export interface ExtensionFileType {
+  /** File extensions this viewer handles (without leading dot, e.g. "csv"). */
+  extensions: string[];
+  /** Whether files are binary (base64 reads) or text. */
+  binary?: boolean;
+}
+
+export interface ExtensionManifest {
+  /** Unique extension identifier (e.g. "cushion.csv-viewer"). */
+  id: string;
+  /** Human-readable name. */
+  name: string;
+  /** Version string (semver recommended). */
+  version: string;
+  /** Entry point relative to the extension directory (optional for bundled extensions). */
+  main?: string;
+  /** File types this extension can view. */
+  fileTypes: ExtensionFileType[];
+  /** Optional description. */
+  description?: string;
+  /** Optional author name. */
+  author?: string;
+  /** Optional icon path relative to the extension directory. */
+  icon?: string;
+  /** Semver range for Cushion compatibility (e.g. ">=1.0"). */
+  cushionVersion?: string;
+}

--- a/packages/extension-api/src/manifest.ts
+++ b/packages/extension-api/src/manifest.ts
@@ -1,27 +1,16 @@
 export interface ExtensionFileType {
-  /** File extensions this viewer handles (without leading dot, e.g. "csv"). */
   extensions: string[];
-  /** Whether files are binary (base64 reads) or text. */
   binary?: boolean;
 }
 
 export interface ExtensionManifest {
-  /** Unique extension identifier (e.g. "cushion.csv-viewer"). */
   id: string;
-  /** Human-readable name. */
   name: string;
-  /** Version string (semver recommended). */
   version: string;
-  /** Entry point relative to the extension directory (optional for bundled extensions). */
   main?: string;
-  /** File types this extension can view. */
   fileTypes: ExtensionFileType[];
-  /** Optional description. */
   description?: string;
-  /** Optional author name. */
   author?: string;
-  /** Optional icon path relative to the extension directory. */
   icon?: string;
-  /** Semver range for Cushion compatibility (e.g. ">=1.0"). */
   cushionVersion?: string;
 }

--- a/packages/extension-api/src/validate-manifest.ts
+++ b/packages/extension-api/src/validate-manifest.ts
@@ -1,11 +1,6 @@
 import type { ExtensionManifest } from './manifest.js';
 
-export interface ValidationResult {
-  valid: boolean;
-  errors: string[];
-}
-
-export function validateManifest(value: unknown): ValidationResult {
+function validateManifest(value: unknown): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
@@ -68,7 +63,6 @@ export function validateManifest(value: unknown): ValidationResult {
   return { valid: errors.length === 0, errors };
 }
 
-/** Type guard: returns the manifest if valid, null otherwise. */
 export function parseManifest(value: unknown): ExtensionManifest | null {
   const result = validateManifest(value);
   return result.valid ? (value as ExtensionManifest) : null;

--- a/packages/extension-api/src/validate-manifest.ts
+++ b/packages/extension-api/src/validate-manifest.ts
@@ -1,0 +1,75 @@
+import type { ExtensionManifest } from './manifest.js';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateManifest(value: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return { valid: false, errors: ['Manifest must be a non-null object'] };
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (typeof obj.id !== 'string' || obj.id.length === 0) {
+    errors.push('id must be a non-empty string');
+  }
+
+  if (typeof obj.name !== 'string' || obj.name.length === 0) {
+    errors.push('name must be a non-empty string');
+  }
+
+  if (typeof obj.version !== 'string' || obj.version.length === 0) {
+    errors.push('version must be a non-empty string');
+  }
+
+  if (obj.main !== undefined && (typeof obj.main !== 'string' || obj.main.length === 0)) {
+    errors.push('main must be a non-empty string if provided');
+  }
+
+  if (!Array.isArray(obj.fileTypes)) {
+    errors.push('fileTypes must be an array');
+  } else if (obj.fileTypes.length === 0) {
+    errors.push('fileTypes must have at least one entry');
+  } else {
+    for (let i = 0; i < obj.fileTypes.length; i++) {
+      const ft = obj.fileTypes[i];
+      if (typeof ft !== 'object' || ft === null || Array.isArray(ft)) {
+        errors.push(`fileTypes[${i}] must be an object`);
+        continue;
+      }
+      const ftObj = ft as Record<string, unknown>;
+      if (!Array.isArray(ftObj.extensions) || ftObj.extensions.length === 0) {
+        errors.push(`fileTypes[${i}].extensions must be a non-empty array`);
+      } else {
+        for (let j = 0; j < ftObj.extensions.length; j++) {
+          if (typeof ftObj.extensions[j] !== 'string' || ftObj.extensions[j].length === 0) {
+            errors.push(`fileTypes[${i}].extensions[${j}] must be a non-empty string`);
+          }
+        }
+      }
+      if (ftObj.binary !== undefined && typeof ftObj.binary !== 'boolean') {
+        errors.push(`fileTypes[${i}].binary must be a boolean if provided`);
+      }
+    }
+  }
+
+  if (obj.description !== undefined && typeof obj.description !== 'string') {
+    errors.push('description must be a string if provided');
+  }
+
+  if (obj.icon !== undefined && typeof obj.icon !== 'string') {
+    errors.push('icon must be a string if provided');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Type guard: returns the manifest if valid, null otherwise. */
+export function parseManifest(value: unknown): ExtensionManifest | null {
+  const result = validateManifest(value);
+  return result.valid ? (value as ExtensionManifest) : null;
+}

--- a/packages/extension-api/tsconfig.json
+++ b/packages/extension-api/tsconfig.json
@@ -14,8 +14,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"],
-  "references": [
-    { "path": "../extension-api" }
-  ]
+  "include": ["src"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,7 +21,6 @@
   "scripts": {
     "build": "tsc -b",
     "type-check": "tsc -b",
-    "typecheck": "tsc -b",
     "lint": "tsc --noEmit"
   }
 }

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -4,6 +4,16 @@ import type {
   PandocBinaryStatus,
   PandocFormat,
 } from './index.js';
+import type { ExtensionManifest } from '@cushion/extension-api';
+
+export interface DiscoveredExtension {
+  manifest: ExtensionManifest;
+  dirName: string;
+}
+
+export interface ExtensionsConfig {
+  disabled?: string[];
+}
 
 export interface TrashItem {
   id: string;
@@ -324,6 +334,20 @@ export interface RPCMethodMap {
   'pandoc/export': {
     params: { markdown: string; title: string; format: PandocFormat; workspacePath: string };
     result: { success: boolean; path: string | null };
+  };
+
+  // Extensions
+  'extensions/discover-global': {
+    params: void;
+    result: { extensions: DiscoveredExtension[] };
+  };
+  'extensions/read-source': {
+    params: { dirName: string };
+    result: { source: string };
+  };
+  'extensions/read-icon': {
+    params: { dirName: string };
+    result: { svg: string | null };
   };
 }
 

--- a/scripts/color-guardrails.mjs
+++ b/scripts/color-guardrails.mjs
@@ -26,7 +26,7 @@ const literalAllowlist = [
 // PdfToolbar uses text-white/border-white for contrast on accent backgrounds
 const utilityAllowlist = [
   /^apps\/frontend\/components\/editor\/PdfToolbar\.tsx$/,
-  /^apps\/frontend\/components\/editor\/PdfViewerNative\.tsx$/,
+  /^apps\/frontend\/components\/editor\/PdfExtension\.tsx$/,
   /^apps\/frontend\/components\/editor\/pdf-constants\.ts$/,
   /^apps\/frontend\/components\/editor\/DictationButton\.tsx$/,
   /^apps\/frontend\/components\/editor\/EditorTabRow\.tsx$/,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
   "references": [
     { "path": "apps/coordinator" },
     { "path": "apps/frontend" },
-    { "path": "packages/types" }
+    { "path": "packages/types" },
+    { "path": "packages/extension-api" }
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- Extension API package (`@cushion/extension-api`) with manifest schema, validation, and `ExtensionContext` types
- `ExtensionHost` wrapper with save pipeline, error boundary, Suspense, and external change watching
- View registry with `bundled` and `extension` sources and dynamic binary detection
- Bundled viewers (PDF, Excalidraw, Image) register through the extension system
- External extension loading from `~/.cushion/extensions/` via IPC discovery → React shim → Blob URL → dynamic `import()`
- Consolidated `binary-extensions` into `view-registry`, unified rendering through `ExtensionHost`

## Test plan

- [ ] Open an image, PDF, and Excalidraw file — each renders through ExtensionHost
- [ ] Place an external extension in `~/.cushion/extensions/` with valid manifest — discovered and loadable
- [ ] Ctrl+S flushes pending writes in extension views
- [ ] External file changes trigger `onExternalChange` callbacks
- [ ] Broken extension doesn't crash the app (error boundary)