### PR TITLE
Fix header tab close button and layout

### DIFF
--- a/apps/frontend/components/editor/EditorTabRow.tsx
+++ b/apps/frontend/components/editor/EditorTabRow.tsx
@@ -1,10 +1,14 @@
 
 import { Minus, Square, X, PanelLeft, PanelRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { hasCustomTitlebar, needsCustomWindowControls, noDragStyle } from './editor-path';
+import { hasCustomTitlebar, isWindows, needsCustomWindowControls, noDragStyle } from './editor-path';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { PaneTabBar } from './PaneTabBar';
 import logoSvg from '/logo.svg?url';
+
+// Space reserved at the trailing edge for the panel toggle button + OS window controls.
+// Windows: titlebar overlay buttons (~138px) sit on the right; macOS/Linux: no right-side controls.
+const TRAILING_RESERVE = isWindows ? 176 : 44;
 
 interface EditorTabRowProps {
   sidebarOpen?: boolean;
@@ -82,7 +86,7 @@ export function EditorTabRow({
         )}
       </div>
 
-      <div className="min-w-0 flex-1 flex items-end">
+      <div className="min-w-0 flex-1 flex items-end overflow-hidden">
         {panes.map((pane, i) => (
           <div
             key={pane.id}
@@ -100,10 +104,12 @@ export function EditorTabRow({
           rightPanelOpen && 'border-l border-border'
         )}
         style={{
-          width: rightPanelWidth ?? 0,
-          marginRight: rightPanelOpen ? 0 : -(rightPanelWidth ?? 0),
+          width: Math.max(0, (rightPanelWidth ?? 0) - TRAILING_RESERVE),
+          marginRight: rightPanelOpen ? 0 : -Math.max(0, (rightPanelWidth ?? 0) - TRAILING_RESERVE),
         }}
       />
+
+      <div className="flex-shrink-0" style={{ width: TRAILING_RESERVE }} />
 
       {onToggleRightPanel && (
         <button
@@ -115,7 +121,7 @@ export function EditorTabRow({
             'hover:bg-muted/30',
             'transition-colors duration-150'
           )}
-          style={{ ...noDragStyle, right: rightPanelOpen ? (rightPanelWidth ?? 0) - 36 : 140 }}
+          style={{ ...noDragStyle, right: rightPanelOpen ? (rightPanelWidth ?? 0) - 36 : (isWindows ? 140 : 8) }}
           title={rightPanelOpen ? 'Close right sidebar' : 'Open right sidebar'}
           aria-label={rightPanelOpen ? 'Close right sidebar' : 'Open right sidebar'}
           aria-pressed={!!rightPanelOpen}

--- a/apps/frontend/components/editor/PaneTabBar.tsx
+++ b/apps/frontend/components/editor/PaneTabBar.tsx
@@ -115,7 +115,7 @@ export function PaneTabBar({ paneId, tabs }: PaneTabBarProps) {
             )}
             <button
               className={cn(
-                "ml-auto w-4 h-4 flex items-center justify-center rounded shrink-0",
+                "relative z-10 ml-auto w-4 h-4 flex items-center justify-center rounded shrink-0",
                 "transition-opacity duration-150",
                 "hover:bg-[var(--background-modifier-hover)]",
                 isActive ? "opacity-60 hover:opacity-100" : "opacity-0 group-hover:opacity-60 group-hover:hover:opacity-100"

--- a/apps/frontend/components/editor/editor-path.ts
+++ b/apps/frontend/components/editor/editor-path.ts
@@ -1,4 +1,5 @@
 export const isLinux = window.electronAPI.platform === 'linux';
+export const isWindows = window.electronAPI.platform === 'win32';
 export const hasCustomTitlebar = !isLinux;
 export const needsCustomWindowControls = false;
 export const noDragStyle = hasCustomTitlebar ? { WebkitAppRegion: 'no-drag' } as React.CSSProperties : undefined;


### PR DESCRIPTION
## Summary
- Fix tab close button not clickable on inactive tabs — the `::after` hover pseudo-element was intercepting clicks, requiring two clicks (activate tab, then close). Added `relative z-10` to lift the button above the overlay.
- Fix trailing space reservation for right panel toggle across platforms (Windows vs macOS/Linux).
- Prevent tab overflow from bleeding past the tab area.

## Test plan
- [ ] Click X on an inactive tab — should close directly without activating first
- [ ] Verify right panel toggle button position on Windows and macOS
- [ ] Verify tabs don't overflow past the right panel area

🤖 Generated with [Claude Code](https://claude.com/claude-code)