### PR TITLE
Heading fold gutter improvements

### DIFF
--- a/apps/frontend/lib/codemirror-wysiwyg/heading-fold-gutter.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/heading-fold-gutter.ts
@@ -192,16 +192,8 @@ class HeadingFoldGutterView {
     const lineHeight = Number.parseFloat(lineStyle.lineHeight);
     const resolvedLineHeight = Number.isFinite(lineHeight) ? lineHeight : lineRect.height;
 
-    const gutterWidthValue = lineStyle.getPropertyValue('--md-fold-gutter-width').trim();
-    const edgeOffsetValue = lineStyle.getPropertyValue('--md-fold-edge-offset').trim();
     const buttonSizeValue = lineStyle.getPropertyValue('--md-fold-chevron-size').trim();
-
-    const gutterWidth = Number.parseFloat(gutterWidthValue);
-    const edgeOffset = Number.parseFloat(edgeOffsetValue);
     const buttonSize = Number.parseFloat(buttonSizeValue);
-
-    const resolvedGutterWidth = Number.isFinite(gutterWidth) ? gutterWidth : defaultGutterWidth;
-    const resolvedEdgeOffset = Number.isFinite(edgeOffset) ? edgeOffset : 0;
     const resolvedButtonSize = Number.isFinite(buttonSize) ? buttonSize : defaultButtonSize;
 
     const paddingTop = Number.parseFloat(lineStyle.paddingTop) || 0;

--- a/apps/frontend/lib/codemirror-wysiwyg/heading-fold-gutter.ts
+++ b/apps/frontend/lib/codemirror-wysiwyg/heading-fold-gutter.ts
@@ -42,8 +42,12 @@ class HeadingFoldGutterView {
     icon.setAttribute('aria-hidden', 'true');
 
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    path.setAttribute('d', 'M6 4l4 4-4 4');
-    path.setAttribute('fill', 'currentColor');
+    path.setAttribute('d', 'M6 3l5 5-5 5');
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', 'currentColor');
+    path.setAttribute('stroke-width', '1.5');
+    path.setAttribute('stroke-linecap', 'round');
+    path.setAttribute('stroke-linejoin', 'round');
 
     icon.appendChild(path);
     this.button.appendChild(icon);
@@ -205,7 +209,7 @@ class HeadingFoldGutterView {
     const top =
       lineRect.top - rootRect.top + paddingTop + (resolvedLineHeight - resolvedButtonSize) / 2;
     const left =
-      lineRect.left - rootRect.left - (resolvedGutterWidth - resolvedEdgeOffset);
+      lineRect.left - rootRect.left - resolvedButtonSize;
 
     this.container.style.top = `${top}px`;
     this.container.style.left = `${left}px`;

--- a/apps/frontend/styles/markdown-editor.css
+++ b/apps/frontend/styles/markdown-editor.css
@@ -1255,7 +1255,7 @@
 /* Base foldable heading - positions chevron in left margin */
 .cm-editor.cm-markdown-wysiwyg .cm-line.cm-heading-foldable {
   position: relative;
-  --md-fold-chevron-size: 18px;
+  --md-fold-chevron-size: 14px;
   --md-fold-gutter-max: 30px;
   --md-fold-gutter-width: clamp(
     var(--md-fold-chevron-size),
@@ -1265,11 +1265,6 @@
   --md-fold-edge-offset: max(
     0px,
     calc(var(--md-fold-gutter-width) - var(--md-fold-chevron-size) - 2px)
-  );
-  --md-fold-chevron-size-actual: clamp(
-    0px,
-    calc(var(--md-fold-gutter-width) - 2px),
-    var(--md-fold-chevron-size)
   );
 }
 


### PR DESCRIPTION
## Summary
- Closer chevron positioning: sits flush against heading text instead of far in the gutter
- Thinner stroke-based chevron (Obsidian-style `›`) instead of filled triangle
- Reduced chevron size from 18px to 14px
- Cleaned up dead code from positioning refactor

## Test plan
- [ ] Hover over headings with content below — chevron appears close to text
- [ ] Click chevron to fold/unfold sections
- [ ] Verify folded state shows persistent chevron rotated to `›`
- [ ] Check various heading levels (H1–H6)